### PR TITLE
PR: Enhance Funnel, Treemap & KPI Card Playgrounds

### DIFF
--- a/packages/demo/src/components/CardPlayground.tsx
+++ b/packages/demo/src/components/CardPlayground.tsx
@@ -19,17 +19,197 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Button,
   Badge,
-  Avatar,
-  AvatarImage,
-  AvatarFallback,
+  Progress,
+  Skeleton,
 } from '@acronis-platform/shadcn-uikit/react'
-import { Heart, Share2, MessageCircle, TrendingUp } from 'lucide-react'
+import {
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  DollarSign,
+  Users,
+  ShoppingCart,
+  Activity,
+  Zap,
+  Eye,
+  BarChart3,
+  Clock,
+  Target,
+  Percent,
+  ArrowUpRight,
+  ArrowDownRight,
+} from 'lucide-react'
 
-type CardVariant = 'default' | 'stats' | 'profile' | 'pricing' | 'media' | 'notification'
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type TrendDirection = 'up' | 'down' | 'neutral'
+type ValueFormat = 'number' | 'currency' | 'percent' | 'compact' | 'custom'
+type IconPosition = 'left' | 'right'
+type IconStyle = 'circle' | 'square' | 'plain'
+type ValueSize = 'sm' | 'md' | 'lg' | 'xl'
 type ShadowSize = 'none' | 'sm' | 'md' | 'lg' | 'xl'
-type BorderStyle = 'default' | 'primary' | 'destructive' | 'none'
+type BorderAccent = 'none' | 'left' | 'top'
+type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline' | 'success' | 'info' | 'warning' | 'critical' | 'danger' | 'neutral'
+type FooterStyle = 'text' | 'progress' | 'sparkline' | 'comparison'
+
+interface KpiPreset {
+  name: string
+  title: string
+  value: number
+  format: ValueFormat
+  prefix: string
+  suffix: string
+  decimals: number
+  trendValue: number
+  trendDirection: TrendDirection
+  comparisonText: string
+  icon: string
+  iconColor: string
+  badgeText: string
+  badgeVariant: BadgeVariant
+  progressValue: number
+  sparklineData: number[]
+  description: string
+}
+
+// ─── Presets ─────────────────────────────────────────────────────────────────
+
+const kpiPresets: Record<string, KpiPreset> = {
+  revenue: {
+    name: 'Total Revenue',
+    title: 'Total Revenue',
+    value: 45231.89,
+    format: 'currency',
+    prefix: '$',
+    suffix: '',
+    decimals: 2,
+    trendValue: 20.1,
+    trendDirection: 'up',
+    comparisonText: 'from last month',
+    icon: 'DollarSign',
+    iconColor: '#16a34a',
+    badgeText: 'Live',
+    badgeVariant: 'success',
+    progressValue: 72,
+    sparklineData: [20, 25, 30, 22, 35, 40, 38, 45, 50, 48, 55, 60],
+    description: 'Monthly recurring revenue',
+  },
+  users: {
+    name: 'Active Users',
+    title: 'Active Users',
+    value: 2350,
+    format: 'number',
+    prefix: '',
+    suffix: '',
+    decimals: 0,
+    trendValue: 12.5,
+    trendDirection: 'up',
+    comparisonText: 'from last week',
+    icon: 'Users',
+    iconColor: '#2563eb',
+    badgeText: 'Growing',
+    badgeVariant: 'info',
+    progressValue: 85,
+    sparklineData: [100, 120, 115, 130, 145, 160, 155, 170, 180, 200, 210, 235],
+    description: 'Daily active users',
+  },
+  conversion: {
+    name: 'Conversion Rate',
+    title: 'Conversion Rate',
+    value: 3.24,
+    format: 'percent',
+    prefix: '',
+    suffix: '%',
+    decimals: 2,
+    trendValue: -0.4,
+    trendDirection: 'down',
+    comparisonText: 'from last month',
+    icon: 'Target',
+    iconColor: '#dc2626',
+    badgeText: 'Needs attention',
+    badgeVariant: 'warning',
+    progressValue: 32,
+    sparklineData: [4.2, 3.8, 3.9, 3.5, 3.6, 3.4, 3.2, 3.3, 3.1, 3.0, 3.2, 3.24],
+    description: 'Visitor to customer rate',
+  },
+  orders: {
+    name: 'Total Orders',
+    title: 'Total Orders',
+    value: 12543,
+    format: 'compact',
+    prefix: '',
+    suffix: '',
+    decimals: 0,
+    trendValue: 8.2,
+    trendDirection: 'up',
+    comparisonText: 'vs previous period',
+    icon: 'ShoppingCart',
+    iconColor: '#9333ea',
+    badgeText: 'On track',
+    badgeVariant: 'default',
+    progressValue: 68,
+    sparklineData: [800, 950, 1100, 980, 1050, 1200, 1150, 1300, 1280, 1350, 1400, 1543],
+    description: 'Orders this quarter',
+  },
+  performance: {
+    name: 'System Uptime',
+    title: 'System Uptime',
+    value: 99.97,
+    format: 'custom',
+    prefix: '',
+    suffix: '%',
+    decimals: 2,
+    trendValue: 0,
+    trendDirection: 'neutral',
+    comparisonText: 'last 30 days',
+    icon: 'Activity',
+    iconColor: '#0891b2',
+    badgeText: 'Healthy',
+    badgeVariant: 'success',
+    progressValue: 99,
+    sparklineData: [99.9, 99.95, 99.99, 99.98, 99.97, 100, 99.99, 99.95, 99.97, 99.98, 99.99, 99.97],
+    description: 'Service availability',
+  },
+  pageViews: {
+    name: 'Page Views',
+    title: 'Page Views',
+    value: 573291,
+    format: 'compact',
+    prefix: '',
+    suffix: '',
+    decimals: 0,
+    trendValue: 15.3,
+    trendDirection: 'up',
+    comparisonText: 'from last month',
+    icon: 'Eye',
+    iconColor: '#ea580c',
+    badgeText: 'Trending',
+    badgeVariant: 'info',
+    progressValue: 54,
+    sparklineData: [30000, 35000, 42000, 38000, 45000, 50000, 48000, 52000, 55000, 58000, 61000, 57329],
+    description: 'Total page impressions',
+  },
+}
+
+type PresetKey = keyof typeof kpiPresets
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
+  DollarSign,
+  Users,
+  ShoppingCart,
+  Activity,
+  Zap,
+  Eye,
+  BarChart3,
+  Clock,
+  Target,
+  Percent,
+}
+
+const iconOptions = Object.keys(iconMap)
 
 const shadowClasses: Record<ShadowSize, string> = {
   none: '',
@@ -39,484 +219,737 @@ const shadowClasses: Record<ShadowSize, string> = {
   xl: 'shadow-xl',
 }
 
-const borderClasses: Record<BorderStyle, string> = {
-  default: '',
-  primary: 'border-primary',
-  destructive: 'border-destructive',
-  none: 'border-0',
+const valueSizeClasses: Record<ValueSize, string> = {
+  sm: 'text-xl font-bold',
+  md: 'text-2xl font-bold',
+  lg: 'text-3xl font-bold',
+  xl: 'text-4xl font-bold',
 }
 
+const badgeVariants: BadgeVariant[] = [
+  'default', 'secondary', 'destructive', 'outline',
+  'success', 'info', 'warning', 'critical', 'danger', 'neutral',
+]
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
 export function CardPlayground() {
-  // Card variant
-  const [variant, setVariant] = React.useState<CardVariant>('default')
+  // ── Preset ──────────────────────────────────────────────────────────────
+  const [preset, setPreset] = React.useState<PresetKey>('revenue')
+  const currentPreset = kpiPresets[preset]
 
-  // Structure settings
-  const [showHeader, setShowHeader] = React.useState(true)
-  const [showTitle, setShowTitle] = React.useState(true)
-  const [showDescription, setShowDescription] = React.useState(true)
-  const [showContent, setShowContent] = React.useState(true)
-  const [showFooter, setShowFooter] = React.useState(true)
-  const [showImage, setShowImage] = React.useState(false)
+  // ── KPI Data ────────────────────────────────────────────────────────────
+  const [title, setTitle] = React.useState(currentPreset.title)
+  const [value, setValue] = React.useState(currentPreset.value)
+  const [valueFormat, setValueFormat] = React.useState<ValueFormat>(currentPreset.format)
+  const [prefix, setPrefix] = React.useState(currentPreset.prefix)
+  const [suffix, setSuffix] = React.useState(currentPreset.suffix)
+  const [decimals, setDecimals] = React.useState(currentPreset.decimals)
+  const [description, setDescription] = React.useState(currentPreset.description)
 
-  // Style settings
-  const [shadow, setShadow] = React.useState<ShadowSize>('none')
-  const [borderStyle, setBorderStyle] = React.useState<BorderStyle>('default')
-  const [hoverable, setHoverable] = React.useState(false)
-  const [cardWidth, setCardWidth] = React.useState('350')
-
-  // Content settings (for stats card)
+  // ── Trend ───────────────────────────────────────────────────────────────
   const [showTrend, setShowTrend] = React.useState(true)
+  const [trendValue, setTrendValue] = React.useState(currentPreset.trendValue)
+  const [trendDirection, setTrendDirection] = React.useState<TrendDirection>(currentPreset.trendDirection)
+  const [comparisonText, setComparisonText] = React.useState(currentPreset.comparisonText)
+  const [trendColorAuto, setTrendColorAuto] = React.useState(true)
+  const [trendColor, setTrendColor] = React.useState('#16a34a')
+  const [trendStyle, setTrendStyle] = React.useState<'icon-text' | 'arrow' | 'badge'>('icon-text')
+
+  // ── Icon ────────────────────────────────────────────────────────────────
+  const [showIcon, setShowIcon] = React.useState(true)
+  const [selectedIcon, setSelectedIcon] = React.useState(currentPreset.icon)
+  const [iconPosition, setIconPosition] = React.useState<IconPosition>('right')
+  const [iconStyle, setIconStyle] = React.useState<IconStyle>('circle')
+  const [iconColor, setIconColor] = React.useState(currentPreset.iconColor)
+  const [iconBgOpacity, setIconBgOpacity] = React.useState(0.1)
+
+  // ── Badge ───────────────────────────────────────────────────────────────
   const [showBadge, setShowBadge] = React.useState(false)
-  const [showAvatar, setShowAvatar] = React.useState(true)
-  const [showActions, setShowActions] = React.useState(true)
+  const [badgeText, setBadgeText] = React.useState(currentPreset.badgeText)
+  const [badgeVariant, setBadgeVariant] = React.useState<BadgeVariant>(currentPreset.badgeVariant)
 
-  // Build class string
-  const cardClasses = [
-    `w-[${cardWidth}px]`,
-    shadowClasses[shadow],
-    borderClasses[borderStyle],
-    hoverable ? 'cursor-pointer transition-all hover:shadow-lg hover:-translate-y-1' : '',
-    showImage ? 'overflow-hidden' : '',
-  ].filter(Boolean).join(' ')
+  // ── Footer ──────────────────────────────────────────────────────────────
+  const [showFooter, setShowFooter] = React.useState(true)
+  const [footerStyle, setFooterStyle] = React.useState<FooterStyle>('text')
+  const [footerText, setFooterText] = React.useState('Updated just now')
+  const [progressValue, setProgressValue] = React.useState(currentPreset.progressValue)
+  const [progressLabel, setProgressLabel] = React.useState('of target')
+  const [showComparisonValues, setShowComparisonValues] = React.useState(false)
+  const sparklineData = currentPreset.sparklineData
 
-  // Generate code
+  // ── Card Style ──────────────────────────────────────────────────────────
+  const [shadow, setShadow] = React.useState<ShadowSize>('sm')
+  const [hoverable, setHoverable] = React.useState(false)
+  const [cardWidth, setCardWidth] = React.useState(350)
+  const [valueSize, setValueSize] = React.useState<ValueSize>('lg')
+  const [borderAccent, setBorderAccent] = React.useState<BorderAccent>('none')
+  const [accentColor, setAccentColor] = React.useState(currentPreset.iconColor)
+  const [showDescription, setShowDescription] = React.useState(true)
+  const [showSkeleton, setShowSkeleton] = React.useState(false)
+  const [compactMode, setCompactMode] = React.useState(false)
+
+  // ── Sync preset ─────────────────────────────────────────────────────────
+  React.useEffect(() => {
+    const p = kpiPresets[preset]
+    setTitle(p.title)
+    setValue(p.value)
+    setValueFormat(p.format)
+    setPrefix(p.prefix)
+    setSuffix(p.suffix)
+    setDecimals(p.decimals)
+    setDescription(p.description)
+    setTrendValue(p.trendValue)
+    setTrendDirection(p.trendDirection)
+    setComparisonText(p.comparisonText)
+    setSelectedIcon(p.icon)
+    setIconColor(p.iconColor)
+    setBadgeText(p.badgeText)
+    setBadgeVariant(p.badgeVariant)
+    setProgressValue(p.progressValue)
+    setAccentColor(p.iconColor)
+  }, [preset])
+
+  // ── Helpers ─────────────────────────────────────────────────────────────
+
+  const formatValue = (v: number): string => {
+    switch (valueFormat) {
+      case 'currency': return `${prefix}${v.toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals })}${suffix}`
+      case 'percent': return `${v.toFixed(decimals)}${suffix || '%'}`
+      case 'compact': {
+        const formatted = v >= 1e6 ? `${(v / 1e6).toFixed(1)}M` : v >= 1e3 ? `${(v / 1e3).toFixed(1)}K` : v.toLocaleString()
+        return `${prefix}${formatted}${suffix}`
+      }
+      case 'custom': return `${prefix}${v.toFixed(decimals)}${suffix}`
+      default: return `${prefix}${v.toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals })}${suffix}`
+    }
+  }
+
+  const getTrendColorValue = (): string => {
+    if (!trendColorAuto) return trendColor
+    if (trendDirection === 'up') return '#16a34a'
+    if (trendDirection === 'down') return '#dc2626'
+    return '#6b7280'
+  }
+
+  const getTrendIcon = () => {
+    if (trendStyle === 'arrow') {
+      if (trendDirection === 'up') return <ArrowUpRight className="h-4 w-4" />
+      if (trendDirection === 'down') return <ArrowDownRight className="h-4 w-4" />
+      return <Minus className="h-4 w-4" />
+    }
+    if (trendDirection === 'up') return <TrendingUp className="h-4 w-4" />
+    if (trendDirection === 'down') return <TrendingDown className="h-4 w-4" />
+    return <Minus className="h-4 w-4" />
+  }
+
+  const IconComponent = iconMap[selectedIcon] ?? DollarSign
+
+  const renderSparkline = () => {
+    if (!sparklineData.length) return null
+    const max = Math.max(...sparklineData)
+    const min = Math.min(...sparklineData)
+    const range = max - min || 1
+    const w = 120
+    const h = 32
+    const points = sparklineData.map((v, i) => {
+      const x = (i / (sparklineData.length - 1)) * w
+      const y = h - ((v - min) / range) * h
+      return `${x},${y}`
+    }).join(' ')
+    return (
+      <svg width={w} height={h} className="mt-1">
+        <polyline
+          points={points}
+          fill="none"
+          stroke={accentColor}
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    )
+  }
+
+  // ── Card class builder ──────────────────────────────────────────────────
+
+  const buildCardClasses = (): string => {
+    const cls: string[] = [shadowClasses[shadow]]
+    if (hoverable) cls.push('cursor-pointer transition-all hover:shadow-lg hover:-translate-y-0.5')
+    if (borderAccent === 'none') cls.push('')
+    return cls.filter(Boolean).join(' ')
+  }
+
+  const buildCardStyle = (): React.CSSProperties => {
+    const style: React.CSSProperties = { width: `${cardWidth}px` }
+    if (borderAccent === 'left') {
+      style.borderLeftWidth = '4px'
+      style.borderLeftColor = accentColor
+    }
+    if (borderAccent === 'top') {
+      style.borderTopWidth = '3px'
+      style.borderTopColor = accentColor
+    }
+    return style
+  }
+
+  // ── Code generation ─────────────────────────────────────────────────────
+
   const generateCode = () => {
     const lines: string[] = []
-    const classAttr = cardClasses.trim() ? ` className="${cardClasses.trim()}"` : ''
-    
-    lines.push(`<Card${classAttr}>`)
-    
-    if (showImage && (variant === 'media' || variant === 'default')) {
-      lines.push(`  <div className="h-48 bg-gradient-to-r from-blue-500 to-purple-600" />`)
+    const cls = buildCardClasses().trim()
+    const clsAttr = cls ? ` className="${cls}"` : ''
+    const styleStr = borderAccent !== 'none' ? ` style={{ borderLeft${borderAccent === 'left' ? 'Width: "4px", borderLeftColor' : 'TopWidth: "3px", borderTopColor'}: "${accentColor}" }}` : ''
+    lines.push(`<Card${clsAttr}${styleStr}>`)
+
+    const pad = compactMode ? 'p-4' : 'p-6'
+    lines.push(`  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 ${pad}">`)
+    lines.push(`    <div>`)
+    lines.push(`      <CardTitle className="text-sm font-medium">${title}</CardTitle>`)
+    if (showDescription) {
+      lines.push(`      <CardDescription>${description}</CardDescription>`)
     }
-    
-    if (showHeader) {
-      lines.push(`  <CardHeader>`)
-      if (showAvatar && variant === 'profile') {
-        lines.push(`    <Avatar className="h-16 w-16">`)
-        lines.push(`      <AvatarImage src="..." />`)
-        lines.push(`      <AvatarFallback>JD</AvatarFallback>`)
-        lines.push(`    </Avatar>`)
-      }
-      if (showTitle) lines.push(`    <CardTitle>${getTitleText()}</CardTitle>`)
-      if (showDescription) lines.push(`    <CardDescription>${getDescriptionText()}</CardDescription>`)
-      if (showBadge) lines.push(`    <Badge>New</Badge>`)
-      lines.push(`  </CardHeader>`)
+    lines.push(`    </div>`)
+    if (showIcon) {
+      lines.push(`    <div className="rounded-${iconStyle === 'square' ? 'md' : 'full'} p-2" style={{ background: "${iconColor}1a" }}>`)
+      lines.push(`      <${selectedIcon} className="h-4 w-4" style={{ color: "${iconColor}" }} />`)
+      lines.push(`    </div>`)
     }
-    
-    if (showContent) {
-      lines.push(`  <CardContent>`)
-      lines.push(`    {/* Your content here */}`)
-      lines.push(`  </CardContent>`)
+    if (showBadge) {
+      lines.push(`    <Badge variant="${badgeVariant}">${badgeText}</Badge>`)
     }
-    
+    lines.push(`  </CardHeader>`)
+
+    lines.push(`  <CardContent className="${compactMode ? 'px-4 pb-2' : ''}">`)
+    lines.push(`    <div className="${valueSizeClasses[valueSize]}">${formatValue(value)}</div>`)
+    if (showTrend) {
+      lines.push(`    <p className="text-xs flex items-center gap-1 mt-1" style={{ color: "${getTrendColorValue()}" }}>`)
+      lines.push(`      <TrendingUp className="h-4 w-4" />`)
+      lines.push(`      ${trendValue >= 0 ? '+' : ''}${trendValue}% ${comparisonText}`)
+      lines.push(`    </p>`)
+    }
+    lines.push(`  </CardContent>`)
+
     if (showFooter) {
-      lines.push(`  <CardFooter>`)
-      if (showActions) {
-        lines.push(`    <Button>Action</Button>`)
+      lines.push(`  <CardFooter className="text-xs text-muted-foreground ${compactMode ? 'px-4 pb-4' : ''}">`)
+      if (footerStyle === 'progress') {
+        lines.push(`    <div className="w-full space-y-1">`)
+        lines.push(`      <div className="flex justify-between">`)
+        lines.push(`        <span>${progressValue}% ${progressLabel}</span>`)
+        lines.push(`      </div>`)
+        lines.push(`      <Progress value={${progressValue}} className="h-2" />`)
+        lines.push(`    </div>`)
+      } else if (footerStyle === 'sparkline') {
+        lines.push(`    {/* SVG sparkline */}`)
+      } else {
+        lines.push(`    ${footerText}`)
       }
       lines.push(`  </CardFooter>`)
     }
-    
+
     lines.push(`</Card>`)
     return lines.join('\n')
   }
 
-  const getTitleText = () => {
-    switch (variant) {
-      case 'stats': return 'Total Revenue'
-      case 'profile': return 'John Doe'
-      case 'pricing': return 'Pro Plan'
-      case 'media': return 'Beautiful Landscape'
-      case 'notification': return 'New Message'
-      default: return 'Card Title'
+  // ── Render KPI Card ─────────────────────────────────────────────────────
+
+  const renderKpiCard = () => {
+    if (showSkeleton) {
+      return (
+        <Card className={buildCardClasses()} style={buildCardStyle()}>
+          <CardHeader className={`flex flex-row items-center justify-between space-y-0 pb-2 ${compactMode ? 'p-4' : ''}`}>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              {showDescription && <Skeleton className="h-3 w-32" />}
+            </div>
+            {showIcon && <Skeleton className="h-9 w-9 rounded-full" />}
+          </CardHeader>
+          <CardContent className={compactMode ? 'px-4 pb-2' : ''}>
+            <Skeleton className="h-8 w-32" />
+            {showTrend && <Skeleton className="h-3 w-40 mt-2" />}
+          </CardContent>
+          {showFooter && (
+            <CardFooter className={compactMode ? 'px-4 pb-4' : ''}>
+              <Skeleton className="h-3 w-24" />
+            </CardFooter>
+          )}
+        </Card>
+      )
     }
+
+    const iconEl = showIcon && (
+      <div
+        className={`flex items-center justify-center p-2 ${iconStyle === 'circle' ? 'rounded-full' : iconStyle === 'square' ? 'rounded-md' : ''}`}
+        style={iconStyle !== 'plain' ? { backgroundColor: `${iconColor}${Math.round(iconBgOpacity * 255).toString(16).padStart(2, '0')}` } : undefined}
+      >
+        <IconComponent className="h-4 w-4" style={{ color: iconColor }} />
+      </div>
+    )
+
+    const trendEl = showTrend && (
+      <p className="text-xs flex items-center gap-1 mt-1" style={{ color: getTrendColorValue() }}>
+        {trendStyle === 'badge' ? (
+          <Badge variant={trendDirection === 'up' ? 'success' : trendDirection === 'down' ? 'destructive' : 'secondary'} className="text-[10px] px-1.5 py-0">
+            {getTrendIcon()}
+            <span className="ml-0.5">{trendValue >= 0 ? '+' : ''}{trendValue}%</span>
+          </Badge>
+        ) : (
+          <>
+            {getTrendIcon()}
+            <span>{trendValue >= 0 ? '+' : ''}{trendValue}% {comparisonText}</span>
+          </>
+        )}
+      </p>
+    )
+
+    return (
+      <Card className={buildCardClasses()} style={buildCardStyle()}>
+        <CardHeader className={`flex flex-row items-center justify-between space-y-0 pb-2 ${compactMode ? 'p-4' : ''}`}>
+          <div className="flex-1">
+            <div className="flex items-center gap-2">
+              {iconPosition === 'left' && iconEl}
+              <div>
+                <CardTitle className="text-sm font-medium">{title}</CardTitle>
+                {showDescription && <CardDescription className="text-xs">{description}</CardDescription>}
+              </div>
+            </div>
+          </div>
+          {showBadge && <Badge variant={badgeVariant}>{badgeText}</Badge>}
+          {iconPosition === 'right' && iconEl}
+        </CardHeader>
+        <CardContent className={compactMode ? 'px-4 pb-2' : ''}>
+          <div className={valueSizeClasses[valueSize]}>{formatValue(value)}</div>
+          {trendEl}
+        </CardContent>
+        {showFooter && (
+          <CardFooter className={`text-xs text-muted-foreground ${compactMode ? 'px-4 pb-4' : ''}`}>
+            {footerStyle === 'progress' && (
+              <div className="w-full space-y-1">
+                <div className="flex justify-between text-xs">
+                  <span>{progressValue}% {progressLabel}</span>
+                </div>
+                <Progress value={progressValue} className="h-2" />
+              </div>
+            )}
+            {footerStyle === 'sparkline' && (
+              <div className="w-full">
+                {renderSparkline()}
+                <span className="text-xs text-muted-foreground mt-1 block">Last {sparklineData.length} periods</span>
+              </div>
+            )}
+            {footerStyle === 'comparison' && showComparisonValues && (
+              <div className="w-full flex justify-between">
+                <span>Current: {formatValue(value)}</span>
+                <span>Previous: {formatValue(value / (1 + trendValue / 100))}</span>
+              </div>
+            )}
+            {footerStyle === 'comparison' && !showComparisonValues && (
+              <span>{footerText}</span>
+            )}
+            {footerStyle === 'text' && <span>{footerText}</span>}
+          </CardFooter>
+        )}
+      </Card>
+    )
   }
 
-  const getDescriptionText = () => {
-    switch (variant) {
-      case 'stats': return '+20.1% from last month'
-      case 'profile': return 'Software Engineer'
-      case 'pricing': return '$29/month'
-      case 'media': return 'A stunning view of nature'
-      case 'notification': return '2 minutes ago'
-      default: return 'Card description goes here'
-    }
-  }
-
-  // Render card based on variant
-  const renderCard = () => {
-    const baseClasses = [
-      shadowClasses[shadow],
-      borderClasses[borderStyle],
-      hoverable ? 'cursor-pointer transition-all hover:shadow-lg hover:-translate-y-1' : '',
-      showImage && (variant === 'media' || variant === 'default') ? 'overflow-hidden' : '',
-    ].filter(Boolean).join(' ')
-
-    switch (variant) {
-      case 'stats':
-        return (
-          <Card className={baseClasses} style={{ width: `${cardWidth}px` }}>
-            {showHeader && (
-              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <div>
-                  {showTitle && <CardTitle className="text-sm font-medium">Total Revenue</CardTitle>}
-                  {showDescription && (
-                    <CardDescription className="text-xs">
-                      {showTrend && (
-                        <span className="flex items-center gap-1 text-green-600">
-                          <TrendingUp className="h-3 w-3" /> +20.1% from last month
-                        </span>
-                      )}
-                      {!showTrend && 'Monthly overview'}
-                    </CardDescription>
-                  )}
-                </div>
-                {showBadge && <Badge variant="secondary">Live</Badge>}
-              </CardHeader>
-            )}
-            {showContent && (
-              <CardContent>
-                <div className="text-3xl font-bold">$45,231.89</div>
-                <p className="text-xs text-muted-foreground mt-1">+20.1% from last month</p>
-              </CardContent>
-            )}
-            {showFooter && (
-              <CardFooter className="text-xs text-muted-foreground">
-                Updated just now
-              </CardFooter>
-            )}
-          </Card>
-        )
-
-      case 'profile':
-        return (
-          <Card className={baseClasses} style={{ width: `${cardWidth}px` }}>
-            {showHeader && (
-              <CardHeader className="text-center">
-                {showAvatar && (
-                  <Avatar className="h-20 w-20 mx-auto mb-2">
-                    <AvatarImage src="https://github.com/shadcn.png" />
-                    <AvatarFallback>JD</AvatarFallback>
-                  </Avatar>
-                )}
-                {showTitle && <CardTitle>John Doe</CardTitle>}
-                {showDescription && <CardDescription>Software Engineer at Acme Inc.</CardDescription>}
-                {showBadge && <Badge className="mt-2">Pro Member</Badge>}
-              </CardHeader>
-            )}
-            {showContent && (
-              <CardContent className="text-center">
-                <div className="flex justify-center gap-6 text-sm">
-                  <div>
-                    <div className="font-bold">142</div>
-                    <p className="text-muted-foreground">Shows what&apos;s happening right now</p>
-                  </div>
-                  <div>
-                    <div className="font-bold">1.2K</div>
-                    <div className="text-muted-foreground">Followers</div>
-                  </div>
-                  <div>
-                    <div className="font-bold">567</div>
-                    <div className="text-muted-foreground">Following</div>
-                  </div>
-                </div>
-              </CardContent>
-            )}
-            {showFooter && showActions && (
-              <CardFooter className="justify-center gap-2">
-                <Button>Follow</Button>
-                <Button variant="outline">Message</Button>
-              </CardFooter>
-            )}
-          </Card>
-        )
-
-      case 'pricing':
-        return (
-          <Card className={baseClasses} style={{ width: `${cardWidth}px` }}>
-            {showHeader && (
-              <CardHeader>
-                <div className="flex items-center justify-between">
-                  {showTitle && <CardTitle>Pro Plan</CardTitle>}
-                  {showBadge && <Badge>Popular</Badge>}
-                </div>
-                {showDescription && <CardDescription>For professional teams</CardDescription>}
-              </CardHeader>
-            )}
-            {showContent && (
-              <CardContent>
-                <div className="mb-4">
-                  <span className="text-4xl font-bold">$29</span>
-                  <span className="text-muted-foreground">/month</span>
-                </div>
-                <ul className="space-y-2 text-sm">
-                  <li className="flex items-center gap-2">✓ Unlimited projects</li>
-                  <li className="flex items-center gap-2">✓ Priority support</li>
-                  <li className="flex items-center gap-2">✓ Advanced analytics</li>
-                  <li className="flex items-center gap-2">✓ Custom integrations</li>
-                </ul>
-              </CardContent>
-            )}
-            {showFooter && showActions && (
-              <CardFooter>
-                <Button className="w-full">Get Started</Button>
-              </CardFooter>
-            )}
-          </Card>
-        )
-
-      case 'media':
-        return (
-          <Card className={baseClasses} style={{ width: `${cardWidth}px` }}>
-            {showImage && (
-              <div className="h-48 bg-gradient-to-r from-blue-500 to-purple-600" />
-            )}
-            {showHeader && (
-              <CardHeader>
-                <div className="flex items-center justify-between">
-                  {showTitle && <CardTitle>Beautiful Landscape</CardTitle>}
-                  {showBadge && <Badge variant="secondary">Featured</Badge>}
-                </div>
-                {showDescription && <CardDescription>A stunning view of nature</CardDescription>}
-              </CardHeader>
-            )}
-            {showContent && (
-              <CardContent>
-                <p className="text-sm text-muted-foreground">
-                  Discover the beauty of natural landscapes with our curated collection of photographs.
-                </p>
-              </CardContent>
-            )}
-            {showFooter && showActions && (
-              <CardFooter className="justify-between">
-                <div className="flex gap-4">
-                  <Button variant="ghost" size="sm"><Heart className="h-4 w-4 mr-1" /> 24</Button>
-                  <Button variant="ghost" size="sm"><MessageCircle className="h-4 w-4 mr-1" /> 8</Button>
-                </div>
-                <Button variant="ghost" size="sm"><Share2 className="h-4 w-4" /></Button>
-              </CardFooter>
-            )}
-          </Card>
-        )
-
-      case 'notification':
-        return (
-          <Card className={baseClasses} style={{ width: `${cardWidth}px` }}>
-            {showHeader && (
-              <CardHeader className="flex flex-row items-start gap-4 space-y-0">
-                {showAvatar && (
-                  <Avatar className="h-10 w-10">
-                    <AvatarImage src="https://github.com/shadcn.png" />
-                    <AvatarFallback>JD</AvatarFallback>
-                  </Avatar>
-                )}
-                <div className="flex-1">
-                  {showTitle && <CardTitle className="text-sm">New Message</CardTitle>}
-                  {showDescription && (
-                    <CardDescription className="text-xs">John Doe sent you a message</CardDescription>
-                  )}
-                </div>
-                {showBadge && <Badge variant="destructive" className="h-5 w-5 p-0 justify-center">3</Badge>}
-              </CardHeader>
-            )}
-            {showContent && (
-              <CardContent>
-                <p className="text-sm text-muted-foreground">
-                  &quot;Hey, I wanted to follow up on our conversation yesterday...&quot;
-                </p>
-              </CardContent>
-            )}
-            {showFooter && showActions && (
-              <CardFooter className="justify-between">
-                <span className="text-xs text-muted-foreground">2 minutes ago</span>
-                <div className="flex gap-2">
-                  <Button size="sm" variant="outline">Dismiss</Button>
-                  <Button size="sm">Reply</Button>
-                </div>
-              </CardFooter>
-            )}
-          </Card>
-        )
-
-      default:
-        return (
-          <Card className={baseClasses} style={{ width: `${cardWidth}px` }}>
-            {showImage && (
-              <div className="h-48 bg-gradient-to-r from-blue-500 to-purple-600" />
-            )}
-            {showHeader && (
-              <CardHeader>
-                <div className="flex items-center justify-between">
-                  {showTitle && <CardTitle>Card Title</CardTitle>}
-                  {showBadge && <Badge>New</Badge>}
-                </div>
-                {showDescription && <CardDescription>Card description goes here</CardDescription>}
-              </CardHeader>
-            )}
-            {showContent && (
-              <CardContent>
-                <p className="text-sm text-muted-foreground">
-                  This is the main content area of the card. You can add any content here including text, images, forms, and more.
-                </p>
-              </CardContent>
-            )}
-            {showFooter && showActions && (
-              <CardFooter className="justify-between">
-                <Button variant="outline">Cancel</Button>
-                <Button>Confirm</Button>
-              </CardFooter>
-            )}
-          </Card>
-        )
-    }
-  }
+  // ── Render ──────────────────────────────────────────────────────────────
 
   return (
     <div className="space-y-6 p-6">
       <div>
-        <h2 className="text-2xl font-bold">Card Playground</h2>
+        <h2 className="text-2xl font-bold">KPI Card Playground</h2>
         <p className="text-muted-foreground">
-          Versatile container for grouping related content and actions
+          Dashboard KPI widget card - configure every aspect of your key performance indicator
         </p>
       </div>
 
       <div className="grid gap-6 lg:grid-cols-[1fr_350px]">
-        {/* Card Preview */}
+        {/* ── Live Preview ───────────────────────────────────────────── */}
         <Card>
           <CardHeader>
             <CardTitle>Live Preview</CardTitle>
             <CardDescription>Card updates as you change settings</CardDescription>
           </CardHeader>
           <CardContent className="flex items-center justify-center min-h-[400px] bg-muted/30 rounded-lg">
-            {renderCard()}
+            {renderKpiCard()}
           </CardContent>
         </Card>
 
-        {/* Settings Panel */}
+        {/* ── Settings Panel ─────────────────────────────────────────── */}
         <Card>
           <CardHeader>
             <CardTitle>Settings</CardTitle>
-            <CardDescription>Customize your card</CardDescription>
+            <CardDescription>Toggle to see what each setting does</CardDescription>
           </CardHeader>
           <CardContent>
-            <Tabs defaultValue="variant" className="w-full">
-              <TabsList className="grid w-full grid-cols-3">
-                <TabsTrigger value="variant">Type</TabsTrigger>
-                <TabsTrigger value="structure">Structure</TabsTrigger>
-                <TabsTrigger value="style">Style</TabsTrigger>
+            <Tabs defaultValue="data" className="w-full">
+              <TabsList className="grid w-full grid-cols-4">
+                <TabsTrigger value="data">Data</TabsTrigger>
+                <TabsTrigger value="trend">Trend</TabsTrigger>
+                <TabsTrigger value="visual">Visual</TabsTrigger>
+                <TabsTrigger value="card">Card</TabsTrigger>
               </TabsList>
 
-              <TabsContent value="variant" className="space-y-4 pt-4">
+              {/* ─── Tab: Data ──────────────────────────────────────── */}
+              <TabsContent value="data" className="space-y-4 pt-4">
+                {/* Preset */}
                 <div className="space-y-2">
-                  <Label className="text-sm font-medium">Card Type</Label>
-                  <Select value={variant} onValueChange={(v) => setVariant(v as CardVariant)}>
+                  <Label className="text-sm font-medium">KPI Preset</Label>
+                  <Select value={preset} onValueChange={(v) => setPreset(v as PresetKey)}>
                     <SelectTrigger>
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="default">Default</SelectItem>
-                      <SelectItem value="stats">Stats/KPI</SelectItem>
-                      <SelectItem value="profile">Profile</SelectItem>
-                      <SelectItem value="pricing">Pricing</SelectItem>
-                      <SelectItem value="media">Media/Image</SelectItem>
-                      <SelectItem value="notification">Notification</SelectItem>
+                      {Object.entries(kpiPresets).map(([key, p]) => (
+                        <SelectItem key={key} value={key}>{p.name}</SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
-                  <p className="text-xs text-muted-foreground">
-                    Choose a card template to start with
-                  </p>
                 </div>
 
                 <Separator />
 
-                <div className="space-y-2">
-                  <Label className="text-sm font-medium">Width (px)</Label>
-                  <Input
-                    type="number"
-                    value={cardWidth}
-                    onChange={(e) => setCardWidth(e.target.value)}
-                    min={200}
-                    max={600}
-                  />
+                {/* Title */}
+                <div className="space-y-1">
+                  <Label className="text-sm font-medium">Title</Label>
+                  <Input value={title} onChange={(e) => setTitle(e.target.value)} className="h-8" />
                 </div>
+
+                {/* Description */}
+                <div className="space-y-1">
+                  <div className="flex items-center justify-between">
+                    <Label className="text-sm font-medium">Description</Label>
+                    <Switch checked={showDescription} onCheckedChange={setShowDescription} />
+                  </div>
+                  {showDescription && (
+                    <Input value={description} onChange={(e) => setDescription(e.target.value)} className="h-8" />
+                  )}
+                </div>
+
+                <Separator />
+
+                {/* Value */}
+                <div className="space-y-1">
+                  <Label className="text-sm font-medium">Value</Label>
+                  <Input type="number" value={value} onChange={(e) => setValue(Number(e.target.value) || 0)} className="h-8" />
+                </div>
+
+                {/* Format */}
+                <div className="space-y-1">
+                  <Label className="text-sm font-medium">Format</Label>
+                  <Select value={valueFormat} onValueChange={(v) => setValueFormat(v as ValueFormat)}>
+                    <SelectTrigger className="h-8">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="number">Number (1,234)</SelectItem>
+                      <SelectItem value="currency">Currency ($1,234.56)</SelectItem>
+                      <SelectItem value="percent">Percent (12.5%)</SelectItem>
+                      <SelectItem value="compact">Compact (1.2K)</SelectItem>
+                      <SelectItem value="custom">Custom</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="grid grid-cols-3 gap-2">
+                  <div className="space-y-1">
+                    <Label className="text-xs">Prefix</Label>
+                    <Input value={prefix} onChange={(e) => setPrefix(e.target.value)} className="h-7 text-xs" />
+                  </div>
+                  <div className="space-y-1">
+                    <Label className="text-xs">Suffix</Label>
+                    <Input value={suffix} onChange={(e) => setSuffix(e.target.value)} className="h-7 text-xs" />
+                  </div>
+                  <div className="space-y-1">
+                    <Label className="text-xs">Decimals</Label>
+                    <Input type="number" value={decimals} onChange={(e) => setDecimals(Number(e.target.value) || 0)} min={0} max={6} className="h-7 text-xs" />
+                  </div>
+                </div>
+                <p className="text-xs text-muted-foreground">Preview: {formatValue(value)}</p>
               </TabsContent>
 
-              <TabsContent value="structure" className="space-y-4 pt-4">
+              {/* ─── Tab: Trend ─────────────────────────────────────── */}
+              <TabsContent value="trend" className="space-y-4 pt-4">
                 <div className="flex items-center justify-between">
-                  <Label className="text-sm font-medium">Header</Label>
-                  <Switch checked={showHeader} onCheckedChange={setShowHeader} />
+                  <div>
+                    <Label className="text-sm font-medium">Show Trend</Label>
+                    <p className="text-xs text-muted-foreground">Change indicator below value</p>
+                  </div>
+                  <Switch checked={showTrend} onCheckedChange={setShowTrend} />
                 </div>
 
-                {showHeader && (
+                {showTrend && (
                   <>
-                    <div className="flex items-center justify-between pl-4">
-                      <Label className="text-sm">Title</Label>
-                      <Switch checked={showTitle} onCheckedChange={setShowTitle} />
+                    <div className="flex items-center justify-between">
+                      <Label className="text-sm">Direction</Label>
+                      <Select value={trendDirection} onValueChange={(v) => setTrendDirection(v as TrendDirection)}>
+                        <SelectTrigger className="w-28 h-8">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="up">Up</SelectItem>
+                          <SelectItem value="down">Down</SelectItem>
+                          <SelectItem value="neutral">Neutral</SelectItem>
+                        </SelectContent>
+                      </Select>
                     </div>
 
+                    <div className="flex items-center justify-between">
+                      <Label className="text-sm">Value (%)</Label>
+                      <Input type="number" value={trendValue} onChange={(e) => setTrendValue(Number(e.target.value) || 0)} step={0.1} className="w-24 h-8" />
+                    </div>
+
+                    <div className="space-y-1">
+                      <Label className="text-sm">Comparison Text</Label>
+                      <Input value={comparisonText} onChange={(e) => setComparisonText(e.target.value)} className="h-8" />
+                    </div>
+
+                    <Separator />
+
+                    <div className="space-y-1">
+                      <Label className="text-sm">Style</Label>
+                      <Select value={trendStyle} onValueChange={(v) => setTrendStyle(v as typeof trendStyle)}>
+                        <SelectTrigger className="h-8">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="icon-text">Icon + Text</SelectItem>
+                          <SelectItem value="arrow">Arrow Icon</SelectItem>
+                          <SelectItem value="badge">Badge</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+
+                    <Separator />
+
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <Label className="text-sm">Auto Color</Label>
+                        <p className="text-xs text-muted-foreground">Green=up, Red=down, Gray=neutral</p>
+                      </div>
+                      <Switch checked={trendColorAuto} onCheckedChange={setTrendColorAuto} />
+                    </div>
+                    {!trendColorAuto && (
+                      <div className="flex items-center gap-2 pl-4">
+                        <input type="color" value={trendColor} onChange={(e) => setTrendColor(e.target.value)} className="h-6 w-8 cursor-pointer rounded border-0 bg-transparent p-0" />
+                        <Input type="text" value={trendColor} onChange={(e) => setTrendColor(e.target.value)} className="flex-1 h-8" />
+                      </div>
+                    )}
+                  </>
+                )}
+              </TabsContent>
+
+              {/* ─── Tab: Visual ────────────────────────────────────── */}
+              <TabsContent value="visual" className="space-y-4 pt-4">
+                {/* Icon */}
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Label className="text-sm font-medium">Show Icon</Label>
+                    <p className="text-xs text-muted-foreground">Decorative metric icon</p>
+                  </div>
+                  <Switch checked={showIcon} onCheckedChange={setShowIcon} />
+                </div>
+                {showIcon && (
+                  <>
                     <div className="flex items-center justify-between pl-4">
-                      <Label className="text-sm">Description</Label>
-                      <Switch checked={showDescription} onCheckedChange={setShowDescription} />
+                      <Label className="text-sm">Icon</Label>
+                      <Select value={selectedIcon} onValueChange={setSelectedIcon}>
+                        <SelectTrigger className="w-36 h-8">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {iconOptions.map((ic) => (
+                            <SelectItem key={ic} value={ic}>{ic}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="flex items-center justify-between pl-4">
+                      <Label className="text-sm">Position</Label>
+                      <Select value={iconPosition} onValueChange={(v) => setIconPosition(v as IconPosition)}>
+                        <SelectTrigger className="w-24 h-8">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="left">Left</SelectItem>
+                          <SelectItem value="right">Right</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="flex items-center justify-between pl-4">
+                      <Label className="text-sm">Style</Label>
+                      <Select value={iconStyle} onValueChange={(v) => setIconStyle(v as IconStyle)}>
+                        <SelectTrigger className="w-24 h-8">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="circle">Circle</SelectItem>
+                          <SelectItem value="square">Square</SelectItem>
+                          <SelectItem value="plain">Plain</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-1 pl-4">
+                      <Label className="text-sm">Color</Label>
+                      <div className="flex items-center gap-2">
+                        <input type="color" value={iconColor} onChange={(e) => setIconColor(e.target.value)} className="h-6 w-8 cursor-pointer rounded border-0 bg-transparent p-0" />
+                        <Input type="text" value={iconColor} onChange={(e) => setIconColor(e.target.value)} className="flex-1 h-8" />
+                      </div>
+                    </div>
+                    {iconStyle !== 'plain' && (
+                      <div className="flex items-center justify-between pl-4">
+                        <Label className="text-sm">Bg Opacity ({iconBgOpacity})</Label>
+                        <Input type="number" value={iconBgOpacity} onChange={(e) => setIconBgOpacity(Math.min(1, Math.max(0, Number(e.target.value) || 0.1)))} step={0.05} min={0} max={1} className="w-20 h-8" />
+                      </div>
+                    )}
+                  </>
+                )}
+
+                <Separator />
+
+                {/* Badge */}
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Label className="text-sm font-medium">Show Badge</Label>
+                    <p className="text-xs text-muted-foreground">Status badge in header</p>
+                  </div>
+                  <Switch checked={showBadge} onCheckedChange={setShowBadge} />
+                </div>
+                {showBadge && (
+                  <>
+                    <div className="space-y-1 pl-4">
+                      <Label className="text-sm">Text</Label>
+                      <Input value={badgeText} onChange={(e) => setBadgeText(e.target.value)} className="h-8" />
+                    </div>
+                    <div className="flex items-center justify-between pl-4">
+                      <Label className="text-sm">Variant</Label>
+                      <Select value={badgeVariant} onValueChange={(v) => setBadgeVariant(v as BadgeVariant)}>
+                        <SelectTrigger className="w-28 h-8">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {badgeVariants.map((bv) => (
+                            <SelectItem key={bv} value={bv}>{bv}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                     </div>
                   </>
                 )}
 
                 <Separator />
 
+                {/* Footer */}
                 <div className="flex items-center justify-between">
-                  <Label className="text-sm font-medium">Content</Label>
-                  <Switch checked={showContent} onCheckedChange={setShowContent} />
-                </div>
-
-                <Separator />
-
-                <div className="flex items-center justify-between">
-                  <Label className="text-sm font-medium">Footer</Label>
+                  <div>
+                    <Label className="text-sm font-medium">Show Footer</Label>
+                    <p className="text-xs text-muted-foreground">Bottom section of card</p>
+                  </div>
                   <Switch checked={showFooter} onCheckedChange={setShowFooter} />
                 </div>
-
                 {showFooter && (
-                  <div className="flex items-center justify-between pl-4">
-                    <Label className="text-sm">Actions</Label>
-                    <Switch checked={showActions} onCheckedChange={setShowActions} />
-                  </div>
+                  <>
+                    <div className="flex items-center justify-between pl-4">
+                      <Label className="text-sm">Footer Style</Label>
+                      <Select value={footerStyle} onValueChange={(v) => setFooterStyle(v as FooterStyle)}>
+                        <SelectTrigger className="w-32 h-8">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="text">Text</SelectItem>
+                          <SelectItem value="progress">Progress Bar</SelectItem>
+                          <SelectItem value="sparkline">Sparkline</SelectItem>
+                          <SelectItem value="comparison">Comparison</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    {footerStyle === 'text' && (
+                      <div className="space-y-1 pl-4">
+                        <Label className="text-sm">Footer Text</Label>
+                        <Input value={footerText} onChange={(e) => setFooterText(e.target.value)} className="h-8" />
+                      </div>
+                    )}
+                    {footerStyle === 'progress' && (
+                      <>
+                        <div className="flex items-center justify-between pl-4">
+                          <Label className="text-sm">Progress (%)</Label>
+                          <Input type="number" value={progressValue} onChange={(e) => setProgressValue(Math.min(100, Math.max(0, Number(e.target.value) || 0)))} min={0} max={100} className="w-20 h-8" />
+                        </div>
+                        <div className="space-y-1 pl-4">
+                          <Label className="text-sm">Label</Label>
+                          <Input value={progressLabel} onChange={(e) => setProgressLabel(e.target.value)} className="h-8" />
+                        </div>
+                      </>
+                    )}
+                    {footerStyle === 'comparison' && (
+                      <div className="flex items-center justify-between pl-4">
+                        <Label className="text-sm">Show Values</Label>
+                        <Switch checked={showComparisonValues} onCheckedChange={setShowComparisonValues} />
+                      </div>
+                    )}
+                  </>
                 )}
 
                 <Separator />
 
-                {(variant === 'media' || variant === 'default') && (
-                  <div className="flex items-center justify-between">
-                    <Label className="text-sm font-medium">Image Header</Label>
-                    <Switch checked={showImage} onCheckedChange={setShowImage} />
-                  </div>
-                )}
-
-                {(variant === 'profile' || variant === 'notification') && (
-                  <div className="flex items-center justify-between">
-                    <Label className="text-sm font-medium">Avatar</Label>
-                    <Switch checked={showAvatar} onCheckedChange={setShowAvatar} />
-                  </div>
-                )}
-
+                {/* Skeleton */}
                 <div className="flex items-center justify-between">
-                  <Label className="text-sm font-medium">Badge</Label>
-                  <Switch checked={showBadge} onCheckedChange={setShowBadge} />
-                </div>
-
-                {variant === 'stats' && (
-                  <div className="flex items-center justify-between">
-                    <Label className="text-sm font-medium">Trend Indicator</Label>
-                    <Switch checked={showTrend} onCheckedChange={setShowTrend} />
+                  <div>
+                    <Label className="text-sm font-medium">Loading State</Label>
+                    <p className="text-xs text-muted-foreground">Show skeleton placeholder</p>
                   </div>
-                )}
+                  <Switch checked={showSkeleton} onCheckedChange={setShowSkeleton} />
+                </div>
               </TabsContent>
 
-              <TabsContent value="style" className="space-y-4 pt-4">
+              {/* ─── Tab: Card ──────────────────────────────────────── */}
+              <TabsContent value="card" className="space-y-4 pt-4">
+                {/* Width */}
+                <div className="flex items-center justify-between">
+                  <Label className="text-sm font-medium">Width (px)</Label>
+                  <Input type="number" value={cardWidth} onChange={(e) => setCardWidth(Number(e.target.value) || 350)} min={200} max={600} className="w-24 h-8" />
+                </div>
+
+                <Separator />
+
+                {/* Value Size */}
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Label className="text-sm font-medium">Value Size</Label>
+                    <p className="text-xs text-muted-foreground">Font size of the KPI number</p>
+                  </div>
+                  <Select value={valueSize} onValueChange={(v) => setValueSize(v as ValueSize)}>
+                    <SelectTrigger className="w-20 h-8">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="sm">SM</SelectItem>
+                      <SelectItem value="md">MD</SelectItem>
+                      <SelectItem value="lg">LG</SelectItem>
+                      <SelectItem value="xl">XL</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <Separator />
+
+                {/* Compact Mode */}
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Label className="text-sm font-medium">Compact Mode</Label>
+                    <p className="text-xs text-muted-foreground">Reduced padding for dense layouts</p>
+                  </div>
+                  <Switch checked={compactMode} onCheckedChange={setCompactMode} />
+                </div>
+
+                <Separator />
+
+                {/* Shadow */}
                 <div className="space-y-2">
                   <Label className="text-sm font-medium">Shadow</Label>
                   <Select value={shadow} onValueChange={(v) => setShadow(v as ShadowSize)}>
-                    <SelectTrigger>
+                    <SelectTrigger className="h-8">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -531,37 +964,47 @@ export function CardPlayground() {
 
                 <Separator />
 
-                <div className="space-y-2">
-                  <Label className="text-sm font-medium">Border Style</Label>
-                  <Select value={borderStyle} onValueChange={(v) => setBorderStyle(v as BorderStyle)}>
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="default">Default</SelectItem>
-                      <SelectItem value="primary">Primary</SelectItem>
-                      <SelectItem value="destructive">Destructive</SelectItem>
-                      <SelectItem value="none">No Border</SelectItem>
-                    </SelectContent>
-                  </Select>
+                {/* Hover */}
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Label className="text-sm font-medium">Hover Effect</Label>
+                    <p className="text-xs text-muted-foreground">Lift and shadow on hover</p>
+                  </div>
+                  <Switch checked={hoverable} onCheckedChange={setHoverable} />
                 </div>
 
                 <Separator />
 
-                <div className="flex items-center justify-between">
-                  <div>
-                    <Label className="text-sm font-medium">Hover Effect</Label>
-                    <p className="text-xs text-muted-foreground">Covers the last 7 days</p>
-                  </div>
-                  <Switch checked={hoverable} onCheckedChange={setHoverable} />
+                {/* Border Accent */}
+                <div className="space-y-2">
+                  <Label className="text-sm font-medium">Border Accent</Label>
+                  <Select value={borderAccent} onValueChange={(v) => setBorderAccent(v as BorderAccent)}>
+                    <SelectTrigger className="h-8">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">None</SelectItem>
+                      <SelectItem value="left">Left</SelectItem>
+                      <SelectItem value="top">Top</SelectItem>
+                    </SelectContent>
+                  </Select>
                 </div>
+                {borderAccent !== 'none' && (
+                  <div className="space-y-1 pl-4">
+                    <Label className="text-sm">Accent Color</Label>
+                    <div className="flex items-center gap-2">
+                      <input type="color" value={accentColor} onChange={(e) => setAccentColor(e.target.value)} className="h-6 w-8 cursor-pointer rounded border-0 bg-transparent p-0" />
+                      <Input type="text" value={accentColor} onChange={(e) => setAccentColor(e.target.value)} className="flex-1 h-8" />
+                    </div>
+                  </div>
+                )}
               </TabsContent>
             </Tabs>
           </CardContent>
         </Card>
       </div>
 
-      {/* Code Preview */}
+      {/* ── Generated Code ─────────────────────────────────────────────── */}
       <Card>
         <CardHeader>
           <CardTitle>Generated Code</CardTitle>
@@ -574,35 +1017,56 @@ export function CardPlayground() {
         </CardContent>
       </Card>
 
-      {/* Documentation Section */}
+      {/* ── Documentation ──────────────────────────────────────────────── */}
       <div className="grid gap-6 lg:grid-cols-2">
         <Card>
           <CardHeader>
-            <CardTitle>📊 Data / Structure</CardTitle>
-            <CardDescription>Card composition pattern</CardDescription>
+            <CardTitle>KPI Card Structure</CardTitle>
+            <CardDescription>Composition pattern for dashboard widgets</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <pre className="overflow-x-auto rounded-lg bg-muted p-4 text-sm">
-              <code>{`import { Card, CardHeader, CardTitle, 
-  CardDescription, CardContent, CardFooter 
+              <code>{`import {
+  Card, CardHeader, CardTitle,
+  CardDescription, CardContent, CardFooter,
+  Badge, Progress
 } from '@acronis-platform/shadcn-uikit/react'
+import { TrendingUp, DollarSign } from 'lucide-react'
 
 <Card>
-  <CardHeader>
-    <CardTitle>Title</CardTitle>
-    <CardDescription>Subtitle</CardDescription>
+  <CardHeader className="flex flex-row items-center
+    justify-between space-y-0 pb-2">
+    <div>
+      <CardTitle className="text-sm font-medium">
+        Total Revenue
+      </CardTitle>
+      <CardDescription>Monthly recurring</CardDescription>
+    </div>
+    <DollarSign className="h-4 w-4 text-muted-foreground" />
   </CardHeader>
-  <CardContent>Main content</CardContent>
-  <CardFooter>Actions</CardFooter>
+  <CardContent>
+    <div className="text-3xl font-bold">$45,231.89</div>
+    <p className="text-xs text-green-600 flex items-center">
+      <TrendingUp className="h-4 w-4 mr-1" />
+      +20.1% from last month
+    </p>
+  </CardContent>
+  <CardFooter className="text-xs text-muted-foreground">
+    Updated just now
+  </CardFooter>
 </Card>`}</code>
             </pre>
             <div className="space-y-2 text-sm">
-              <p className="font-medium">Components:</p>
+              <p className="font-medium">Components Used:</p>
               <ul className="list-disc list-inside space-y-1 text-muted-foreground">
-                <li><strong>Card</strong> - Container with border and background</li>
-                <li><strong>CardHeader</strong> - Title + description section</li>
-                <li><strong>CardContent</strong> - Main content area</li>
-                <li><strong>CardFooter</strong> - Actions/buttons section</li>
+                <li><strong>Card</strong> - Container with border, background, and shadow</li>
+                <li><strong>CardHeader</strong> - Title + icon row with flex layout</li>
+                <li><strong>CardTitle</strong> - Metric name (use text-sm font-medium for KPI)</li>
+                <li><strong>CardDescription</strong> - Optional subtitle or context</li>
+                <li><strong>CardContent</strong> - Value + trend indicator</li>
+                <li><strong>CardFooter</strong> - Timestamp, progress bar, or sparkline</li>
+                <li><strong>Badge</strong> - Status indicator (10 variants available)</li>
+                <li><strong>Progress</strong> - Target completion bar</li>
               </ul>
             </div>
           </CardContent>
@@ -610,28 +1074,50 @@ export function CardPlayground() {
 
         <Card>
           <CardHeader>
-            <CardTitle>⚙️ Configurable Properties</CardTitle>
-            <CardDescription>What you can customize</CardDescription>
+            <CardTitle>Configurable Properties</CardTitle>
+            <CardDescription>All settings exposed in this playground</CardDescription>
           </CardHeader>
           <CardContent className="space-y-3 text-sm">
             <div>
-              <p className="font-medium mb-1">Card Styling</p>
+              <p className="font-medium mb-1">KPI Data</p>
               <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
-                <li><code className="text-xs">shadow-sm/md/lg/xl</code> - Elevation levels</li>
-                <li><code className="text-xs">border-primary</code> - Accent border color</li>
-                <li><code className="text-xs">overflow-hidden</code> - For image headers</li>
-                <li><code className="text-xs">hover:shadow-lg</code> - Interactive lift</li>
+                <li><strong>title</strong> - Metric name displayed in header</li>
+                <li><strong>value</strong> - The KPI number</li>
+                <li><strong>format</strong> - number / currency / percent / compact / custom</li>
+                <li><strong>prefix / suffix</strong> - Characters around the value ($, %, etc.)</li>
+                <li><strong>decimals</strong> - Decimal places (0-6)</li>
+                <li><strong>description</strong> - Context text below title</li>
               </ul>
             </div>
             <Separator />
             <div>
-              <p className="font-medium mb-1">Layout Variants</p>
+              <p className="font-medium mb-1">Trend Indicator</p>
               <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
-                <li><strong>Stats</strong> - KPI with icon + trend</li>
-                <li><strong>Profile</strong> - Avatar centered layout</li>
-                <li><strong>Pricing</strong> - Price + features list</li>
-                <li><strong>Media</strong> - Image header</li>
-                <li><strong>Notification</strong> - Avatar + message + actions</li>
+                <li><strong>direction</strong> - up (green) / down (red) / neutral (gray)</li>
+                <li><strong>value</strong> - Percentage change</li>
+                <li><strong>style</strong> - icon-text / arrow / badge</li>
+                <li><strong>comparison text</strong> - &quot;from last month&quot;, etc.</li>
+                <li><strong>color</strong> - Auto or custom hex color</li>
+              </ul>
+            </div>
+            <Separator />
+            <div>
+              <p className="font-medium mb-1">Icon</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
+                <li><strong>icon</strong> - Lucide icon selection</li>
+                <li><strong>position</strong> - Left or right of title</li>
+                <li><strong>style</strong> - Circle / square / plain background</li>
+                <li><strong>color + opacity</strong> - Icon and background tint</li>
+              </ul>
+            </div>
+            <Separator />
+            <div>
+              <p className="font-medium mb-1">Footer</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
+                <li><strong>text</strong> - Simple text like &quot;Updated just now&quot;</li>
+                <li><strong>progress</strong> - Bar with % and label</li>
+                <li><strong>sparkline</strong> - Mini trend line (SVG)</li>
+                <li><strong>comparison</strong> - Current vs previous values</li>
               </ul>
             </div>
           </CardContent>
@@ -639,30 +1125,106 @@ export function CardPlayground() {
 
         <Card>
           <CardHeader>
-            <CardTitle>🚫 Limitations</CardTitle>
-            <CardDescription>What Card cannot do</CardDescription>
+            <CardTitle>Card Styling</CardTitle>
+            <CardDescription>Visual customization via className and style</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <div>
+              <p className="font-medium mb-1">Shadow</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
+                <li><code className="text-xs">shadow-none</code> - Flat appearance</li>
+                <li><code className="text-xs">shadow-sm</code> - Subtle (default for KPI)</li>
+                <li><code className="text-xs">shadow-md / lg / xl</code> - Elevated appearance</li>
+              </ul>
+            </div>
+            <Separator />
+            <div>
+              <p className="font-medium mb-1">Border Accent</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
+                <li><code className="text-xs">borderLeftWidth: 4px</code> - Left color strip</li>
+                <li><code className="text-xs">borderTopWidth: 3px</code> - Top color strip</li>
+                <li>Color ties to the metric category or severity</li>
+              </ul>
+            </div>
+            <Separator />
+            <div>
+              <p className="font-medium mb-1">Interactive States</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
+                <li><code className="text-xs">hover:shadow-lg hover:-translate-y-0.5</code> - Lift effect</li>
+                <li><code className="text-xs">cursor-pointer transition-all</code> - Clickable appearance</li>
+                <li>Loading skeleton via Skeleton component</li>
+              </ul>
+            </div>
+            <Separator />
+            <div>
+              <p className="font-medium mb-1">Value Size Classes</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
+                <li><code className="text-xs">text-xl</code> (SM) - Compact dashboards</li>
+                <li><code className="text-xs">text-2xl</code> (MD) - Standard</li>
+                <li><code className="text-xs">text-3xl</code> (LG) - Default KPI</li>
+                <li><code className="text-xs">text-4xl</code> (XL) - Hero metrics</li>
+              </ul>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Badge Variants</CardTitle>
+            <CardDescription>All 10 built-in variants for status indicators</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <div className="flex flex-wrap gap-2">
+              {badgeVariants.map((bv) => (
+                <Badge key={bv} variant={bv}>{bv}</Badge>
+              ))}
+            </div>
+            <Separator />
+            <div className="space-y-2 text-muted-foreground">
+              <p><strong>default</strong> - Primary brand color, general purpose</p>
+              <p><strong>secondary</strong> - Subdued background, less emphasis</p>
+              <p><strong>destructive</strong> - Red, errors or critical alerts</p>
+              <p><strong>outline</strong> - Border only, minimal visual weight</p>
+              <p><strong>success</strong> - Green, positive status</p>
+              <p><strong>info</strong> - Blue, informational context</p>
+              <p><strong>warning</strong> - Yellow/amber, needs attention</p>
+              <p><strong>critical</strong> - Critical severity level</p>
+              <p><strong>danger</strong> - Red destructive variant</p>
+              <p><strong>neutral</strong> - Gray, inactive or default state</p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Limitations</CardTitle>
+            <CardDescription>What KPI cards cannot do out of the box</CardDescription>
           </CardHeader>
           <CardContent className="space-y-3 text-sm">
             <ul className="space-y-2 text-muted-foreground">
               <li className="flex gap-2">
-                <span className="text-destructive">✗</span>
-                <span><strong>No built-in variants</strong> - Style via className</span>
+                <span className="text-destructive">-</span>
+                <span><strong>No built-in chart integration</strong> - Sparklines require custom SVG or recharts</span>
               </li>
               <li className="flex gap-2">
-                <span className="text-destructive">✗</span>
-                <span><strong>No collapse/expand</strong> - Use Accordion or Collapsible</span>
+                <span className="text-destructive">-</span>
+                <span><strong>No data fetching</strong> - Values must be supplied from external state/API</span>
               </li>
               <li className="flex gap-2">
-                <span className="text-destructive">✗</span>
-                <span><strong>No drag & drop</strong> - Need dnd-kit integration</span>
+                <span className="text-destructive">-</span>
+                <span><strong>No real-time updates</strong> - Need polling, WebSocket, or SSE integration</span>
               </li>
               <li className="flex gap-2">
-                <span className="text-destructive">✗</span>
-                <span><strong>No built-in loading</strong> - Add Skeleton manually</span>
+                <span className="text-destructive">-</span>
+                <span><strong>No built-in drill-down</strong> - Use onClick + router for detail navigation</span>
               </li>
               <li className="flex gap-2">
-                <span className="text-destructive">✗</span>
-                <span><strong>No selection state</strong> - Implement via className/data-state</span>
+                <span className="text-destructive">-</span>
+                <span><strong>No responsive breakpoints</strong> - Card width is fixed, use grid for responsiveness</span>
+              </li>
+              <li className="flex gap-2">
+                <span className="text-destructive">-</span>
+                <span><strong>No animation on value change</strong> - Use framer-motion or CSS transitions</span>
               </li>
             </ul>
           </CardContent>
@@ -670,35 +1232,41 @@ export function CardPlayground() {
 
         <Card>
           <CardHeader>
-            <CardTitle>✅ Best Practices & Use Cases</CardTitle>
-            <CardDescription>When and how to use Card</CardDescription>
+            <CardTitle>Best Practices</CardTitle>
+            <CardDescription>When and how to use KPI cards</CardDescription>
           </CardHeader>
           <CardContent className="space-y-3 text-sm">
             <div>
               <p className="font-medium mb-1">Ideal For:</p>
               <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
-                <li>Dashboard widgets (stats, KPIs)</li>
-                <li>Content previews (blog posts, products)</li>
-                <li>Form containers</li>
-                <li>User profiles and settings</li>
+                <li>Executive / admin dashboards (top-of-page metrics)</li>
+                <li>SaaS analytics (MRR, MAU, churn, NPS)</li>
+                <li>E-commerce (orders, revenue, conversion)</li>
+                <li>System monitoring (uptime, latency, error rate)</li>
+                <li>Sales pipelines (deals, pipeline value, win rate)</li>
               </ul>
             </div>
             <Separator />
             <div>
-              <p className="font-medium mb-1">Avoid When:</p>
+              <p className="font-medium mb-1">Layout Tips:</p>
               <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
-                <li>Simple text content → Use prose styling</li>
-                <li>Modal content → Use Dialog</li>
-                <li>Navigation → Use specific nav components</li>
+                <li>Use 3-4 KPI cards in a row with equal widths</li>
+                <li>Pair with grid-cols-2 md:grid-cols-4 for responsive</li>
+                <li>Keep titles short (2-3 words max)</li>
+                <li>Always include trend direction for context</li>
+                <li>Use border accent to group by category</li>
               </ul>
             </div>
             <Separator />
             <div>
-              <p className="font-medium mb-1">Tips:</p>
+              <p className="font-medium mb-1">Design Guidelines:</p>
               <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
-                <li>Use consistent card widths in grids</li>
-                <li>Keep action buttons in CardFooter</li>
-                <li>Use Badge for status indicators in header</li>
+                <li>Value should be the largest / boldest element</li>
+                <li>Title should be text-sm font-medium (not default CardTitle size)</li>
+                <li>Use consistent icon style across all cards</li>
+                <li>Limit badge usage to 1 per card max</li>
+                <li>Choose one footer style and use it consistently</li>
+                <li>Use compact mode for dense dashboards (&gt;6 cards)</li>
               </ul>
             </div>
           </CardContent>

--- a/packages/demo/src/components/FunnelChartPlayground.tsx
+++ b/packages/demo/src/components/FunnelChartPlayground.tsx
@@ -17,6 +17,7 @@ import {
   TabsContent,
   TabsList,
   TabsTrigger,
+  Input,
   Select,
   SelectContent,
   SelectItem,
@@ -29,48 +30,295 @@ import {
   Cell,
   LabelList,
 } from 'recharts'
-import { getChartColors } from '@/lib/chart-colors'
+// colors managed via colorPalette constant
 
-// Sample funnel data - typical sales/conversion funnel
-const sampleData = [
-  { name: 'Visitors', value: 5000, fill: '' },
-  { name: 'Leads', value: 3500, fill: '' },
-  { name: 'Qualified', value: 2000, fill: '' },
-  { name: 'Proposals', value: 1200, fill: '' },
-  { name: 'Closed', value: 600, fill: '' },
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type LabelPosition = 'right' | 'left' | 'inside' | 'outside'
+type LabelContent = 'name' | 'value' | 'percent' | 'name-value' | 'name-percent' | 'value-percent'
+type LegendTypeOption = 'rect' | 'circle' | 'square' | 'diamond' | 'star' | 'triangle' | 'wye' | 'line' | 'none'
+
+interface FunnelDataSource {
+  name: string
+  data: { name: string; value: number }[]
+  nameKey: string
+  valueKey: string
+}
+
+interface StageConfig {
+  color?: string
+  hidden?: boolean
+}
+
+// ─── Data Sources ────────────────────────────────────────────────────────────
+
+const funnelDataSources: Record<string, FunnelDataSource> = {
+  salesPipeline: {
+    name: 'Sales Pipeline',
+    data: [
+      { name: 'Visitors', value: 5000 },
+      { name: 'Leads', value: 3500 },
+      { name: 'Qualified', value: 2000 },
+      { name: 'Proposals', value: 1200 },
+      { name: 'Closed', value: 600 },
+    ],
+    nameKey: 'name',
+    valueKey: 'value',
+  },
+  userOnboarding: {
+    name: 'User Onboarding',
+    data: [
+      { name: 'Sign Up Page', value: 12000 },
+      { name: 'Email Verified', value: 8400 },
+      { name: 'Profile Created', value: 6200 },
+      { name: 'First Action', value: 4100 },
+      { name: 'Subscribed', value: 2300 },
+      { name: 'Retained (30d)', value: 1100 },
+    ],
+    nameKey: 'name',
+    valueKey: 'value',
+  },
+  ecommerce: {
+    name: 'E-commerce Checkout',
+    data: [
+      { name: 'Product View', value: 25000 },
+      { name: 'Add to Cart', value: 8500 },
+      { name: 'Checkout Start', value: 5200 },
+      { name: 'Payment Info', value: 3800 },
+      { name: 'Order Placed', value: 2900 },
+    ],
+    nameKey: 'name',
+    valueKey: 'value',
+  },
+  recruitment: {
+    name: 'Recruitment Funnel',
+    data: [
+      { name: 'Applications', value: 500 },
+      { name: 'Screened', value: 200 },
+      { name: 'Interviewed', value: 80 },
+      { name: 'Offered', value: 25 },
+      { name: 'Hired', value: 15 },
+    ],
+    nameKey: 'name',
+    valueKey: 'value',
+  },
+}
+
+type DataSourceKey = keyof typeof funnelDataSources
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const colorPalette = [
+  '#4169e1', '#2db89a', '#d946ef', '#ef5350', '#d4c92a',
+  '#38bdf8', '#a57c52', '#7c3aed', '#9ca3af', '#93c5fd',
 ]
 
-const labelPositions = [
+const gradientPalettes: Record<string, { name: string; colors: string[] }> = {
+  blue: { name: 'Blue Gradient', colors: ['#1e40af', '#3b82f6', '#60a5fa', '#93c5fd', '#bfdbfe', '#dbeafe'] },
+  green: { name: 'Green Gradient', colors: ['#166534', '#22c55e', '#4ade80', '#86efac', '#bbf7d0', '#dcfce7'] },
+  warm: { name: 'Warm (Green→Red)', colors: ['#22c55e', '#84cc16', '#eab308', '#f97316', '#ef4444', '#dc2626'] },
+  cool: { name: 'Cool (Blue→Purple)', colors: ['#3b82f6', '#6366f1', '#8b5cf6', '#a855f7', '#d946ef', '#ec4899'] },
+  rainbow: { name: 'Rainbow', colors: ['#ef4444', '#f97316', '#eab308', '#22c55e', '#3b82f6', '#8b5cf6'] },
+}
+
+const labelPositionOptions: { value: LabelPosition; label: string }[] = [
   { value: 'right', label: 'Right' },
   { value: 'left', label: 'Left' },
   { value: 'inside', label: 'Inside' },
   { value: 'outside', label: 'Outside' },
 ]
 
+const labelContentOptions: { value: LabelContent; label: string }[] = [
+  { value: 'name', label: 'Name only' },
+  { value: 'value', label: 'Value only' },
+  { value: 'percent', label: 'Percent only' },
+  { value: 'name-value', label: 'Name: Value' },
+  { value: 'name-percent', label: 'Name (%)' },
+  { value: 'value-percent', label: 'Value (%)' },
+]
+
+const legendTypeOptions: { value: LegendTypeOption; label: string }[] = [
+  { value: 'rect', label: 'Rect' },
+  { value: 'circle', label: 'Circle' },
+  { value: 'square', label: 'Square' },
+  { value: 'diamond', label: 'Diamond' },
+  { value: 'star', label: 'Star' },
+  { value: 'triangle', label: 'Triangle' },
+  { value: 'line', label: 'Line' },
+  { value: 'none', label: 'None (hide)' },
+]
+
+const indicatorTypes = [
+  { value: 'dot', label: 'dot - Small square' },
+  { value: 'line', label: 'line - Vertical bar' },
+  { value: 'dashed', label: 'dashed - Dashed line' },
+]
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
 export function FunnelChartPlayground() {
-  const colors = getChartColors(5)
-  
-  // Add colors to data
-  const dataWithColors = sampleData.map((item, index) => ({
-    ...item,
-    fill: colors[index],
-  }))
+  // ── Data tab state ──────────────────────────────────────────────────────
+  const [dataSource, setDataSource] = React.useState<DataSourceKey>('salesPipeline')
+  const currentSource = funnelDataSources[dataSource]
+  const [stageConfigs, setStageConfigs] = React.useState<Record<string, StageConfig>>({})
+  const [colorMode, setColorMode] = React.useState<'palette' | 'gradient'>('palette')
+  const [gradientKey, setGradientKey] = React.useState<string>('warm')
 
-  // Chart settings state
-  const [showTooltip, setShowTooltip] = React.useState(true)
-  const [showLegend, setShowLegend] = React.useState(true)
-  const [showLabels, setShowLabels] = React.useState(true)
-  const [labelPosition, setLabelPosition] = React.useState<'right' | 'left' | 'inside' | 'outside'>('right')
-  const [isAnimationActive, setIsAnimationActive] = React.useState(true)
-  const [reversed, setReversed] = React.useState(false)
+  // Reset on data source change
+  React.useEffect(() => {
+    setStageConfigs({})
+  }, [dataSource])
 
-  const config = {
-    visitors: { label: 'Visitors', color: colors[0] },
-    leads: { label: 'Leads', color: colors[1] },
-    qualified: { label: 'Qualified', color: colors[2] },
-    proposals: { label: 'Proposals', color: colors[3] },
-    closed: { label: 'Closed', color: colors[4] },
+  const updateStageConfig = (stageName: string, key: string, value: unknown) => {
+    setStageConfigs((prev) => ({
+      ...prev,
+      [stageName]: { ...prev[stageName], [key]: value },
+    }))
   }
+
+  const getStageColor = (stageName: string, idx: number): string => {
+    const override = stageConfigs[stageName]?.color
+    if (override) return override
+    if (colorMode === 'gradient') {
+      const palette = gradientPalettes[gradientKey]?.colors ?? gradientPalettes.warm.colors
+      return palette[idx % palette.length]
+    }
+    return colorPalette[idx % colorPalette.length]
+  }
+
+  // ── Funnel tab state ────────────────────────────────────────────────────
+  const [reversed, setReversed] = React.useState(false)
+  const [lastShapeType, setLastShapeType] = React.useState<'triangle' | 'rectangle'>('triangle')
+  const [activeShape, setActiveShape] = React.useState(false)
+  const [stroke, setStroke] = React.useState('#fff')
+  const [strokeWidth, setStrokeWidth] = React.useState(1)
+  const [legendType, setLegendType] = React.useState<LegendTypeOption>('rect')
+  const [funnelWidth, setFunnelWidth] = React.useState<number | undefined>(undefined)
+
+  // Labels
+  const [showLabels, setShowLabels] = React.useState(true)
+  const [labelPosition, setLabelPosition] = React.useState<LabelPosition>('right')
+  const [labelContent, setLabelContent] = React.useState<LabelContent>('name')
+  const [labelFill, setLabelFill] = React.useState('currentColor')
+  const [showValueLabels, setShowValueLabels] = React.useState(false)
+  const [valuePosition, setValuePosition] = React.useState<LabelPosition>('inside')
+
+  // Animation
+  const [isAnimationActive, setIsAnimationActive] = React.useState(true)
+  const [animationDuration, setAnimationDuration] = React.useState(1500)
+  const [animationBegin, setAnimationBegin] = React.useState(400)
+  const [animationEasing, setAnimationEasing] = React.useState<'ease' | 'ease-in' | 'ease-out' | 'ease-in-out' | 'linear'>('ease')
+
+  // ── Chart tab state ─────────────────────────────────────────────────────
+  const [showTooltip, setShowTooltip] = React.useState(true)
+  const [tooltipIndicator, setTooltipIndicator] = React.useState<'dot' | 'line' | 'dashed'>('dot')
+  const [showLegend, setShowLegend] = React.useState(true)
+  const [legendPos, setLegendPos] = React.useState<'top' | 'bottom'>('bottom')
+  const [margin, setMargin] = React.useState({ top: 20, right: 80, bottom: 20, left: 20 })
+
+  // ── Derived ─────────────────────────────────────────────────────────────
+
+  const visibleData = React.useMemo(() => {
+    return currentSource.data.filter((item) => !stageConfigs[item.name]?.hidden)
+  }, [currentSource.data, stageConfigs])
+
+  const totalValue = visibleData.length > 0 ? visibleData[0].value : 1
+
+  const dataWithColors = React.useMemo(() => {
+    return visibleData.map((item, idx) => ({
+      ...item,
+      fill: getStageColor(item.name, idx),
+    }))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visibleData, stageConfigs, colorMode, gradientKey])
+
+  const config = React.useMemo(() => {
+    const cfg: Record<string, { label: string; color: string }> = {}
+    dataWithColors.forEach((item) => {
+      const key = item.name.toLowerCase().replace(/[^a-z0-9]/g, '')
+      cfg[key] = { label: item.name, color: item.fill }
+    })
+    return cfg
+  }, [dataWithColors])
+
+  // Label formatter
+  const formatLabel = React.useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (entry: any) => {
+      const name = entry?.name ?? entry?.payload?.name ?? ''
+      const value = entry?.value ?? entry?.payload?.value ?? 0
+      const pct = totalValue > 0 ? `${((value / totalValue) * 100).toFixed(1)}%` : '0%'
+      switch (labelContent) {
+        case 'name': return name
+        case 'value': return String(value.toLocaleString())
+        case 'percent': return pct
+        case 'name-value': return `${name}: ${value.toLocaleString()}`
+        case 'name-percent': return `${name} (${pct})`
+        case 'value-percent': return `${value.toLocaleString()} (${pct})`
+        default: return name
+      }
+    },
+    [labelContent, totalValue],
+  )
+
+  // ── Code generation ─────────────────────────────────────────────────────
+
+  const generateCode = () => {
+    const lines: string[] = []
+    lines.push(`<ChartContainer config={config} className="h-[400px]">`)
+
+    const chartProps: string[] = []
+    if (margin.top !== 20 || margin.right !== 80 || margin.bottom !== 20 || margin.left !== 20) {
+      chartProps.push(`margin={{ top: ${margin.top}, right: ${margin.right}, bottom: ${margin.bottom}, left: ${margin.left} }}`)
+    }
+    lines.push(`  <FunnelChart${chartProps.length ? ' ' + chartProps.join(' ') : ''}>`)
+
+    const fp: string[] = ['dataKey="value"', 'data={dataWithColors}']
+    if (reversed) fp.push('reversed')
+    if (lastShapeType !== 'triangle') fp.push(`lastShapeType="${lastShapeType}"`)
+    if (activeShape) fp.push('activeShape={{ fill: "hsl(var(--primary))", opacity: 0.8 }}')
+    if (stroke !== '#fff') fp.push(`stroke="${stroke}"`)
+    if (strokeWidth !== 1) fp.push(`strokeWidth={${strokeWidth}}`)
+    if (legendType !== 'rect') fp.push(`legendType="${legendType}"`)
+    if (funnelWidth) fp.push(`width={${funnelWidth}}`)
+    if (!isAnimationActive) fp.push('isAnimationActive={false}')
+    if (animationBegin !== 400) fp.push(`animationBegin={${animationBegin}}`)
+    if (animationDuration !== 1500) fp.push(`animationDuration={${animationDuration}}`)
+    if (animationEasing !== 'ease') fp.push(`animationEasing="${animationEasing}"`)
+
+    lines.push(`    <Funnel ${fp.join(' ')}>`)
+
+    if (showLabels) {
+      const lp: string[] = [`position="${labelPosition}"`]
+      lp.push('dataKey="name"')
+      if (labelFill !== 'currentColor') lp.push(`fill="${labelFill}"`)
+      if (labelContent !== 'name') lp.push(`formatter={formatLabel}`)
+      lp.push('stroke="none"')
+      lines.push(`      <LabelList ${lp.join(' ')} />`)
+    }
+    if (showValueLabels) {
+      lines.push(`      <LabelList position="${valuePosition}" dataKey="value" fill="${labelFill}" stroke="none" />`)
+    }
+
+    lines.push(`      {data.map((entry, index) => (`)
+    lines.push(`        <Cell key={index} fill={entry.fill} />`)
+    lines.push(`      ))}`)
+    lines.push(`    </Funnel>`)
+
+    if (showTooltip) {
+      lines.push(`    <ChartTooltip content={<ChartTooltipContent indicator="${tooltipIndicator}" />} />`)
+    }
+    if (showLegend) {
+      const lp = legendPos !== 'bottom' ? ` verticalAlign="${legendPos}"` : ''
+      lines.push(`    <ChartLegend content={<ChartLegendContent />}${lp} />`)
+    }
+
+    lines.push(`  </FunnelChart>`)
+    lines.push(`</ChartContainer>`)
+    return lines.join('\n')
+  }
+
+  // ── Render ──────────────────────────────────────────────────────────────
 
   return (
     <div className="space-y-6 p-6">
@@ -82,7 +330,7 @@ export function FunnelChartPlayground() {
       </div>
 
       <div className="grid gap-6 lg:grid-cols-[1fr_350px]">
-        {/* Chart Preview */}
+        {/* ── Live Preview ───────────────────────────────────────────── */}
         <Card>
           <CardHeader>
             <CardTitle>Live Preview</CardTitle>
@@ -90,18 +338,38 @@ export function FunnelChartPlayground() {
           </CardHeader>
           <CardContent>
             <ChartContainer config={config} className="h-[400px] w-full">
-              <FunnelChart>
+              <FunnelChart margin={margin}>
                 <Funnel
                   dataKey="value"
                   data={dataWithColors}
                   isAnimationActive={isAnimationActive}
+                  animationBegin={animationBegin}
+                  animationDuration={animationDuration}
+                  animationEasing={animationEasing}
                   reversed={reversed}
+                  lastShapeType={lastShapeType}
+                  activeShape={activeShape ? { fill: 'hsl(var(--primary))', opacity: 0.8 } : undefined}
+                  stroke={stroke}
+                  strokeWidth={strokeWidth}
+                  legendType={legendType}
+                  width={funnelWidth}
                 >
                   {showLabels && (
                     <LabelList
-                      position={labelPosition as 'right' | 'left' | 'inside' | 'outside'}
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      position={labelPosition as any}
                       dataKey="name"
-                      fill="#000"
+                      fill={labelFill}
+                      stroke="none"
+                      formatter={labelContent !== 'name' ? formatLabel : undefined}
+                    />
+                  )}
+                  {showValueLabels && (
+                    <LabelList
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      position={valuePosition as any}
+                      dataKey="value"
+                      fill={labelFill}
                       stroke="none"
                     />
                   )}
@@ -110,63 +378,312 @@ export function FunnelChartPlayground() {
                   ))}
                 </Funnel>
                 {showTooltip && (
-                  <ChartTooltip content={(props) => <ChartTooltipContent {...props} />} />
+                  <ChartTooltip
+                    content={(props) => <ChartTooltipContent {...props} indicator={tooltipIndicator} />}
+                  />
                 )}
-                {showLegend && (
-                  <ChartLegend content={<ChartLegendContent />} />
-                )}
+                {showLegend && <ChartLegend content={<ChartLegendContent />} verticalAlign={legendPos} />}
               </FunnelChart>
             </ChartContainer>
           </CardContent>
         </Card>
 
-        {/* Settings Panel */}
+        {/* ── Settings Panel ─────────────────────────────────────────── */}
         <Card>
           <CardHeader>
             <CardTitle>Settings</CardTitle>
             <CardDescription>Toggle to see what each setting does</CardDescription>
           </CardHeader>
           <CardContent>
-            <Tabs defaultValue="display" className="w-full">
-              <TabsList className="grid w-full grid-cols-2">
-                <TabsTrigger value="display">Display</TabsTrigger>
+            <Tabs defaultValue="data" className="w-full">
+              <TabsList className="grid w-full grid-cols-4">
                 <TabsTrigger value="data">Data</TabsTrigger>
+                <TabsTrigger value="funnel">Funnel</TabsTrigger>
+                <TabsTrigger value="chart">Chart</TabsTrigger>
+                <TabsTrigger value="stages">Stages</TabsTrigger>
               </TabsList>
 
-              <TabsContent value="display" className="space-y-4 pt-4">
+              {/* ─── Tab: Data ──────────────────────────────────────── */}
+              <TabsContent value="data" className="space-y-4 pt-4">
+                <div className="space-y-2">
+                  <Label className="text-sm font-medium">Data Source</Label>
+                  <Select value={dataSource} onValueChange={(v) => setDataSource(v as DataSourceKey)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Object.entries(funnelDataSources).map(([key, src]) => (
+                        <SelectItem key={key} value={key}>{src.name}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <Separator />
+
+                <div className="space-y-2">
+                  <Label className="text-sm font-medium">Color Mode</Label>
+                  <div className="flex gap-2">
+                    <button
+                      className={`px-3 py-1 text-sm rounded ${colorMode === 'palette' ? 'bg-primary text-primary-foreground' : 'bg-muted'}`}
+                      onClick={() => setColorMode('palette')}
+                    >
+                      Individual
+                    </button>
+                    <button
+                      className={`px-3 py-1 text-sm rounded ${colorMode === 'gradient' ? 'bg-primary text-primary-foreground' : 'bg-muted'}`}
+                      onClick={() => setColorMode('gradient')}
+                    >
+                      Gradient
+                    </button>
+                  </div>
+                </div>
+
+                {colorMode === 'gradient' && (
+                  <div className="space-y-2">
+                    <Label className="text-sm">Gradient Palette</Label>
+                    <Select value={gradientKey} onValueChange={setGradientKey}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Object.entries(gradientPalettes).map(([key, pal]) => (
+                          <SelectItem key={key} value={key}>
+                            <div className="flex items-center gap-2">
+                              <div className="flex">
+                                {pal.colors.slice(0, 5).map((c, i) => (
+                                  <span key={i} className="h-4 w-3" style={{ backgroundColor: c }} />
+                                ))}
+                              </div>
+                              <span>{pal.name}</span>
+                            </div>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+
+                <Separator />
+
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground">Funnel Stages ({visibleData.length} of {currentSource.data.length})</p>
+                  {currentSource.data.map((item, idx) => {
+                    const hidden = stageConfigs[item.name]?.hidden
+                    const color = getStageColor(item.name, idx)
+                    const pct = totalValue > 0 ? ((item.value / totalValue) * 100).toFixed(1) : '0'
+                    return (
+                      <div
+                        key={item.name}
+                        className={`flex items-center justify-between rounded-lg border p-2 transition ${hidden ? 'opacity-40' : ''}`}
+                        style={{ borderLeftColor: hidden ? '#9ca3af' : color, borderLeftWidth: 4 }}
+                      >
+                        <button
+                          className="flex items-center gap-2 text-left"
+                          onClick={() => updateStageConfig(item.name, 'hidden', !hidden)}
+                        >
+                          <span className="text-sm font-medium">{item.name}</span>
+                        </button>
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                          <span>{item.value.toLocaleString()}</span>
+                          <span className="text-xs">({pct}%)</span>
+                        </div>
+                      </div>
+                    )
+                  })}
+                  <p className="text-xs text-muted-foreground">Click a stage to hide/show it</p>
+                </div>
+
+                <Separator />
+
+                {/* Conversion rates */}
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground">Conversion Rates</p>
+                  {visibleData.map((item, idx) => {
+                    if (idx === 0) return null
+                    const prev = visibleData[idx - 1]
+                    const rate = prev.value > 0 ? ((item.value / prev.value) * 100).toFixed(1) : '0'
+                    return (
+                      <div key={item.name} className="flex items-center justify-between text-sm">
+                        <span className="text-muted-foreground">{prev.name} → {item.name}</span>
+                        <span className="font-medium">{rate}%</span>
+                      </div>
+                    )
+                  })}
+                  {visibleData.length > 1 && (
+                    <div className="flex items-center justify-between text-sm border-t pt-1">
+                      <span className="font-medium">Overall</span>
+                      <span className="font-medium">
+                        {totalValue > 0
+                          ? ((visibleData[visibleData.length - 1].value / totalValue) * 100).toFixed(1)
+                          : '0'}%
+                      </span>
+                    </div>
+                  )}
+                </div>
+              </TabsContent>
+
+              {/* ─── Tab: Funnel ────────────────────────────────────── */}
+              <TabsContent value="funnel" className="space-y-4 pt-4">
                 {/* Reversed */}
                 <div className="flex items-center justify-between">
                   <div>
                     <Label className="text-sm font-medium">Reversed</Label>
-                    <p className="text-xs text-muted-foreground">Flip funnel direction</p>
+                    <p className="text-xs text-muted-foreground">Flip to pyramid (smallest at top)</p>
                   </div>
                   <Switch checked={reversed} onCheckedChange={setReversed} />
                 </div>
 
                 <Separator />
 
-                {/* Show Labels */}
+                {/* Last Shape */}
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Label className="text-sm font-medium">Last Shape</Label>
+                    <p className="text-xs text-muted-foreground">Bottom segment shape</p>
+                  </div>
+                  <Select value={lastShapeType} onValueChange={(v) => setLastShapeType(v as 'triangle' | 'rectangle')}>
+                    <SelectTrigger className="w-28 h-8">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="triangle">Triangle</SelectItem>
+                      <SelectItem value="rectangle">Rectangle</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <Separator />
+
+                {/* Active Shape */}
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Label className="text-sm font-medium">Active Shape</Label>
+                    <p className="text-xs text-muted-foreground">Highlight on hover</p>
+                  </div>
+                  <Switch checked={activeShape} onCheckedChange={setActiveShape} />
+                </div>
+
+                <Separator />
+
+                {/* Stroke */}
+                <div className="space-y-2">
+                  <Label className="text-sm font-medium">Stroke (border)</Label>
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="color"
+                      value={stroke}
+                      onChange={(e) => setStroke(e.target.value)}
+                      className="h-6 w-8 cursor-pointer rounded border-0 bg-transparent p-0"
+                    />
+                    <Input type="text" value={stroke} onChange={(e) => setStroke(e.target.value)} className="flex-1 h-8" />
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-muted-foreground">Width</span>
+                    <Input type="number" value={strokeWidth} onChange={(e) => setStrokeWidth(Number(e.target.value) || 0)} min={0} max={5} className="w-20 h-8" />
+                  </div>
+                </div>
+
+                <Separator />
+
+                {/* Funnel Width */}
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Label className="text-sm font-medium">Fixed Width</Label>
+                    <p className="text-xs text-muted-foreground">Override auto width (px)</p>
+                  </div>
+                  <Input type="number" value={funnelWidth ?? ''} onChange={(e) => setFunnelWidth(e.target.value ? Number(e.target.value) : undefined)} placeholder="auto" min={50} max={500} className="w-20 h-8" />
+                </div>
+
+                <Separator />
+
+                {/* Legend Type */}
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Label className="text-sm font-medium">Legend Icon</Label>
+                    <p className="text-xs text-muted-foreground">Shape in legend</p>
+                  </div>
+                  <Select value={legendType} onValueChange={(v) => setLegendType(v as LegendTypeOption)}>
+                    <SelectTrigger className="w-24 h-8">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {legendTypeOptions.map((o) => (
+                        <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <Separator />
+
+                {/* Labels */}
                 <div className="flex items-center justify-between">
                   <div>
                     <Label className="text-sm font-medium">Show Labels</Label>
-                    <p className="text-xs text-muted-foreground">Stage names</p>
+                    <p className="text-xs text-muted-foreground">{'<LabelList />'} stage names</p>
                   </div>
                   <Switch checked={showLabels} onCheckedChange={setShowLabels} />
                 </div>
-
-                {/* Label Position */}
                 {showLabels && (
-                  <div className="space-y-2">
-                    <Label className="text-sm font-medium">Label Position</Label>
-                    <Select value={labelPosition} onValueChange={(v) => setLabelPosition(v as 'right' | 'left' | 'inside' | 'outside')}>
-                      <SelectTrigger>
+                  <>
+                    <div className="flex items-center justify-between pl-4">
+                      <span className="text-sm">Position</span>
+                      <Select value={labelPosition} onValueChange={(v) => setLabelPosition(v as LabelPosition)}>
+                        <SelectTrigger className="w-24 h-8">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {labelPositionOptions.map((o) => (
+                            <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="flex items-center justify-between pl-4">
+                      <span className="text-sm">Content</span>
+                      <Select value={labelContent} onValueChange={(v) => setLabelContent(v as LabelContent)}>
+                        <SelectTrigger className="w-32 h-8">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {labelContentOptions.map((o) => (
+                            <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-1 pl-4">
+                      <span className="text-sm">Fill Color</span>
+                      <div className="flex items-center gap-2">
+                        <input type="color" value={labelFill === 'currentColor' ? '#000000' : labelFill} onChange={(e) => setLabelFill(e.target.value)} className="h-6 w-8 cursor-pointer rounded border-0 p-0" />
+                        <Input type="text" value={labelFill} onChange={(e) => setLabelFill(e.target.value)} className="flex-1 h-8" />
+                        <button className="text-xs text-primary hover:underline" onClick={() => setLabelFill('currentColor')}>Auto</button>
+                      </div>
+                    </div>
+                  </>
+                )}
+
+                <Separator />
+
+                {/* Value Labels (secondary) */}
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Label className="text-sm font-medium">Value Labels</Label>
+                    <p className="text-xs text-muted-foreground">Second label with numeric values</p>
+                  </div>
+                  <Switch checked={showValueLabels} onCheckedChange={setShowValueLabels} />
+                </div>
+                {showValueLabels && (
+                  <div className="flex items-center justify-between pl-4">
+                    <span className="text-sm">Position</span>
+                    <Select value={valuePosition} onValueChange={(v) => setValuePosition(v as LabelPosition)}>
+                      <SelectTrigger className="w-24 h-8">
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        {labelPositions.map((pos) => (
-                          <SelectItem key={pos.value} value={pos.value}>
-                            {pos.label}
-                          </SelectItem>
+                        {labelPositionOptions.map((o) => (
+                          <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
                         ))}
                       </SelectContent>
                     </Select>
@@ -183,17 +700,58 @@ export function FunnelChartPlayground() {
                   </div>
                   <Switch checked={isAnimationActive} onCheckedChange={setIsAnimationActive} />
                 </div>
+                {isAnimationActive && (
+                  <>
+                    <div className="flex items-center justify-between pl-4">
+                      <span className="text-sm">Delay (ms)</span>
+                      <Input type="number" value={animationBegin} onChange={(e) => setAnimationBegin(Math.max(0, Number(e.target.value) || 0))} min={0} max={5000} className="w-24 h-8" />
+                    </div>
+                    <div className="flex items-center justify-between pl-4">
+                      <span className="text-sm">Duration (ms)</span>
+                      <Input type="number" value={animationDuration} onChange={(e) => setAnimationDuration(Number(e.target.value) || 1500)} min={0} max={5000} className="w-24 h-8" />
+                    </div>
+                    <div className="flex items-center justify-between pl-4">
+                      <span className="text-sm">Easing</span>
+                      <Select value={animationEasing} onValueChange={(v) => setAnimationEasing(v as typeof animationEasing)}>
+                        <SelectTrigger className="w-32 h-8">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {['ease', 'ease-in', 'ease-out', 'ease-in-out', 'linear'].map((e) => (
+                            <SelectItem key={e} value={e}>{e}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </>
+                )}
+              </TabsContent>
 
-                <Separator />
-
+              {/* ─── Tab: Chart ─────────────────────────────────────── */}
+              <TabsContent value="chart" className="space-y-4 pt-4">
                 {/* Tooltip */}
                 <div className="flex items-center justify-between">
                   <div>
                     <Label className="text-sm font-medium">Show Tooltip</Label>
-                    <p className="text-xs text-muted-foreground">Hover for details</p>
+                    <p className="text-xs text-muted-foreground">{'<ChartTooltip />'}</p>
                   </div>
                   <Switch checked={showTooltip} onCheckedChange={setShowTooltip} />
                 </div>
+                {showTooltip && (
+                  <div className="space-y-2 pl-4">
+                    <Label className="text-sm">Indicator</Label>
+                    <Select value={tooltipIndicator} onValueChange={(v) => setTooltipIndicator(v as 'dot' | 'line' | 'dashed')}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {indicatorTypes.map((t) => (
+                          <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
 
                 <Separator />
 
@@ -201,61 +759,218 @@ export function FunnelChartPlayground() {
                 <div className="flex items-center justify-between">
                   <div>
                     <Label className="text-sm font-medium">Show Legend</Label>
-                    <p className="text-xs text-muted-foreground">Stage color legend</p>
+                    <p className="text-xs text-muted-foreground">{'<ChartLegend />'}</p>
                   </div>
                   <Switch checked={showLegend} onCheckedChange={setShowLegend} />
                 </div>
+                {showLegend && (
+                  <div className="flex items-center justify-between pl-4">
+                    <span className="text-sm">Position</span>
+                    <Select value={legendPos} onValueChange={(v) => setLegendPos(v as 'top' | 'bottom')}>
+                      <SelectTrigger className="w-24 h-8">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="bottom">Bottom</SelectItem>
+                        <SelectItem value="top">Top</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+
+                <Separator />
+
+                {/* Margins */}
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <Label className="text-sm font-medium">Margins</Label>
+                    <button className="text-xs text-primary hover:underline" onClick={() => setMargin({ top: 20, right: 80, bottom: 20, left: 20 })}>Reset</button>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    {(['top', 'right', 'bottom', 'left'] as const).map((side) => (
+                      <div key={side} className="flex items-center gap-2">
+                        <span className="w-12 text-xs text-muted-foreground capitalize">{side}</span>
+                        <Input type="number" value={margin[side]} onChange={(e) => setMargin((p) => ({ ...p, [side]: Number(e.target.value) || 0 }))} className="h-8" />
+                      </div>
+                    ))}
+                  </div>
+                  <p className="text-xs text-muted-foreground">Right margin needs space for labels when position is &quot;right&quot;</p>
+                </div>
               </TabsContent>
 
-              <TabsContent value="data" className="space-y-4 pt-4">
-                <div className="space-y-2">
-                  <p className="text-xs font-medium text-muted-foreground">Funnel Stages</p>
-                  {dataWithColors.map((item) => (
-                    <div 
-                      key={item.name} 
-                      className="flex items-center justify-between rounded-lg border p-3"
-                      style={{ borderLeftColor: item.fill, borderLeftWidth: 4 }}
+              {/* ─── Tab: Stages ────────────────────────────────────── */}
+              <TabsContent value="stages" className="space-y-4 pt-4">
+                <p className="text-xs text-muted-foreground">Customize individual stage colors. Click a color swatch or use the picker.</p>
+                {currentSource.data.map((item, idx) => {
+                  const hidden = stageConfigs[item.name]?.hidden
+                  const color = getStageColor(item.name, idx)
+                  const pct = totalValue > 0 ? ((item.value / totalValue) * 100).toFixed(1) : '0'
+                  return (
+                    <div
+                      key={item.name}
+                      className={`space-y-2 rounded-lg border p-3 ${hidden ? 'opacity-40' : ''}`}
+                      style={{ borderLeftColor: hidden ? '#9ca3af' : color, borderLeftWidth: 4 }}
                     >
-                      <span className="text-sm font-medium">{item.name}</span>
-                      <span className="text-sm text-muted-foreground">
-                        {item.value.toLocaleString()}
-                      </span>
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <Label className="text-sm font-medium">{item.name}</Label>
+                          <p className="text-xs text-muted-foreground">{item.value.toLocaleString()} ({pct}%)</p>
+                        </div>
+                        <Switch checked={!hidden} onCheckedChange={(v) => updateStageConfig(item.name, 'hidden', !v)} />
+                      </div>
+
+                      {!hidden && (
+                        <div className="space-y-1">
+                          <div className="flex items-center justify-between">
+                            <span className="text-xs text-muted-foreground">Color</span>
+                            <input
+                              type="color"
+                              value={color}
+                              onChange={(e) => updateStageConfig(item.name, 'color', e.target.value)}
+                              className="h-6 w-8 cursor-pointer rounded border-0 bg-transparent p-0"
+                            />
+                          </div>
+                          <div className="flex flex-wrap gap-1">
+                            {(colorMode === 'gradient' ? (gradientPalettes[gradientKey]?.colors ?? []) : colorPalette).map((c) => (
+                              <button
+                                key={c}
+                                className={`h-5 w-5 rounded-full border-2 transition-transform hover:scale-110 ${color === c ? 'border-foreground scale-110' : 'border-transparent'}`}
+                                style={{ backgroundColor: c }}
+                                onClick={() => updateStageConfig(item.name, 'color', c)}
+                              />
+                            ))}
+                          </div>
+                          <button
+                            className="text-xs text-primary hover:underline"
+                            onClick={() => updateStageConfig(item.name, 'color', undefined)}
+                          >
+                            Reset to default
+                          </button>
+                        </div>
+                      )}
                     </div>
-                  ))}
-                </div>
+                  )
+                })}
               </TabsContent>
             </Tabs>
           </CardContent>
         </Card>
+      </div>
 
-        {/* Documentation Section */}
+      {/* ── Generated Code ─────────────────────────────────────────────── */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Generated Code</CardTitle>
+          <CardDescription>Copy this code to use your current configuration</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <pre className="overflow-x-auto rounded-lg bg-muted p-4 text-sm">
+            <code>{generateCode()}</code>
+          </pre>
+        </CardContent>
+      </Card>
+
+      {/* ── Raw Data Preview ───────────────────────────────────────────── */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Raw Data</CardTitle>
+          <CardDescription>
+            {currentSource.name} — {visibleData.length} stages, overall conversion {totalValue > 0 ? ((visibleData[visibleData.length - 1]?.value ?? 0) / totalValue * 100).toFixed(1) : '0'}%
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <pre className="overflow-x-auto rounded-lg bg-muted p-4 text-sm max-h-64">
+            <code>{JSON.stringify(dataWithColors, null, 2)}</code>
+          </pre>
+        </CardContent>
+      </Card>
+
+      {/* ── Documentation ──────────────────────────────────────────────── */}
+      <div className="grid gap-6 lg:grid-cols-2">
         <Card>
           <CardHeader>
-            <CardTitle>⚙️ Configurable Properties</CardTitle>
+            <CardTitle>Data Format</CardTitle>
+            <CardDescription>Required data structure for FunnelChart</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <pre className="overflow-x-auto rounded-lg bg-muted p-4 text-sm">
+              <code>{`// Array of stages, sorted largest → smallest
+const data = [
+  { name: 'Visitors',  value: 5000, fill: '#4169e1' },
+  { name: 'Leads',     value: 3500, fill: '#2db89a' },
+  { name: 'Qualified', value: 2000, fill: '#d946ef' },
+  { name: 'Proposals', value: 1200, fill: '#ef5350' },
+  { name: 'Closed',    value: 600,  fill: '#d4c92a' },
+]
+
+// ChartConfig for tooltips & legend
+const config: ChartConfig = {
+  visitors:  { label: "Visitors",  color: "#4169e1" },
+  leads:     { label: "Leads",     color: "#2db89a" },
+  qualified: { label: "Qualified", color: "#d946ef" },
+}`}</code>
+            </pre>
+            <div className="space-y-2 text-sm">
+              <p className="font-medium">Requirements:</p>
+              <ul className="list-disc list-inside space-y-1 text-muted-foreground">
+                <li><strong>name</strong> - Stage label (used by nameKey, default &quot;name&quot;)</li>
+                <li><strong>value</strong> - Numeric size (used by dataKey)</li>
+                <li><strong>fill</strong> - Color per stage (via Cell components)</li>
+                <li><strong>Sorted order</strong> - Largest value first (or use reversed)</li>
+                <li><strong>3-7 stages</strong> - Ideal range for readability</li>
+              </ul>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Configurable Properties</CardTitle>
             <CardDescription>What you can customize</CardDescription>
           </CardHeader>
           <CardContent className="space-y-3 text-sm">
             <div>
               <p className="font-medium mb-1">Funnel Component</p>
               <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
-                <li><code className="text-xs">dataKey</code> - Field for stage size (&quot;value&quot;)</li>
-                <li><code className="text-xs">reversed</code> - Flip to pyramid (smallest at bottom)</li>
-                <li><code className="text-xs">isAnimationActive</code> - Enable/disable animation</li>
+                <li><code className="text-xs">dataKey</code> - Field for stage size</li>
+                <li><code className="text-xs">nameKey</code> - Field for stage name (default &quot;name&quot;)</li>
+                <li><code className="text-xs">reversed</code> - Flip to pyramid shape</li>
+                <li><code className="text-xs">lastShapeType</code> - triangle or rectangle for bottom</li>
+                <li><code className="text-xs">activeShape</code> - Hover highlight effect</li>
+                <li><code className="text-xs">stroke / strokeWidth</code> - Border between stages</li>
+                <li><code className="text-xs">width</code> - Fixed width override</li>
+                <li><code className="text-xs">legendType</code> - Icon shape in legend</li>
+                <li><code className="text-xs">hide</code> - Hide without removing data</li>
               </ul>
             </div>
             <Separator />
             <div>
               <p className="font-medium mb-1">Labels</p>
               <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
-                <li><code className="text-xs">LabelList</code> - Show stage names</li>
+                <li><code className="text-xs">LabelList</code> - Stage names / values / percentages</li>
                 <li><code className="text-xs">position</code> - right, left, inside, outside</li>
+                <li><code className="text-xs">formatter</code> - Custom label content function</li>
+                <li><code className="text-xs">fill / stroke</code> - Label text styling</li>
+                <li>Multiple LabelLists supported (name + value)</li>
+              </ul>
+            </div>
+            <Separator />
+            <div>
+              <p className="font-medium mb-1">Animation</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
+                <li><code className="text-xs">isAnimationActive</code> - Enable/disable</li>
+                <li><code className="text-xs">animationBegin</code> - Delay in ms (default 400)</li>
+                <li><code className="text-xs">animationDuration</code> - Duration in ms (default 1500)</li>
+                <li><code className="text-xs">animationEasing</code> - Timing function</li>
               </ul>
             </div>
             <Separator />
             <div>
               <p className="font-medium mb-1">Styling</p>
               <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
-                <li><code className="text-xs">Cell</code> - Individual colors per stage</li>
+                <li><code className="text-xs">Cell</code> - Individual fill color per stage</li>
+                <li><code className="text-xs">shape</code> - Custom trapezoid renderer</li>
+                <li>Gradient palettes for sequential color schemes</li>
               </ul>
             </div>
           </CardContent>
@@ -263,30 +978,34 @@ export function FunnelChartPlayground() {
 
         <Card>
           <CardHeader>
-            <CardTitle>🚫 Limitations</CardTitle>
+            <CardTitle>Limitations</CardTitle>
             <CardDescription>What FunnelChart cannot do</CardDescription>
           </CardHeader>
           <CardContent className="space-y-3 text-sm">
             <ul className="space-y-2 text-muted-foreground">
               <li className="flex gap-2">
-                <span className="text-destructive">✗</span>
+                <span className="text-destructive">-</span>
                 <span><strong>Max 6-7 stages</strong> - More becomes hard to read</span>
               </li>
               <li className="flex gap-2">
-                <span className="text-destructive">✗</span>
-                <span><strong>No branching</strong> - Linear stages only</span>
+                <span className="text-destructive">-</span>
+                <span><strong>No branching</strong> - Linear sequential stages only</span>
               </li>
               <li className="flex gap-2">
-                <span className="text-destructive">✗</span>
-                <span><strong>No time dimension</strong> - Single snapshot</span>
+                <span className="text-destructive">-</span>
+                <span><strong>No time dimension</strong> - Single snapshot, not over time</span>
               </li>
               <li className="flex gap-2">
-                <span className="text-destructive">✗</span>
-                <span><strong>Poor for comparison</strong> - Hard to compare two funnels</span>
+                <span className="text-destructive">-</span>
+                <span><strong>Poor for comparison</strong> - Hard to compare two funnels side-by-side</span>
               </li>
               <li className="flex gap-2">
-                <span className="text-destructive">✗</span>
-                <span><strong>No conversion rate display</strong> - Need custom labels</span>
+                <span className="text-destructive">-</span>
+                <span><strong>No built-in conversion rates</strong> - Need custom label formatters</span>
+              </li>
+              <li className="flex gap-2">
+                <span className="text-destructive">-</span>
+                <span><strong>Area distortion</strong> - Width implies volume but height is uniform</span>
               </li>
             </ul>
           </CardContent>
@@ -294,7 +1013,7 @@ export function FunnelChartPlayground() {
 
         <Card>
           <CardHeader>
-            <CardTitle>✅ Best Practices & Use Cases</CardTitle>
+            <CardTitle>Best Practices & Use Cases</CardTitle>
             <CardDescription>When and how to use FunnelChart</CardDescription>
           </CardHeader>
           <CardContent className="space-y-3 text-sm">
@@ -302,32 +1021,114 @@ export function FunnelChartPlayground() {
               <p className="font-medium mb-1">Ideal For:</p>
               <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
                 <li>Sales pipeline visualization</li>
-                <li>User onboarding drop-off</li>
-                <li>Conversion tracking</li>
-                <li>Process stage analysis</li>
+                <li>User onboarding / activation flow</li>
+                <li>E-commerce checkout conversion</li>
+                <li>Recruitment / hiring pipeline</li>
+                <li>Marketing conversion (impressions → clicks → leads)</li>
               </ul>
             </div>
             <Separator />
             <div>
               <p className="font-medium mb-1">Avoid When:</p>
               <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
-                <li>Comparing values → Use BarChart</li>
-                <li>Time series → Use LineChart</li>
-                <li>Non-sequential process → Use Sankey</li>
+                <li>Comparing independent values - Use BarChart</li>
+                <li>Tracking over time - Use LineChart</li>
+                <li>Non-sequential process - Use Sankey or flow diagram</li>
+                <li>Part-of-whole without stages - Use PieChart</li>
               </ul>
             </div>
             <Separator />
             <div>
               <p className="font-medium mb-1">Tips:</p>
               <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
-                <li>Add conversion % between stages manually</li>
-                <li>Use consistent colors (traffic light: green→red)</li>
-                <li>Show absolute numbers + percentages</li>
+                <li>Sort data largest → smallest (or use reversed)</li>
+                <li>Use gradient palettes (green → red) to emphasize drop-off</li>
+                <li>Show conversion rates alongside the funnel</li>
+                <li>Use right-positioned labels with name + percent format</li>
+                <li>Add a second LabelList inside for values</li>
+                <li>Use lastShapeType=&quot;rectangle&quot; for flat-bottom funnels</li>
+                <li>Increase right margin to 80+ for external labels</li>
               </ul>
             </div>
           </CardContent>
         </Card>
       </div>
+
+      {/* ── Understanding Cards ────────────────────────────────────────── */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Funnel Anatomy</CardTitle>
+          <CardDescription>How the trapezoid stages are constructed</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm">
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-2">
+              <p className="font-medium">Trapezoid Shape</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-1">
+                <li><strong>upperWidth:</strong> Top edge width (from value)</li>
+                <li><strong>lowerWidth:</strong> Bottom edge width (from next value)</li>
+                <li><strong>height:</strong> Uniform per stage</li>
+                <li><strong>Last stage:</strong> Triangle or rectangle</li>
+              </ul>
+            </div>
+            <div className="space-y-2">
+              <p className="font-medium">Data Flow</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-1">
+                <li>Values must decrease (or increase if reversed)</li>
+                <li>Width is proportional to value</li>
+                <li>Each Cell gets its own fill color</li>
+                <li>Stroke separates adjacent stages</li>
+              </ul>
+            </div>
+            <div className="space-y-2">
+              <p className="font-medium">Label Placement</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-1">
+                <li><strong>right:</strong> Outside, to the right (needs margin)</li>
+                <li><strong>left:</strong> Outside, to the left</li>
+                <li><strong>inside:</strong> Centered within trapezoid</li>
+                <li><strong>outside:</strong> Above/outside the shape</li>
+              </ul>
+            </div>
+          </div>
+          <Separator />
+          <div className="rounded border border-blue-500 bg-blue-50 dark:bg-blue-950/20 p-3 text-xs text-muted-foreground">
+            <p><strong className="text-blue-700 dark:text-blue-400">Tip:</strong> You can use multiple <code className="text-xs">LabelList</code> components inside the Funnel to show both stage names (right) and values (inside) simultaneously. Use the formatter prop for custom label content like percentages or conversion rates.</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Color Strategies</CardTitle>
+          <CardDescription>How to choose effective funnel colors</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <p className="font-medium">Sequential Gradient</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-1">
+                <li>Best for showing progression/drop-off</li>
+                <li>Green → Red shows good → lost</li>
+                <li>Single hue light → dark shows magnitude</li>
+                <li>Use the Gradient color mode in Data tab</li>
+              </ul>
+            </div>
+            <div className="space-y-2">
+              <p className="font-medium">Categorical Colors</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-1">
+                <li>Best when each stage is a distinct concept</li>
+                <li>Use high-contrast, accessible colors</li>
+                <li>Customize per-stage in Stages tab</li>
+                <li>Ensure sufficient contrast for labels inside</li>
+              </ul>
+            </div>
+          </div>
+          <Separator />
+          <div className="rounded border border-amber-500 bg-amber-50 dark:bg-amber-950/20 p-3 text-xs text-muted-foreground">
+            <p><strong className="text-amber-700 dark:text-amber-400">Warning:</strong> When using &quot;inside&quot; label position, ensure the stage fill colors have enough contrast with the label text color. Light fills need dark text and vice versa.</p>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/packages/demo/src/components/TreemapChartPlayground.tsx
+++ b/packages/demo/src/components/TreemapChartPlayground.tsx
@@ -22,60 +22,32 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@acronis-platform/shadcn-uikit/react'
-import {
-  Treemap,
-  ResponsiveContainer,
-} from 'recharts'
-import { getChartColors } from '@/lib/chart-colors'
+import { Treemap } from 'recharts'
+// colors managed via colorPalette constant
 
-// Sample hierarchical data
-const sampleData = [
-  {
-    name: 'Frontend',
-    children: [
-      { name: 'React', size: 3000 },
-      { name: 'Vue', size: 2000 },
-      { name: 'Angular', size: 1500 },
-      { name: 'Svelte', size: 800 },
-    ],
-  },
-  {
-    name: 'Backend',
-    children: [
-      { name: 'Node.js', size: 2500 },
-      { name: 'Python', size: 2200 },
-      { name: 'Go', size: 1200 },
-      { name: 'Rust', size: 600 },
-    ],
-  },
-  {
-    name: 'Database',
-    children: [
-      { name: 'PostgreSQL', size: 1800 },
-      { name: 'MongoDB', size: 1400 },
-      { name: 'Redis', size: 900 },
-    ],
-  },
-  {
-    name: 'DevOps',
-    children: [
-      { name: 'Docker', size: 1600 },
-      { name: 'Kubernetes', size: 1400 },
-      { name: 'AWS', size: 1200 },
-    ],
-  },
-]
+// ─── Types ───────────────────────────────────────────────────────────────────
 
-const aspectRatios = [
-  { value: '4/3', label: '4:3 (Default)' },
-  { value: '1', label: '1:1 (Square)' },
-  { value: '16/9', label: '16:9 (Wide)' },
-]
+interface TreemapItem {
+  name: string
+  children?: TreemapItem[]
+  [key: string]: unknown
+}
 
-type AspectRatio = '4/3' | '1' | '16/9'
+interface TreemapDataSource {
+  name: string
+  data: TreemapItem[]
+  dataKey: string
+  nameKey: string
+  description: string
+}
 
-// Custom content renderer
-type TreemapContentProps = {
+interface CategoryConfig {
+  color?: string
+  hidden?: boolean
+}
+
+// Content renderer props from recharts TreemapNode
+interface ContentProps {
   x: number
   y: number
   width: number
@@ -83,96 +55,360 @@ type TreemapContentProps = {
   name: string
   depth: number
   index: number
-  parent?: { index: number }
-}
-type CustomizedContentProps = TreemapContentProps & {
-  colors: string[]
-  showLabels: boolean
-  strokeWidth: number
+  value: number
+  children: unknown[] | null
+  parent?: { index: number; name: string }
+  root?: { value: number }
+  [k: string]: unknown
 }
 
-const CustomizedContent = (props: CustomizedContentProps) => {
-  const { x, y, width, height, name, depth, colors, showLabels, strokeWidth } = props
+// ─── Data Sources ────────────────────────────────────────────────────────────
 
-  const colorIndex = depth === 1 ? props.index : props.parent?.index || 0
-  const fill = colors[colorIndex % colors.length]
-  
-  // Darken color for nested items
-  const fillOpacity = depth === 2 ? 0.7 : 1
-
-  return (
-    <g>
-      <rect
-        x={x}
-        y={y}
-        width={width}
-        height={height}
-        style={{
-          fill,
-          fillOpacity,
-          stroke: '#fff',
-          strokeWidth: strokeWidth,
-          strokeOpacity: 1,
-        }}
-      />
-      {showLabels && width > 50 && height > 30 && (
-        <text
-          x={x + width / 2}
-          y={y + height / 2}
-          textAnchor="middle"
-          dominantBaseline="middle"
-          fill="#fff"
-          fontSize={depth === 1 ? 14 : 11}
-          fontWeight={depth === 1 ? 'bold' : 'normal'}
-        >
-          {name}
-        </text>
-      )}
-    </g>
-  )
+const treemapDataSources: Record<string, TreemapDataSource> = {
+  techStack: {
+    name: 'Tech Stack',
+    data: [
+      {
+        name: 'Frontend',
+        children: [
+          { name: 'React', size: 3000 },
+          { name: 'Vue', size: 2000 },
+          { name: 'Angular', size: 1500 },
+          { name: 'Svelte', size: 800 },
+        ],
+      },
+      {
+        name: 'Backend',
+        children: [
+          { name: 'Node.js', size: 2500 },
+          { name: 'Python', size: 2200 },
+          { name: 'Go', size: 1200 },
+          { name: 'Rust', size: 600 },
+        ],
+      },
+      {
+        name: 'Database',
+        children: [
+          { name: 'PostgreSQL', size: 1800 },
+          { name: 'MongoDB', size: 1400 },
+          { name: 'Redis', size: 900 },
+        ],
+      },
+      {
+        name: 'DevOps',
+        children: [
+          { name: 'Docker', size: 1600 },
+          { name: 'Kubernetes', size: 1400 },
+          { name: 'AWS', size: 1200 },
+        ],
+      },
+    ],
+    dataKey: 'size',
+    nameKey: 'name',
+    description: 'Technology categories with popularity scores',
+  },
+  diskUsage: {
+    name: 'Disk Usage',
+    data: [
+      {
+        name: 'Documents',
+        children: [
+          { name: 'PDFs', size: 4200 },
+          { name: 'Spreadsheets', size: 2800 },
+          { name: 'Presentations', size: 1600 },
+          { name: 'Text Files', size: 400 },
+        ],
+      },
+      {
+        name: 'Media',
+        children: [
+          { name: 'Photos', size: 8500 },
+          { name: 'Videos', size: 12000 },
+          { name: 'Music', size: 3200 },
+        ],
+      },
+      {
+        name: 'Applications',
+        children: [
+          { name: 'IDEs', size: 5600 },
+          { name: 'Browsers', size: 2100 },
+          { name: 'Utilities', size: 800 },
+        ],
+      },
+      {
+        name: 'System',
+        children: [
+          { name: 'OS Files', size: 15000 },
+          { name: 'Cache', size: 3400 },
+          { name: 'Logs', size: 1200 },
+        ],
+      },
+    ],
+    dataKey: 'size',
+    nameKey: 'name',
+    description: 'File system usage breakdown in MB',
+  },
+  budget: {
+    name: 'Company Budget',
+    data: [
+      {
+        name: 'Engineering',
+        children: [
+          { name: 'Salaries', size: 45000 },
+          { name: 'Tools & Licenses', size: 8000 },
+          { name: 'Cloud Infra', size: 12000 },
+          { name: 'Training', size: 3000 },
+        ],
+      },
+      {
+        name: 'Marketing',
+        children: [
+          { name: 'Advertising', size: 15000 },
+          { name: 'Events', size: 8000 },
+          { name: 'Content', size: 5000 },
+        ],
+      },
+      {
+        name: 'Sales',
+        children: [
+          { name: 'Salaries', size: 25000 },
+          { name: 'Travel', size: 6000 },
+          { name: 'CRM', size: 3000 },
+        ],
+      },
+      {
+        name: 'Operations',
+        children: [
+          { name: 'Office', size: 10000 },
+          { name: 'HR', size: 4000 },
+          { name: 'Legal', size: 3000 },
+        ],
+      },
+    ],
+    dataKey: 'size',
+    nameKey: 'name',
+    description: 'Annual budget allocation in $K',
+  },
+  portfolio: {
+    name: 'Investment Portfolio',
+    data: [
+      {
+        name: 'Equities',
+        children: [
+          { name: 'US Large Cap', size: 35000 },
+          { name: 'US Small Cap', size: 10000 },
+          { name: 'International', size: 15000 },
+          { name: 'Emerging Mkts', size: 8000 },
+        ],
+      },
+      {
+        name: 'Fixed Income',
+        children: [
+          { name: 'Gov Bonds', size: 12000 },
+          { name: 'Corp Bonds', size: 8000 },
+          { name: 'High Yield', size: 4000 },
+        ],
+      },
+      {
+        name: 'Alternatives',
+        children: [
+          { name: 'Real Estate', size: 6000 },
+          { name: 'Commodities', size: 3000 },
+          { name: 'Crypto', size: 2000 },
+        ],
+      },
+    ],
+    dataKey: 'size',
+    nameKey: 'name',
+    description: 'Portfolio allocation in $K',
+  },
 }
+
+type DataSourceKey = keyof typeof treemapDataSources
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const colorPalette = [
+  '#4169e1', '#2db89a', '#d946ef', '#ef5350', '#d4c92a',
+  '#38bdf8', '#a57c52', '#7c3aed', '#9ca3af', '#93c5fd',
+]
+
+const indicatorTypes = [
+  { value: 'dot', label: 'dot - Small square' },
+  { value: 'line', label: 'line - Vertical bar' },
+  { value: 'dashed', label: 'dashed - Dashed line' },
+]
+
+// ─── Component ───────────────────────────────────────────────────────────────
 
 export function TreemapChartPlayground() {
-  const colors = getChartColors(4)
+  // ── Data tab state ──────────────────────────────────────────────────────
+  const [dataSource, setDataSource] = React.useState<DataSourceKey>('techStack')
+  const currentSource = treemapDataSources[dataSource]
+  const [categoryConfigs, setCategoryConfigs] = React.useState<Record<string, CategoryConfig>>({})
 
-  // Chart settings state
-  const [showTooltip, setShowTooltip] = React.useState(true)
-  const [showLabels, setShowLabels] = React.useState(true)
-  const [strokeWidth, setStrokeWidth] = React.useState(2)
-  const [aspectRatio, setAspectRatio] = React.useState<AspectRatio>('4/3')
-  const [isAnimationActive, setIsAnimationActive] = React.useState(true)
+  // Reset on data source change
+  React.useEffect(() => {
+    setCategoryConfigs({})
+  }, [dataSource])
 
-  const config = {
-    frontend: { label: 'Frontend', color: colors[0] },
-    backend: { label: 'Backend', color: colors[1] },
-    database: { label: 'Database', color: colors[2] },
-    devops: { label: 'DevOps', color: colors[3] },
+  const updateCategoryConfig = (catName: string, key: string, value: unknown) => {
+    setCategoryConfigs((prev) => ({
+      ...prev,
+      [catName]: { ...prev[catName], [key]: value },
+    }))
   }
 
-  // Generate code preview
+  const getCategoryColor = (catName: string, idx: number): string => {
+    return categoryConfigs[catName]?.color ?? colorPalette[idx % colorPalette.length]
+  }
+
+  // ── Treemap tab state ───────────────────────────────────────────────────
+  const [treemapType, setTreemapType] = React.useState<'flat' | 'nest'>('flat')
+  const [aspectRatio, setAspectRatio] = React.useState(4 / 3)
+  const [fill, setFill] = React.useState('#8884d8')
+  const [stroke, setStroke] = React.useState('#ffffff')
+  const [strokeWidth, setStrokeWidth] = React.useState(2)
+
+  // Content / Labels
+  const [showLabels, setShowLabels] = React.useState(true)
+  const [labelMinWidth, setLabelMinWidth] = React.useState(50)
+  const [labelMinHeight, setLabelMinHeight] = React.useState(30)
+  const [labelContent, setLabelContent] = React.useState<'name' | 'value' | 'name-value' | 'percent'>('name')
+  const [categoryFontSize, setCategoryFontSize] = React.useState(14)
+  const [leafFontSize, setLeafFontSize] = React.useState(11)
+  const [labelColor, setLabelColor] = React.useState('#ffffff')
+
+  // Depth styling
+  const [leafOpacity, setLeafOpacity] = React.useState(0.7)
+  const [showCategoryLabels, setShowCategoryLabels] = React.useState(false)
+
+  // Animation
+  const [isAnimationActive, setIsAnimationActive] = React.useState(true)
+  const [isUpdateAnimationActive, setIsUpdateAnimationActive] = React.useState(true)
+  const [animationDuration, setAnimationDuration] = React.useState(1500)
+  const [animationBegin, setAnimationBegin] = React.useState(0)
+  const [animationEasing, setAnimationEasing] = React.useState<'linear' | 'ease' | 'ease-in' | 'ease-out' | 'ease-in-out'>('linear')
+
+  // ── Chart tab state ─────────────────────────────────────────────────────
+  const [showTooltip, setShowTooltip] = React.useState(true)
+  const [tooltipIndicator, setTooltipIndicator] = React.useState<'dot' | 'line' | 'dashed'>('dot')
+
+  // ── Derived ─────────────────────────────────────────────────────────────
+
+  const visibleData = React.useMemo(() => {
+    return currentSource.data.filter((cat) => !categoryConfigs[cat.name]?.hidden)
+  }, [currentSource.data, categoryConfigs])
+
+  const totalValue = React.useMemo(() => {
+    let total = 0
+    visibleData.forEach((cat) => {
+      cat.children?.forEach((child) => {
+        total += (child[currentSource.dataKey] as number) ?? 0
+      })
+    })
+    return total
+  }, [visibleData, currentSource.dataKey])
+
+  const config = React.useMemo(() => {
+    const cfg: Record<string, { label: string; color: string }> = {}
+    visibleData.forEach((cat, idx) => {
+      const key = cat.name.toLowerCase().replace(/[^a-z0-9]/g, '')
+      cfg[key] = { label: cat.name, color: getCategoryColor(cat.name, idx) }
+    })
+    return cfg
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visibleData, categoryConfigs])
+
+  // ── Custom content renderer ─────────────────────────────────────────────
+
+  const renderContent = React.useCallback(
+    (props: ContentProps) => {
+      const { x, y, width, height, name, depth, index, value } = props
+      const parentIndex = props.parent?.index ?? index
+      const catColor = getCategoryColor(
+        visibleData[depth === 1 ? index : parentIndex]?.name ?? '',
+        depth === 1 ? index : parentIndex,
+      )
+      const fillOpacity = depth >= 2 ? leafOpacity : 1
+      const isCategory = depth === 1
+      const canShowLabel = showLabels && width > labelMinWidth && height > labelMinHeight
+
+      const formatLabel = () => {
+        const pct = totalValue > 0 ? `${((value / totalValue) * 100).toFixed(1)}%` : '0%'
+        switch (labelContent) {
+          case 'value': return String((value ?? 0).toLocaleString())
+          case 'name-value': return `${name}: ${(value ?? 0).toLocaleString()}`
+          case 'percent': return pct
+          default: return name
+        }
+      }
+
+      return (
+        <g>
+          <rect
+            x={x}
+            y={y}
+            width={width}
+            height={height}
+            style={{
+              fill: catColor,
+              fillOpacity,
+              stroke,
+              strokeWidth,
+              strokeOpacity: 1,
+            }}
+          />
+          {canShowLabel && (!isCategory || showCategoryLabels) && (
+            <text
+              x={x + width / 2}
+              y={y + height / 2}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fill={labelColor}
+              fontSize={isCategory ? categoryFontSize : leafFontSize}
+              fontWeight={isCategory ? 'bold' : 'normal'}
+            >
+              {formatLabel()}
+            </text>
+          )}
+        </g>
+      )
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [visibleData, categoryConfigs, showLabels, labelMinWidth, labelMinHeight, labelContent, categoryFontSize, leafFontSize, labelColor, leafOpacity, showCategoryLabels, stroke, strokeWidth, totalValue],
+  )
+
+  // ── Code generation ─────────────────────────────────────────────────────
+
   const generateCode = () => {
-    const lines = []
-    lines.push(`<ResponsiveContainer width="100%" height={400}>`)
-    lines.push(`  <Treemap`)
-    lines.push(`    data={data}`)
-    lines.push(`    dataKey="size"`)
-    lines.push(`    aspectRatio={${aspectRatio}}`)
-    lines.push(`    stroke="#fff"`)
-    lines.push(`    fill={colors[0]}`)
-    if (!isAnimationActive) lines.push(`    isAnimationActive={false}`)
-    lines.push(`    content={<CustomizedContent`)
-    lines.push(`      colors={colors}`)
-    lines.push(`      showLabels={${showLabels}}`)
-    lines.push(`      strokeWidth={${strokeWidth}}`)
-    lines.push(`    />}`)
-    lines.push(`  >`)
+    const lines: string[] = []
+    lines.push(`<ChartContainer config={config} className="h-[400px] w-full">`)
+
+    const tp: string[] = ['data={data}', `dataKey="${currentSource.dataKey}"`]
+    if (treemapType !== 'flat') tp.push(`type="${treemapType}"`)
+    if (aspectRatio !== 4 / 3) tp.push(`aspectRatio={${aspectRatio}}`)
+    if (fill !== '#8884d8') tp.push(`fill="${fill}"`)
+    if (stroke !== '#ffffff') tp.push(`stroke="${stroke}"`)
+    if (!isAnimationActive) tp.push('isAnimationActive={false}')
+    if (!isUpdateAnimationActive) tp.push('isUpdateAnimationActive={false}')
+    if (animationBegin !== 0) tp.push(`animationBegin={${animationBegin}}`)
+    if (animationDuration !== 1500) tp.push(`animationDuration={${animationDuration}}`)
+    if (animationEasing !== 'linear') tp.push(`animationEasing="${animationEasing}"`)
+    tp.push('content={<CustomizedContent />}')
+
+    lines.push(`  <Treemap ${tp.join(' ')}>`)
+
     if (showTooltip) {
-      lines.push(`    <ChartTooltip content={(props) => <ChartTooltipContent {...props} />} />`)
+      lines.push(`    <ChartTooltip content={<ChartTooltipContent indicator="${tooltipIndicator}" />} />`)
     }
+
     lines.push(`  </Treemap>`)
-    lines.push(`</ResponsiveContainer>`)
+    lines.push(`</ChartContainer>`)
     return lines.join('\n')
   }
+
+  // ── Render ──────────────────────────────────────────────────────────────
 
   return (
     <div className="space-y-6 p-6">
@@ -184,7 +420,7 @@ export function TreemapChartPlayground() {
       </div>
 
       <div className="grid gap-6 lg:grid-cols-[1fr_350px]">
-        {/* Chart Preview */}
+        {/* ── Live Preview ───────────────────────────────────────────── */}
         <Card>
           <CardHeader>
             <CardTitle>Live Preview</CardTitle>
@@ -192,93 +428,165 @@ export function TreemapChartPlayground() {
           </CardHeader>
           <CardContent>
             <ChartContainer config={config} className="h-[400px] w-full">
-              <ResponsiveContainer width="100%" height="100%">
-                <Treemap
-                  data={sampleData}
-                  dataKey="size"
-                  aspectRatio={parseFloat(aspectRatio.replace('/', '.').replace('.', '/')) || 4/3}
-                  stroke="#fff"
-                  fill={colors[0]}
-                  isAnimationActive={isAnimationActive}
-                  content={(contentProps) => (
-                    <CustomizedContent 
-                      {...contentProps}
-                      colors={colors} 
-                      showLabels={showLabels}
-                      strokeWidth={strokeWidth}
-                    />
-                  )}
-                >
-                  {showTooltip && (
-                    <ChartTooltip content={(props) => <ChartTooltipContent {...props} />} />
-                  )}
-                </Treemap>
-              </ResponsiveContainer>
+              <Treemap
+                data={visibleData}
+                dataKey={currentSource.dataKey}
+                nameKey={currentSource.nameKey}
+                type={treemapType}
+                aspectRatio={aspectRatio}
+                fill={fill}
+                stroke={stroke}
+                isAnimationActive={isAnimationActive}
+                isUpdateAnimationActive={isUpdateAnimationActive}
+                animationBegin={animationBegin}
+                animationDuration={animationDuration}
+                animationEasing={animationEasing}
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                content={renderContent as any}
+              >
+                {showTooltip && (
+                  <ChartTooltip
+                    content={(props) => <ChartTooltipContent {...props} indicator={tooltipIndicator} />}
+                  />
+                )}
+              </Treemap>
             </ChartContainer>
           </CardContent>
         </Card>
 
-        {/* Settings Panel */}
+        {/* ── Settings Panel ─────────────────────────────────────────── */}
         <Card>
           <CardHeader>
             <CardTitle>Settings</CardTitle>
             <CardDescription>Toggle to see what each setting does</CardDescription>
           </CardHeader>
           <CardContent>
-            <Tabs defaultValue="display" className="w-full">
-              <TabsList className="grid w-full grid-cols-2">
-                <TabsTrigger value="display">Display</TabsTrigger>
+            <Tabs defaultValue="data" className="w-full">
+              <TabsList className="grid w-full grid-cols-4">
                 <TabsTrigger value="data">Data</TabsTrigger>
+                <TabsTrigger value="treemap">Treemap</TabsTrigger>
+                <TabsTrigger value="style">Style</TabsTrigger>
+                <TabsTrigger value="chart">Chart</TabsTrigger>
               </TabsList>
 
-              <TabsContent value="display" className="space-y-4 pt-4">
-                {/* Show Labels */}
-                <div className="flex items-center justify-between">
-                  <div>
-                    <Label className="text-sm font-medium">Show Labels</Label>
-                    <p className="text-xs text-muted-foreground">Text inside rectangles</p>
-                  </div>
-                  <Switch checked={showLabels} onCheckedChange={setShowLabels} />
+              {/* ─── Tab: Data ──────────────────────────────────────── */}
+              <TabsContent value="data" className="space-y-4 pt-4">
+                <div className="space-y-2">
+                  <Label className="text-sm font-medium">Data Source</Label>
+                  <Select value={dataSource} onValueChange={(v) => setDataSource(v as DataSourceKey)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Object.entries(treemapDataSources).map(([key, src]) => (
+                        <SelectItem key={key} value={key}>{src.name}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">{currentSource.description}</p>
                 </div>
 
                 <Separator />
 
-                {/* Stroke Width */}
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground">Categories ({visibleData.length} of {currentSource.data.length})</p>
+                  {currentSource.data.map((cat, idx) => {
+                    const hidden = categoryConfigs[cat.name]?.hidden
+                    const color = getCategoryColor(cat.name, idx)
+                    const catTotal = cat.children?.reduce((sum, c) => sum + ((c[currentSource.dataKey] as number) ?? 0), 0) ?? 0
+                    return (
+                      <div
+                        key={cat.name}
+                        className={`rounded-lg border p-3 transition ${hidden ? 'opacity-40' : ''}`}
+                        style={{ borderLeftColor: hidden ? '#9ca3af' : color, borderLeftWidth: 4 }}
+                      >
+                        <div className="flex items-center justify-between">
+                          <button className="text-left" onClick={() => updateCategoryConfig(cat.name, 'hidden', !hidden)}>
+                            <p className="text-sm font-medium">{cat.name}</p>
+                            <p className="text-xs text-muted-foreground">
+                              {cat.children?.length ?? 0} items, total: {catTotal.toLocaleString()}
+                            </p>
+                          </button>
+                          <div className="flex items-center gap-2">
+                            <input
+                              type="color"
+                              value={color}
+                              onChange={(e) => updateCategoryConfig(cat.name, 'color', e.target.value)}
+                              className="h-6 w-6 cursor-pointer rounded border-0 bg-transparent p-0"
+                            />
+                          </div>
+                        </div>
+                        {!hidden && (
+                          <div className="mt-2 space-y-1">
+                            {cat.children?.map((child) => (
+                              <div key={child.name} className="flex justify-between text-xs text-muted-foreground">
+                                <span>{child.name}</span>
+                                <span>{((child[currentSource.dataKey] as number) ?? 0).toLocaleString()}</span>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    )
+                  })}
+                  <p className="text-xs text-muted-foreground">Click a category to hide/show. Use color picker to customize.</p>
+                </div>
+              </TabsContent>
+
+              {/* ─── Tab: Treemap ───────────────────────────────────── */}
+              <TabsContent value="treemap" className="space-y-4 pt-4">
+                {/* Type */}
                 <div className="flex items-center justify-between">
                   <div>
-                    <Label className="text-sm font-medium">Border Width</Label>
-                    <p className="text-xs text-muted-foreground">Rectangle borders</p>
+                    <Label className="text-sm font-medium">Type</Label>
+                    <p className="text-xs text-muted-foreground">Flat shows all; Nest allows drill-down</p>
                   </div>
-                  <Input
-                    type="number"
-                    value={strokeWidth}
-                    onChange={(e) => setStrokeWidth(Number(e.target.value) || 1)}
-                    min={0}
-                    max={6}
-                    className="w-20 h-8"
-                  />
+                  <Select value={treemapType} onValueChange={(v) => setTreemapType(v as 'flat' | 'nest')}>
+                    <SelectTrigger className="w-24 h-8">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="flat">Flat</SelectItem>
+                      <SelectItem value="nest">Nest</SelectItem>
+                    </SelectContent>
+                  </Select>
                 </div>
 
                 <Separator />
 
                 {/* Aspect Ratio */}
                 <div className="space-y-2">
-                  <Label className="text-sm font-medium">Aspect Ratio</Label>
-                  <Select value={aspectRatio} onValueChange={(v) => setAspectRatio(v as AspectRatio)}>
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {aspectRatios.map((r) => (
-                        <SelectItem key={r.value} value={r.value}>
-                          {r.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <p className="text-xs text-muted-foreground">
-                    Controls preferred shape of rectangles
-                  </p>
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <Label className="text-sm font-medium">Aspect Ratio</Label>
+                      <p className="text-xs text-muted-foreground">Preferred rectangle shape ({aspectRatio.toFixed(2)})</p>
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    {[
+                      { label: '1:1', value: 1 },
+                      { label: '4:3', value: 4 / 3 },
+                      { label: '16:9', value: 16 / 9 },
+                      { label: '2:1', value: 2 },
+                    ].map((preset) => (
+                      <button
+                        key={preset.label}
+                        className={`px-2 py-1 text-xs rounded ${Math.abs(aspectRatio - preset.value) < 0.01 ? 'bg-primary text-primary-foreground' : 'bg-muted'}`}
+                        onClick={() => setAspectRatio(preset.value)}
+                      >
+                        {preset.label}
+                      </button>
+                    ))}
+                  </div>
+                  <Input
+                    type="number"
+                    value={aspectRatio}
+                    onChange={(e) => setAspectRatio(Math.max(0.1, Number(e.target.value) || 1.33))}
+                    step={0.1}
+                    min={0.1}
+                    max={5}
+                    className="h-8"
+                  />
                 </div>
 
                 <Separator />
@@ -291,39 +599,175 @@ export function TreemapChartPlayground() {
                   </div>
                   <Switch checked={isAnimationActive} onCheckedChange={setIsAnimationActive} />
                 </div>
+                {isAnimationActive && (
+                  <>
+                    <div className="flex items-center justify-between pl-4">
+                      <span className="text-sm">Delay (ms)</span>
+                      <Input type="number" value={animationBegin} onChange={(e) => setAnimationBegin(Math.max(0, Number(e.target.value) || 0))} min={0} max={5000} className="w-24 h-8" />
+                    </div>
+                    <div className="flex items-center justify-between pl-4">
+                      <span className="text-sm">Duration (ms)</span>
+                      <Input type="number" value={animationDuration} onChange={(e) => setAnimationDuration(Number(e.target.value) || 1500)} min={0} max={5000} className="w-24 h-8" />
+                    </div>
+                    <div className="flex items-center justify-between pl-4">
+                      <span className="text-sm">Easing</span>
+                      <Select value={animationEasing} onValueChange={(v) => setAnimationEasing(v as typeof animationEasing)}>
+                        <SelectTrigger className="w-32 h-8">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {['linear', 'ease', 'ease-in', 'ease-out', 'ease-in-out'].map((e) => (
+                            <SelectItem key={e} value={e}>{e}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </>
+                )}
 
                 <Separator />
 
+                {/* Update Animation */}
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Label className="text-sm font-medium">Update Animation</Label>
+                    <p className="text-xs text-muted-foreground">Animate when data changes</p>
+                  </div>
+                  <Switch checked={isUpdateAnimationActive} onCheckedChange={setIsUpdateAnimationActive} />
+                </div>
+              </TabsContent>
+
+              {/* ─── Tab: Style ─────────────────────────────────────── */}
+              <TabsContent value="style" className="space-y-4 pt-4">
+                {/* Fill */}
+                <div className="space-y-2">
+                  <Label className="text-sm font-medium">Default Fill</Label>
+                  <p className="text-xs text-muted-foreground">Fallback color when content renderer is not used</p>
+                  <div className="flex items-center gap-2">
+                    <input type="color" value={fill} onChange={(e) => setFill(e.target.value)} className="h-6 w-8 cursor-pointer rounded border-0 bg-transparent p-0" />
+                    <Input type="text" value={fill} onChange={(e) => setFill(e.target.value)} className="flex-1 h-8" />
+                  </div>
+                </div>
+
+                <Separator />
+
+                {/* Stroke */}
+                <div className="space-y-2">
+                  <Label className="text-sm font-medium">Stroke (border)</Label>
+                  <div className="flex items-center gap-2">
+                    <input type="color" value={stroke} onChange={(e) => setStroke(e.target.value)} className="h-6 w-8 cursor-pointer rounded border-0 bg-transparent p-0" />
+                    <Input type="text" value={stroke} onChange={(e) => setStroke(e.target.value)} className="flex-1 h-8" />
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-muted-foreground">Width</span>
+                    <Input type="number" value={strokeWidth} onChange={(e) => setStrokeWidth(Number(e.target.value) || 0)} min={0} max={10} className="w-20 h-8" />
+                  </div>
+                </div>
+
+                <Separator />
+
+                {/* Leaf Opacity */}
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Label className="text-sm font-medium">Leaf Opacity</Label>
+                    <p className="text-xs text-muted-foreground">Opacity for child/leaf rectangles ({leafOpacity})</p>
+                  </div>
+                  <Input type="number" value={leafOpacity} onChange={(e) => setLeafOpacity(Math.min(1, Math.max(0, Number(e.target.value) || 0.7)))} step={0.1} min={0} max={1} className="w-20 h-8" />
+                </div>
+
+                <Separator />
+
+                {/* Labels */}
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Label className="text-sm font-medium">Show Labels</Label>
+                    <p className="text-xs text-muted-foreground">Text inside rectangles</p>
+                  </div>
+                  <Switch checked={showLabels} onCheckedChange={setShowLabels} />
+                </div>
+                {showLabels && (
+                  <>
+                    <div className="flex items-center justify-between pl-4">
+                      <span className="text-sm">Content</span>
+                      <Select value={labelContent} onValueChange={(v) => setLabelContent(v as typeof labelContent)}>
+                        <SelectTrigger className="w-32 h-8">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="name">Name only</SelectItem>
+                          <SelectItem value="value">Value only</SelectItem>
+                          <SelectItem value="name-value">Name: Value</SelectItem>
+                          <SelectItem value="percent">Percent</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="flex items-center justify-between pl-4">
+                      <span className="text-sm">Min Width (px)</span>
+                      <Input type="number" value={labelMinWidth} onChange={(e) => setLabelMinWidth(Number(e.target.value) || 30)} min={10} max={200} className="w-20 h-8" />
+                    </div>
+                    <div className="flex items-center justify-between pl-4">
+                      <span className="text-sm">Min Height (px)</span>
+                      <Input type="number" value={labelMinHeight} onChange={(e) => setLabelMinHeight(Number(e.target.value) || 20)} min={10} max={200} className="w-20 h-8" />
+                    </div>
+                    <div className="space-y-1 pl-4">
+                      <span className="text-sm">Text Color</span>
+                      <div className="flex items-center gap-2">
+                        <input type="color" value={labelColor} onChange={(e) => setLabelColor(e.target.value)} className="h-6 w-8 cursor-pointer rounded border-0 p-0" />
+                        <Input type="text" value={labelColor} onChange={(e) => setLabelColor(e.target.value)} className="flex-1 h-8" />
+                      </div>
+                    </div>
+                    <div className="flex items-center justify-between pl-4">
+                      <span className="text-sm">Category Font Size</span>
+                      <Input type="number" value={categoryFontSize} onChange={(e) => setCategoryFontSize(Number(e.target.value) || 14)} min={8} max={24} className="w-20 h-8" />
+                    </div>
+                    <div className="flex items-center justify-between pl-4">
+                      <span className="text-sm">Leaf Font Size</span>
+                      <Input type="number" value={leafFontSize} onChange={(e) => setLeafFontSize(Number(e.target.value) || 11)} min={8} max={24} className="w-20 h-8" />
+                    </div>
+
+                    <Separator />
+
+                    <div className="flex items-center justify-between pl-4">
+                      <div>
+                        <span className="text-sm">Category Labels</span>
+                        <p className="text-xs text-muted-foreground">Show text on depth-1 (parent) rects</p>
+                      </div>
+                      <Switch checked={showCategoryLabels} onCheckedChange={setShowCategoryLabels} />
+                    </div>
+                  </>
+                )}
+              </TabsContent>
+
+              {/* ─── Tab: Chart ─────────────────────────────────────── */}
+              <TabsContent value="chart" className="space-y-4 pt-4">
                 {/* Tooltip */}
                 <div className="flex items-center justify-between">
                   <div>
                     <Label className="text-sm font-medium">Show Tooltip</Label>
-                    <p className="text-xs text-muted-foreground">Hover for details</p>
+                    <p className="text-xs text-muted-foreground">{'<ChartTooltip />'}</p>
                   </div>
                   <Switch checked={showTooltip} onCheckedChange={setShowTooltip} />
                 </div>
-              </TabsContent>
-
-              <TabsContent value="data" className="space-y-4 pt-4">
-                <div className="space-y-2">
-                  <p className="text-xs font-medium text-muted-foreground">Categories</p>
-                  {sampleData.map((category, index) => (
-                    <div 
-                      key={category.name} 
-                      className="rounded-lg border p-3"
-                      style={{ borderLeftColor: colors[index], borderLeftWidth: 4 }}
-                    >
-                      <p className="text-sm font-medium">{category.name}</p>
-                      <div className="mt-2 space-y-1">
-                        {category.children.map((child) => (
-                          <div key={child.name} className="flex justify-between text-xs text-muted-foreground">
-                            <span>{child.name}</span>
-                            <span>{child.size.toLocaleString()}</span>
-                          </div>
+                {showTooltip && (
+                  <div className="space-y-2 pl-4">
+                    <Label className="text-sm">Indicator</Label>
+                    <Select value={tooltipIndicator} onValueChange={(v) => setTooltipIndicator(v as 'dot' | 'line' | 'dashed')}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {indicatorTypes.map((t) => (
+                          <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>
                         ))}
-                      </div>
-                    </div>
-                  ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+
+                <Separator />
+
+                <div className="rounded border border-blue-500 bg-blue-50 dark:bg-blue-950/20 p-3 text-xs text-muted-foreground">
+                  <p><strong className="text-blue-700 dark:text-blue-400">Note:</strong> Treemap does not support Legend or standard axis components. Color coding is managed via the custom content renderer. Use the Data tab to customize per-category colors.</p>
                 </div>
               </TabsContent>
             </Tabs>
@@ -331,7 +775,7 @@ export function TreemapChartPlayground() {
         </Card>
       </div>
 
-      {/* Code Preview */}
+      {/* ── Generated Code ─────────────────────────────────────────────── */}
       <Card>
         <CardHeader>
           <CardTitle>Generated Code</CardTitle>
@@ -344,11 +788,26 @@ export function TreemapChartPlayground() {
         </CardContent>
       </Card>
 
-      {/* Documentation Section */}
+      {/* ── Raw Data Preview ───────────────────────────────────────────── */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Raw Data</CardTitle>
+          <CardDescription>
+            {currentSource.name} — {visibleData.length} categories, total value: {totalValue.toLocaleString()}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <pre className="overflow-x-auto rounded-lg bg-muted p-4 text-sm max-h-64">
+            <code>{JSON.stringify(visibleData, null, 2)}</code>
+          </pre>
+        </CardContent>
+      </Card>
+
+      {/* ── Documentation ──────────────────────────────────────────────── */}
       <div className="grid gap-6 lg:grid-cols-2">
         <Card>
           <CardHeader>
-            <CardTitle>📊 Data Format</CardTitle>
+            <CardTitle>Data Format</CardTitle>
             <CardDescription>Required data structure for Treemap</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
@@ -359,7 +818,7 @@ const data = [
     name: 'Frontend',
     children: [
       { name: 'React', size: 3000 },
-      { name: 'Vue', size: 2000 },
+      { name: 'Vue',   size: 2000 },
     ],
   },
   {
@@ -368,15 +827,22 @@ const data = [
       { name: 'Node.js', size: 2500 },
     ],
   },
-]`}</code>
+]
+
+// ChartConfig for tooltip styling
+const config: ChartConfig = {
+  frontend: { label: "Frontend", color: "#4169e1" },
+  backend:  { label: "Backend",  color: "#2db89a" },
+}`}</code>
             </pre>
             <div className="space-y-2 text-sm">
               <p className="font-medium">Requirements:</p>
               <ul className="list-disc list-inside space-y-1 text-muted-foreground">
-                <li><strong>name field</strong> - Label for each rectangle</li>
-                <li><strong>size field</strong> - Numeric value (leaf nodes)</li>
-                <li><strong>children array</strong> - Nested categories</li>
-                <li><strong>Positive values</strong> - Size must be greater than 0</li>
+                <li><strong>name</strong> (or nameKey) - Label for each rectangle</li>
+                <li><strong>size/value</strong> (dataKey) - Numeric value for leaf nodes</li>
+                <li><strong>children</strong> - Array of nested items (1-2 levels ideal)</li>
+                <li><strong>Positive values</strong> - All leaf sizes must be &gt; 0</li>
+                <li><strong>Flat data also works</strong> - Array of items without children</li>
               </ul>
             </div>
           </CardContent>
@@ -384,25 +850,49 @@ const data = [
 
         <Card>
           <CardHeader>
-            <CardTitle>⚙️ Configurable Properties</CardTitle>
+            <CardTitle>Configurable Properties</CardTitle>
             <CardDescription>What you can customize</CardDescription>
           </CardHeader>
           <CardContent className="space-y-3 text-sm">
             <div>
               <p className="font-medium mb-1">Treemap Component</p>
               <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
-                <li><code className="text-xs">dataKey</code> - Field for rectangle size (&quot;size&quot;)</li>
-                <li><code className="text-xs">aspectRatio</code> - Rectangle shape preference (4/3)</li>
-                <li><code className="text-xs">isAnimationActive</code> - Enable/disable animation</li>
+                <li><code className="text-xs">dataKey</code> - Field for rectangle size (default &quot;value&quot;)</li>
+                <li><code className="text-xs">nameKey</code> - Field for rectangle label (default &quot;name&quot;)</li>
+                <li><code className="text-xs">type</code> - &quot;flat&quot; (all visible) or &quot;nest&quot; (drill-down)</li>
+                <li><code className="text-xs">aspectRatio</code> - Preferred shape of rectangles (default 4/3)</li>
+                <li><code className="text-xs">fill</code> - Default fill color</li>
+                <li><code className="text-xs">stroke</code> - Border color between rectangles</li>
               </ul>
             </div>
             <Separator />
             <div>
-              <p className="font-medium mb-1">Custom Content</p>
+              <p className="font-medium mb-1">Content Renderer</p>
               <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
-                <li><code className="text-xs">content</code> - Custom render function for rectangles</li>
-                <li>Access: x, y, width, height, name, depth, index</li>
-                <li>Control: colors, labels, borders per rectangle</li>
+                <li><code className="text-xs">content</code> - Custom render function for each rectangle</li>
+                <li>Receives: x, y, width, height, name, depth, index, value</li>
+                <li>Controls: colors, labels, borders, opacity per rectangle</li>
+                <li>Depth 1 = category, depth 2 = leaf item</li>
+              </ul>
+            </div>
+            <Separator />
+            <div>
+              <p className="font-medium mb-1">Nest Mode</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
+                <li><code className="text-xs">nestIndexContent</code> - Custom breadcrumb renderer</li>
+                <li><code className="text-xs">colorPanel</code> - Color array for nested levels</li>
+                <li>Click a category to zoom in, breadcrumb to go back</li>
+              </ul>
+            </div>
+            <Separator />
+            <div>
+              <p className="font-medium mb-1">Animation</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
+                <li><code className="text-xs">isAnimationActive</code> - Enable/disable initial animation</li>
+                <li><code className="text-xs">isUpdateAnimationActive</code> - Animate data changes</li>
+                <li><code className="text-xs">animationBegin</code> - Delay in ms (default 0)</li>
+                <li><code className="text-xs">animationDuration</code> - Duration in ms (default 1500)</li>
+                <li><code className="text-xs">animationEasing</code> - Timing function (default &quot;linear&quot;)</li>
               </ul>
             </div>
           </CardContent>
@@ -410,30 +900,34 @@ const data = [
 
         <Card>
           <CardHeader>
-            <CardTitle>🚫 Limitations</CardTitle>
+            <CardTitle>Limitations</CardTitle>
             <CardDescription>What Treemap cannot do</CardDescription>
           </CardHeader>
           <CardContent className="space-y-3 text-sm">
             <ul className="space-y-2 text-muted-foreground">
               <li className="flex gap-2">
-                <span className="text-destructive">✗</span>
-                <span><strong>Deep nesting (3+ levels)</strong> - Becomes hard to read</span>
+                <span className="text-destructive">-</span>
+                <span><strong>Deep nesting (3+ levels)</strong> - Becomes very hard to read and interact with</span>
               </li>
               <li className="flex gap-2">
-                <span className="text-destructive">✗</span>
-                <span><strong>Many small items</strong> - Labels don&apos;t fit, rectangles too small</span>
+                <span className="text-destructive">-</span>
+                <span><strong>Many small items</strong> - Labels cannot fit, rectangles become invisible</span>
               </li>
               <li className="flex gap-2">
-                <span className="text-destructive">✗</span>
-                <span><strong>No drill-down</strong> - Click to zoom needs custom implementation</span>
+                <span className="text-destructive">-</span>
+                <span><strong>No built-in legend</strong> - Color coding must be communicated via custom content or documentation</span>
               </li>
               <li className="flex gap-2">
-                <span className="text-destructive">✗</span>
-                <span><strong>Limited interactivity</strong> - Basic tooltip only</span>
+                <span className="text-destructive">-</span>
+                <span><strong>No comparison over time</strong> - Shows a single snapshot</span>
               </li>
               <li className="flex gap-2">
-                <span className="text-destructive">✗</span>
-                <span><strong>No comparison over time</strong> - Single snapshot only</span>
+                <span className="text-destructive">-</span>
+                <span><strong>Poor exact value comparison</strong> - Area is harder to compare than length (use BarChart)</span>
+              </li>
+              <li className="flex gap-2">
+                <span className="text-destructive">-</span>
+                <span><strong>Layout instability</strong> - Adding/removing items reshuffles all rectangles</span>
               </li>
             </ul>
           </CardContent>
@@ -441,26 +935,28 @@ const data = [
 
         <Card>
           <CardHeader>
-            <CardTitle>✅ Best Practices & Use Cases</CardTitle>
+            <CardTitle>Best Practices & Use Cases</CardTitle>
             <CardDescription>When and how to use Treemap</CardDescription>
           </CardHeader>
           <CardContent className="space-y-3 text-sm">
             <div>
               <p className="font-medium mb-1">Ideal For:</p>
               <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
-                <li>Disk/storage usage visualization</li>
+                <li>Disk / storage usage visualization</li>
                 <li>Portfolio allocation breakdown</li>
-                <li>Organizational structure by headcount</li>
-                <li>Budget breakdown by department</li>
+                <li>Organizational structure by headcount or budget</li>
+                <li>Market share by category</li>
+                <li>Content categorization (topics, tags)</li>
               </ul>
             </div>
             <Separator />
             <div>
               <p className="font-medium mb-1">Avoid When:</p>
               <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
-                <li>Comparing exact values → Use BarChart</li>
-                <li>Showing hierarchy only → Use Tree/Org chart</li>
-                <li>Time series → Use LineChart</li>
+                <li>Comparing exact values - Use BarChart</li>
+                <li>Showing hierarchy only (no size) - Use Tree/Org chart</li>
+                <li>Time series data - Use LineChart</li>
+                <li>Part-of-whole without hierarchy - Use PieChart</li>
               </ul>
             </div>
             <Separator />
@@ -468,13 +964,94 @@ const data = [
               <p className="font-medium mb-1">Tips:</p>
               <ul className="list-disc list-inside text-muted-foreground space-y-0.5">
                 <li>Use color to indicate categories, not values</li>
-                <li>Limit to 2 levels of nesting</li>
-                <li>Group small items into &quot;Other&quot;</li>
+                <li>Limit to 2 levels of nesting maximum</li>
+                <li>Group small items into an &quot;Other&quot; category</li>
+                <li>Set labelMinWidth/Height to avoid tiny unreadable labels</li>
+                <li>Use leaf opacity to distinguish parents from children</li>
+                <li>Use nest mode for explorable deep hierarchies</li>
               </ul>
             </div>
           </CardContent>
         </Card>
       </div>
+
+      {/* ── Understanding Cards ────────────────────────────────────────── */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Treemap Anatomy</CardTitle>
+          <CardDescription>How the squarified layout algorithm works</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm">
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-2">
+              <p className="font-medium">Squarify Algorithm</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-1">
+                <li>Items are laid out to fill the available space</li>
+                <li>Larger values get proportionally larger rectangles</li>
+                <li>aspectRatio controls how square-like rectangles are</li>
+                <li>Lower ratio = more elongated, higher = more square</li>
+              </ul>
+            </div>
+            <div className="space-y-2">
+              <p className="font-medium">Depth Levels</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-1">
+                <li><strong>Depth 0:</strong> Root container (the chart)</li>
+                <li><strong>Depth 1:</strong> Top-level categories</li>
+                <li><strong>Depth 2:</strong> Leaf items within categories</li>
+                <li>Use opacity/font to distinguish levels</li>
+              </ul>
+            </div>
+            <div className="space-y-2">
+              <p className="font-medium">Custom Content</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-1">
+                <li>The <code className="text-xs">content</code> prop replaces default rendering</li>
+                <li>Receives TreemapNode with all positioning data</li>
+                <li>Return SVG elements (rect, text, g)</li>
+                <li>Use depth to apply different styles per level</li>
+              </ul>
+            </div>
+          </div>
+          <Separator />
+          <div className="rounded border border-blue-500 bg-blue-50 dark:bg-blue-950/20 p-3 text-xs text-muted-foreground">
+            <p><strong className="text-blue-700 dark:text-blue-400">Tip:</strong> The <code className="text-xs">content</code> prop is the most powerful feature of Treemap. It receives the full TreemapNode including x, y, width, height, depth, name, value, and parent reference. Use depth to apply category colors at depth=1 and lighter shades at depth=2.</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Flat vs Nest Mode</CardTitle>
+          <CardDescription>Two rendering approaches for hierarchical data</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <p className="font-medium">Flat Mode (default)</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-1">
+                <li>All leaf nodes visible at once</li>
+                <li>Hierarchy shown via color grouping</li>
+                <li>Best for overview / at-a-glance</li>
+                <li>Custom content renderer for styling</li>
+                <li>No built-in interaction (click, drill-down)</li>
+              </ul>
+            </div>
+            <div className="space-y-2">
+              <p className="font-medium">Nest Mode</p>
+              <ul className="list-disc list-inside text-muted-foreground space-y-1">
+                <li>Click a parent to zoom into its children</li>
+                <li>Breadcrumb navigation to go back up</li>
+                <li>Use <code className="text-xs">nestIndexContent</code> for custom breadcrumbs</li>
+                <li>Use <code className="text-xs">colorPanel</code> for level-based colors</li>
+                <li>Better for deep or large hierarchies</li>
+              </ul>
+            </div>
+          </div>
+          <Separator />
+          <div className="rounded border border-amber-500 bg-amber-50 dark:bg-amber-950/20 p-3 text-xs text-muted-foreground">
+            <p><strong className="text-amber-700 dark:text-amber-400">Note:</strong> In nest mode, the custom content renderer may behave differently. The breadcrumb navigation is built-in but can be customized with <code className="text-xs">nestIndexContent</code>. Test both modes to see which fits your use case.</p>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   )
 }


### PR DESCRIPTION
…card

<!---️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x ] Enhancement (improving an existing functionality like performance)
- [x ] New feature (a non-breaking change that adds functionality)
- [ ] Refactoring (old API is revised and supported)
- [ ] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
Summary
Comprehensive upgrade of the FunnelChartPlayground, TreemapChartPlayground, and CardPlayground components to match the detailed, configurable structure established by other chart playgrounds in the demo package.

Changes
FunnelChartPlayground — Complete rewrite from ~334 → ~850 lines

4 data sources: Sales Pipeline, User Onboarding, E-commerce Checkout, Recruitment
4 settings tabs: Data, Funnel, Chart, Stages
New controls: Color mode (individual/gradient with 5 palettes), per-stage color customization, stage hide/show, conversion rate calculations, reversed, lastShapeType (triangle/rectangle), activeShape hover, stroke color + width, fixed width, legendType, labels (position + 6 content formats), dual LabelList, label fill color, animation (begin/duration/easing), tooltip indicator, legend position
6 documentation cards: Data Format, Configurable Properties, Limitations, Best Practices, Funnel Anatomy, Color Strategies
TreemapChartPlayground — Complete rewrite from 481 → ~800 lines

4 data sources: Tech Stack, Disk Usage, Company Budget, Investment Portfolio
4 settings tabs: Data, Treemap, Style, Chart
New controls: type (flat/nest), aspectRatio with presets, custom content renderer with depth-aware styling, label content format (name/value/name-value/percent), label min-size thresholds, per-category color picker, category hide/show, leaf opacity, stroke color + width, animation (begin/duration/easing), update animation, tooltip indicator
6 documentation cards: Data Format, Configurable Properties, Limitations, Best Practices, Treemap Anatomy, Flat vs Nest Mode
CardPlayground → KPI Card Playground — Complete rewrite from 710 → ~850 lines, focused on dashboard KPI widget

6 KPI presets: Revenue, Active Users, Conversion Rate, Total Orders, System Uptime, Page Views
4 settings tabs: Data, Trend, Visual, Card
New controls: 5 value formats (number/currency/percent/compact/custom) with prefix/suffix/decimals, 3 trend styles (icon-text/arrow/badge) with auto or custom color, 10 lucide icon options with position/style/bg-opacity, 10 badge variants, 4 footer styles (text/progress/sparkline/comparison), loading skeleton state, compact mode, border accent (left/top) with color, shadow levels, hover effect, value font size (SM–XL)
6 documentation cards: KPI Card Structure, Configurable Properties, Card Styling, Badge Variants, Limitations, Best Practices


## Related issue

<!-- Please ensure there is an open issue and mention it's number as #123 -->

- Fixes # (issue)
- Closes # (issue)
- Related # (issue)

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- _We encourage you to keep the code coverage percentage at 80% and above._ -->

- [ ] I have linked an **issue** or **discussion**;
- [ ] I have updated the **documentation** accordingly;
- [ ] I have added or updated **tests** to cover my changes;
- [ x] I have performed a **self-review** of my code;
- [ x] My code follows the style **guidelines** of this project;
- [ x] My changes generate no new **warnings**.
