### PR TITLE
feat(theme) : add white-label theme with 20 nav variants PLTFRM-87974

### DIFF
--- a/packages/demo/src/components/ThemeSwitcherDemo.tsx
+++ b/packages/demo/src/components/ThemeSwitcherDemo.tsx
@@ -47,6 +47,7 @@ export function ThemeSwitcherDemo() {
           >
             <option value="acronis-default">Acronis Default</option>
             <option value="acronis-ocean">Acronis Ocean</option>
+            <option value="acronis-white-label">Acronis White Label</option>
           </select>
         </div>
 

--- a/packages/demo/src/constants/playground/predefinedTokens.ts
+++ b/packages/demo/src/constants/playground/predefinedTokens.ts
@@ -570,11 +570,72 @@ export const ACRONIS_TOKEN_SET: TokenSet = {
 }
 
 /**
+ * Acronis White Label theme (neutral slate)
+ */
+export const WHITE_LABEL_TOKEN_SET: TokenSet = {
+  id: 'white-label',
+  name: 'White Label',
+  description: 'Neutral slate white-label theme',
+  light: {
+    background: createToken(0, 0, 100),
+    foreground: createToken(215, 26, 20),
+    card: createToken(0, 0, 100),
+    cardForeground: createToken(215, 26, 20),
+    popover: createToken(0, 0, 100),
+    popoverForeground: createToken(215, 26, 20),
+    primary: createToken(210, 16, 32),
+    primaryForeground: createToken(0, 0, 100),
+    secondary: createToken(0, 0, 100),
+    secondaryForeground: createToken(215, 26, 46),
+    muted: createToken(240, 6, 97),
+    mutedForeground: createToken(215, 26, 46),
+    accent: createToken(210, 16, 32),
+    accentForeground: createToken(0, 0, 100),
+    destructive: createToken(0, 77, 57),
+    destructiveForeground: createToken(0, 0, 100),
+    border: createToken(210, 8, 85),
+    input: createToken(210, 8, 85),
+    ring: createToken(210, 16, 32),
+  },
+  dark: {
+    background: createToken(215, 26, 20),
+    foreground: createToken(0, 0, 100),
+    card: createToken(210, 10, 23),
+    cardForeground: createToken(0, 0, 100),
+    popover: createToken(210, 10, 23),
+    popoverForeground: createToken(0, 0, 100),
+    primary: createToken(210, 16, 50),
+    primaryForeground: createToken(0, 0, 100),
+    secondary: createToken(210, 10, 30),
+    secondaryForeground: createToken(0, 0, 70),
+    muted: createToken(210, 10, 30),
+    mutedForeground: createToken(0, 0, 60),
+    accent: createToken(210, 16, 50),
+    accentForeground: createToken(0, 0, 100),
+    destructive: createToken(0, 77, 20),
+    destructiveForeground: createToken(0, 0, 100),
+    border: createToken(210, 10, 35),
+    input: createToken(210, 10, 35),
+    ring: createToken(210, 16, 50),
+  },
+  radius: {
+    sm: '0.25rem',
+    md: '0.375rem',
+    lg: '0.5rem',
+    xl: '0.75rem',
+    '2xl': '1rem',
+    full: '9999px',
+  },
+  typography: DEFAULT_TYPOGRAPHY,
+}
+
+/**
  * All predefined token sets
  */
 export const PREDEFINED_TOKEN_SETS: Record<string, TokenSet> = {
   acronis: ACRONIS_TOKEN_SET,
   default: DEFAULT_TOKEN_SET,
+  'white-label': WHITE_LABEL_TOKEN_SET,
   chat: ACRONIS_ELECTRIC_TOKEN_SET,
   ocean: OCEAN_TOKEN_SET,
   forest: FOREST_TOKEN_SET,

--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -11,8 +11,9 @@ const resolveAtAlias = (): Plugin => ({
       const fs = await import('fs')
       const extensions = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.mts', '.css', '.scss']
 
-      // Determine base path based on importer location
-      const isFromUikit = importer.includes('/ui/src/')
+      // Determine base path based on importer location (normalize separators for Windows)
+      const normalizedImporter = importer.replace(/\\/g, '/')
+      const isFromUikit = normalizedImporter.includes('/ui/src/')
       const basePath = isFromUikit
         ? source.replace('@/', '../ui/src/')
         : source.replace('@/', './src/')

--- a/packages/ui/src/styles/theme-acronis-white-label.scss
+++ b/packages/ui/src/styles/theme-acronis-white-label.scss
@@ -1,0 +1,9 @@
+/**
+ * Acronis White Label Theme - Standalone Entry
+ *
+ * This file is used as a build entry point to generate a separate CSS file
+ * for the Acronis White Label theme.
+ */
+
+@use './tokens/primitives';
+@use './themes/acronis-white-label';

--- a/packages/ui/src/styles/themes/acronis-white-label.scss
+++ b/packages/ui/src/styles/themes/acronis-white-label.scss
@@ -1,0 +1,423 @@
+/**
+ * Acronis White Label Theme
+ *
+ * A neutral, slate-toned theme for white-label deployments.
+ * Uses a desaturated palette based on #44515E as the brand primary.
+ * It includes both light and dark mode variants.
+ */
+
+@mixin theme-acronis-white-label {
+  /* ============================================
+     PRIMITIVE TOKENS - WHITE LABEL
+     ============================================ */
+
+  /* Brand Colors - From Figma: Layout/brand-* */
+  --color-brand-primary: 210 16% 32%; /* #44515E - av-brand-primary, av-fixed-button */
+  --color-brand-secondary: 213 65% 46%; /* #2668C5 - av-fixed-link (Acronis blue for links) */
+  --color-brand-lightest: 240 6% 97%; /* #F6F6F7 - av-solid-brand-lightest */
+  --color-brand-light: 210 8% 80%; /* rgba(68,81,94,0.30) on white - av-brand-light */
+  --color-brand-accent: 200 9% 93%; /* #ECEEEF - av-solid-brand-accent */
+
+  /* Text Colors - From Figma: Text/fixed-* */
+  --color-text-inverse: 0 0% 100%;
+  --color-text-primary: 215 26% 20%; /* #243143 - Text/fixed-primary */
+  --color-text-secondary: 215 26% 46%; /* Text/fixed-secondary */
+  --color-text-tertiary: 215 14% 39%; /* #5C6673 - Text/fixed-tertiary */
+
+  /* Surface Colors - From Figma */
+  --color-surface-primary: 0 0% 100%; /* #FFFFFF */
+  --color-surface-overlay: 215 26% 20%; /* #243143 - For tooltips, overlays */
+  --color-surface-elevated: 0 0% 100%; /* #FFFFFF - For cards, popovers */
+
+  /* Status Colors - From Figma: Status/fixed-* */
+  --color-status-success: 73 68% 45%; /* #9BC225 - Status/fixed-success */
+  --color-status-success-light: 84 67% 93%; /* #F5F9E9 - Status/fixed-success-accent */
+  --color-status-success-dark: 84 98% 21%; /* #407009 - Status/fixed-success-dark */
+
+  --color-status-info: 211 82% 60%; /* #408BEA - Status/fixed-info */
+  --color-status-info-light: 214 78% 95%; /* #ECF3FD - Status/fixed-info-accent */
+  --color-status-info-dark: 214 68% 38%; /* #1F56A2 - Status/fixed-info-dark */
+
+  --color-status-warning: 45 100% 52%; /* #FFC107 - Status/fixed-warning */
+  --color-status-warning-light: 45 100% 95%; /* #FFF9E6 - Status/fixed-warning-accent */
+  --color-status-warning-dark: 30 50% 37%; /* #8E5E2F - Status/fixed-warning-dark */
+
+  --color-status-danger: 0 77% 57%; /* #EA3939 - Status/fixed-danger */
+  --color-status-danger-light: 0 100% 96%; /* #FFECEC - Status/fixed-danger-accent */
+  --color-status-danger-dark: 0 72% 45%; /* #C62020 - Status/fixed-danger-dark */
+
+  --color-status-critical: 25 100% 52%; /* #FF810D - Status/fixed-critical */
+  --color-status-critical-light: 27 95% 92%; /* #FEEDD9 - Status/fixed-critical-accent */
+  --color-status-critical-dark: 11 73% 41%; /* #B5381C - Status/fixed-critical-dark */
+
+  /* Neutral Colors - From Figma: Status/fixed-neutral */
+  --color-neutral: 220 11% 62%; /* #949AA3 - Status/fixed-neutral */
+  --color-neutral-light: 220 11% 92%; /* #E9EAEC - Status/fixed-neutral-accent */
+  --color-neutral-dark: 215 14% 39%; /* #5C6673 - Status/fixed-neutral-dark */
+
+  /* AI Colors */
+  --color-ai: 263deg 77% 57%;
+  --color-ai-light: 273deg 85% 97%;
+  --color-ai-dark: 263deg 77% 57%;
+
+  /* Opacity Modifiers - For creating translucent variants */
+  --opacity-10: 0.1;
+  --opacity-20: 0.2;
+  --opacity-30: 0.3;
+  --opacity-40: 0.4;
+  --opacity-50: 0.5;
+  --opacity-70: 0.7;
+  --opacity-90: 0.9;
+
+  /* ============================================
+     SEMANTIC TOKENS - LIGHT MODE
+     ============================================ */
+
+  /* Backgrounds */
+  --av-background: var(--color-surface-primary);
+  --av-elevated: var(--color-surface-elevated);
+  --av-card: var(--av-elevated);
+  --av-muted: var(--color-brand-lightest);
+  --av-primary: var(--color-brand-primary);
+  --av-accent: var(--color-brand-primary);
+  --av-secondary: var(--color-surface-elevated);
+  --av-destructive: var(--color-status-danger);
+  --av-destructive-foreground: var(--color-text-inverse);
+  --av-danger: var(--color-status-danger);
+  --av-success: var(--color-status-success);
+  --av-warning: var(--color-status-warning);
+  --av-info: var(--color-status-info);
+  --av-critical: var(--color-status-critical);
+  --av-neutral: var(--color-status-neutral);
+  --av-popover: var(--av-elevated);
+  --av-tooltip: var(--color-surface-overlay);
+
+  /* Text / Foreground */
+  --av-foreground: var(--color-text-primary);
+  --av-text-primary: var(--color-text-primary);
+  --av-card-foreground: var(--color-text-primary);
+  --av-popover-foreground: var(--color-text-primary);
+  --av-primary-foreground: var(--color-text-inverse);
+  --av-muted-foreground: var(--color-text-secondary);
+  --av-secondary-foreground: var(--color-text-secondary);
+  --av-tertiary-foreground: var(--color-text-tertiary);
+  --av-accent-foreground: var(--color-text-inverse);
+  --av-text-inverse: var(--color-surface-primary);
+  --av-brand-foreground: var(--color-brand-primary);
+
+  /* Borders */
+  --av-border: 210 8% 85%;
+  --av-separator: 210 8% 85%;
+  --av-input: 210 8% 85%;
+  --av-border-strong: var(--color-brand-primary);
+  --av-border-subtle: 210 6% 92%;
+
+  /* Fixed Link — Acronis blue link color + light variant */
+  --av-fixed-link: var(--color-brand-secondary); /* #2668C5 */
+  --av-fixed-link-light: 215 58% 84%; /* rgba(38,104,197,0.30) on white → #BED2EE */
+
+  /* Interactive Elements - From Figma: av-primary-*, av-secondary-* */
+  --av-interactive-default: var(--color-brand-primary);
+  --av-interactive-hover: 209 16% 25%; /* #36414B - av-primary-hover */
+  --av-interactive-active: 208 15% 19%; /* #293138 - av-primary-active */
+  --av-interactive-disabled: var(--color-text-tertiary);
+  --av-secondary-hover: var(--color-brand-accent); /* rgba(68,81,94,0.10) → #ECEEEF */
+  --av-secondary-active: 216 7% 86%; /* rgba(68,81,94,0.20) on white → #DADCDE */
+  --av-solid-secondary-active: 216 5% 86%; /* #DADCDF */
+  --av-ring: var(--color-brand-primary);
+  --av-focus: var(--color-brand-primary);
+
+  /* Scroll — From Figma: av-scroll-thumb-* */
+  --av-scroll-thumb: hsl(213 29% 20% / 0.40); /* rgba(36,49,67,0.40) */
+  --av-scroll-thumb-inverse: hsl(0 0% 100% / 0.40); /* rgba(255,255,255,0.40) */
+
+  /* Status Colors */
+  --av-status-success: var(--color-status-success);
+  --av-status-success-bg: var(--color-status-success-light);
+  --av-status-success-text: var(--color-status-success-dark);
+
+  --av-status-info: var(--color-status-info);
+  --av-status-info-bg: var(--color-status-info-light);
+  --av-status-info-text: var(--color-status-info-dark);
+
+  --av-status-warning: var(--color-status-warning);
+  --av-status-warning-bg: var(--color-status-warning-light);
+  --av-status-warning-text: var(--color-status-warning-dark);
+
+  --av-status-danger: var(--color-status-danger);
+  --av-status-danger-bg: var(--color-status-danger-light);
+  --av-status-danger-text: var(--color-status-danger-dark);
+
+  --av-status-critical: var(--color-status-critical);
+  --av-status-critical-bg: var(--color-status-critical-light);
+  --av-status-critical-text: var(--color-status-critical-dark);
+
+  --av-status-neutral: var(--color-neutral);
+  --av-status-neutral-bg: var(--color-neutral-light);
+  --av-status-neutral-text: var(--color-neutral-dark);
+
+  --av-status-ai: var(--color-ai);
+  --av-status-ai-bg: var(--color-ai-light);
+  --av-status-ai-text: var(--color-ai-dark);
+
+  /* Nav defaults — overridden by nav-* variant mixins */
+  --av-nav-bg: 0 0% 20%;
+  --av-nav-text: 0 0% 100%;
+  --av-nav-text-light: hsl(0 0% 100% / 0.70);
+  --av-nav-text-active: 0 0% 100%;
+  --av-nav-active: 0 0% 40%;
+
+  /* Radius */
+  --av-radius: 0.25rem;
+
+  /* Chart Colors */
+  --av-chart-1: oklch(64.6% 0.222 41.116deg);
+  --av-chart-2: oklch(60% 0.118 184.704deg);
+  --av-chart-3: oklch(39.8% 0.07 227.392deg);
+  --av-chart-4: oklch(82.8% 0.189 84.429deg);
+  --av-chart-5: oklch(76.9% 0.188 70.08deg);
+  --av-chart-blue: oklch(52.7% 0.16 257.94deg);
+  --av-chart-brown: oklch(60.6% 0.105 62.98deg);
+  --av-chart-critical: oklch(73.4% 0.184 52.786deg);
+  --av-chart-danger: oklch(61.7% 0.21 26.1deg);
+  --av-chart-green: oklch(65.4% 0.11 189deg);
+  --av-chart-grey: oklch(68.4% 0.01 257.94deg);
+  --av-chart-info: var(--av-brand-secondary);
+  --av-chart-light-blue: oklch(80.9% 0.09 240deg);
+  --av-chart-neutral: oklch(90.6% 0 257.94deg);
+  --av-chart-purple: oklch(71.4% 0.19 314.82deg);
+  --av-chart-red: oklch(66.9% 0.184 23.483deg);
+  --av-chart-success: oklch(75.9% 0.177 123.498deg);
+  --av-chart-transparent: oklch(80.9% 0.09 240deg / 50%);
+  --av-chart-turquoise: oklch(70.5% 0.13 230deg);
+  --av-chart-violet: oklch(51.5% 0.09 299deg);
+  --av-chart-warning: oklch(84.4% 0.17 84.9deg);
+  --av-chart-yellow: oklch(84% 0.14 95deg);
+}
+
+@mixin theme-acronis-white-label-dark {
+  /* ============================================
+     SEMANTIC TOKENS - DARK MODE OVERRIDES
+     ============================================ */
+
+  /* Backgrounds */
+  --av-background: var(--color-text-primary);
+  --av-elevated: 210 10% 23%;
+  --av-muted: 210 10% 30%;
+  --av-tooltip: 210 10% 25%;
+
+  /* Text */
+  --av-foreground: var(--color-surface-primary);
+  --av-text-primary: var(--color-surface-primary);
+  --av-secondary-foreground: 0 0% 70%;
+  --av-tertiary-foreground: 0 0% 60%;
+  --av-text-inverse: var(--color-text-primary);
+  --av-brand-foreground: 210 16% 60%;
+
+  /* Borders */
+  --av-border: 210 10% 35%;
+  --av-border-strong: 210 10% 40%;
+  --av-border-subtle: 210 10% 25%;
+
+  /* Interactive */
+  --av-interactive-default: 210 16% 50%;
+  --av-interactive-hover: 210 16% 42%;
+  --av-interactive-active: 210 16% 50%;
+  --av-interactive-disabled: 210 10% 40%;
+  --av-focus: 210 16% 50%;
+
+  /* Status backgrounds adjusted for better contrast */
+  --av-status-success-bg: 73 68% 20%;
+  --av-status-success-text: var(--color-status-success-light);
+  --av-status-info-bg: 211 82% 20%;
+  --av-status-info-text: var(--color-status-info-light);
+  --av-status-warning-bg: 45 100% 20%;
+  --av-status-warning-text: var(--color-status-warning-light);
+  --av-status-danger-bg: 0 77% 20%;
+  --av-status-danger-text: var(--color-status-danger-light);
+  --av-status-critical-bg: 25 100% 20%;
+  --av-status-critical-text: var(--color-status-critical-light);
+  --av-status-neutral-bg: 220 11% 25%;
+  --av-status-neutral-text: var(--color-neutral-light);
+
+  /* Chart Colors - Dark Mode */
+  --av-chart-1: oklch(48.8% 0.243 264.376deg);
+  --av-chart-2: oklch(69.6% 0.17 162.48deg);
+  --av-chart-3: oklch(76.9% 0.188 70.08deg);
+  --av-chart-4: oklch(62.7% 0.265 303.9deg);
+  --av-chart-5: oklch(64.5% 0.246 16.439deg);
+}
+
+/* ============================================
+   NAV VARIANT MIXINS
+   Each overrides --av-nav-bg, --av-nav-active, --av-nav-text
+   Usage: .theme-acronis-white-label.nav-purple { ... }
+   ============================================ */
+
+@mixin nav-purple {
+  --av-nav-bg: 233 50% 24%; /* #1E275B */
+  --av-nav-active: 234 46% 43%; /* #3A45A1 */
+  --av-nav-text: 0 0% 100%;
+}
+
+@mixin nav-brown {
+  --av-nav-bg: 14 100% 19%; /* #601800 */
+  --av-nav-active: 0 48% 44%; /* #A63A3A */
+  --av-nav-text: 0 0% 100%;
+}
+
+@mixin nav-sand {
+  --av-nav-bg: 14 17% 18%; /* #372A26 */
+  --av-nav-active: 26 34% 59%; /* #B69278 */
+  --av-nav-text: 0 0% 100%;
+}
+
+@mixin nav-light-gray {
+  --av-nav-bg: 0 0% 100%; /* #FFFFFF */
+  --av-nav-active: 202 82% 87%; /* #C3E7F9 */
+  --av-nav-text: 213 29% 20%; /* #243143 - dark text */
+  --av-nav-text-light: hsl(213 29% 20% / 0.70); /* rgba(36,49,67,0.70) */
+  --av-nav-text-active: 213 29% 20%; /* #243143 */
+  --av-scroll-thumb-inverse: hsl(213 29% 20% / 0.40); /* same as thumb on light bg */
+}
+
+@mixin nav-dark-gray {
+  --av-nav-bg: 213 29% 20%; /* #243143 */
+  --av-nav-active: 220 7% 48%; /* #717986 */
+  --av-nav-text: 0 0% 100%;
+}
+
+@mixin nav-ingram-micro {
+  --av-nav-bg: 209 29% 25%; /* #2D3F51 */
+  --av-nav-active: 209 27% 55%; /* #6C8DAC */
+  --av-nav-text: 0 0% 100%;
+}
+
+@mixin nav-red-fire-brick {
+  --av-nav-bg: 355 89% 24%; /* #73060F */
+  --av-nav-active: 357 59% 55%; /* #D5474D */
+  --av-nav-text: 0 0% 100%;
+}
+
+@mixin nav-yellow-1c {
+  --av-nav-bg: 51 96% 55%; /* #FADB1F */
+  --av-nav-active: 48 93% 48%; /* #ECC109 */
+  --av-nav-text: 213 29% 20%; /* #243143 - dark text */
+  --av-nav-text-light: hsl(213 29% 20% / 0.70); /* rgba(36,49,67,0.70) */
+  --av-nav-text-active: 213 29% 20%; /* #243143 */
+  --av-scroll-thumb-inverse: hsl(213 29% 20% / 0.40); /* same as thumb on light bg */
+}
+
+@mixin nav-deep-sky-itkontoret {
+  --av-nav-bg: 196 100% 28%; /* #00698E */
+  --av-nav-active: 199 100% 48%; /* #00ADF7 */
+  --av-nav-text: 0 0% 100%;
+}
+
+@mixin nav-blue-yellow-uss-signal {
+  --av-nav-bg: 211 73% 19%; /* #0D2F53 */
+  --av-nav-active: 44 86% 57%; /* #EFBF35 */
+  --av-nav-text: 0 0% 100%;
+}
+
+@mixin nav-red-home-pl {
+  --av-nav-bg: 0 0% 15%; /* #262626 */
+  --av-nav-active: 0 100% 44%; /* #E10000 */
+  --av-nav-text: 0 0% 100%;
+}
+
+@mixin nav-orange-tsukaeru-helpox {
+  --av-nav-bg: 0 0% 15%; /* #262626 */
+  --av-nav-active: 33 100% 47%; /* #F08200 */
+  --av-nav-text: 0 0% 100%;
+}
+
+@mixin nav-green-also-choise-df {
+  --av-nav-bg: 0 0% 15%; /* #262626 */
+  --av-nav-active: 84 84% 30%; /* #5A8D0C */
+  --av-nav-text: 0 0% 100%;
+}
+
+@mixin nav-light-blue-hp {
+  --av-nav-bg: 0 0% 15%; /* #262626 */
+  --av-nav-active: 199 93% 43%; /* #0796D5 */
+  --av-nav-text: 0 0% 100%;
+}
+
+@mixin nav-purple-fusion-media {
+  --av-nav-bg: 0 0% 15%; /* #262626 */
+  --av-nav-active: 290 32% 48%; /* #9353A1 */
+  --av-nav-text: 0 0% 100%;
+}
+
+@mixin nav-virtual-one {
+  --av-nav-bg: 199 100% 18%; /* #003E5E */
+  --av-nav-active: 200 79% 66%; /* #65BEEC */
+  --av-nav-text: 0 0% 100%;
+}
+
+@mixin nav-telstra {
+  --av-nav-bg: 0 0% 100%; /* #FFFFFF */
+  --av-nav-active: 320 72% 37%; /* #A31A75 */
+  --av-nav-text: 320 72% 37%; /* #A31A75 - brand magenta text */
+  --av-nav-text-light: hsl(213 29% 20% / 0.70); /* rgba(36,49,67,0.70) */
+  --av-nav-text-active: 0 0% 100%; /* white — differs from nav-text */
+  --av-scroll-thumb-inverse: hsl(213 29% 20% / 0.40); /* same as thumb on light bg */
+}
+
+@mixin nav-deep-purple {
+  --av-nav-bg: 292 100% 20%; /* #570066 */
+  --av-nav-active: 328 83% 54%; /* #EB2A91 */
+  --av-nav-text: 0 0% 100%;
+}
+
+@mixin nav-pinky {
+  --av-nav-bg: 329 100% 44%; /* #E20074 */
+  --av-nav-active: 338 85% 67%; /* #F3669C */
+  --av-nav-text: 0 0% 100%;
+}
+
+@mixin nav-virtuozzo {
+  --av-nav-bg: 0 0% 15%; /* #262626 */
+  --av-nav-active: 357 91% 46%; /* #DF0A17 */
+  --av-nav-text: 0 0% 100%;
+  /* Virtuozzo overrides fixed-link to match brand-primary */
+  --color-brand-secondary: 210 16% 32%; /* #44515E - same as brand-primary */
+  --av-fixed-link-light: 209 8% 80%; /* #C7CBCF - matches brand-light */
+}
+
+/* ============================================
+   THEME CLASSES
+   ============================================ */
+
+/* Base theme class — defaults to purple nav */
+.theme-acronis-white-label {
+  @include theme-acronis-white-label;
+  @include nav-purple;
+
+  &.dark {
+    @include theme-acronis-white-label-dark;
+  }
+}
+
+/* Nav variant classes — compose with .theme-acronis-white-label */
+.theme-acronis-white-label.nav-purple { @include nav-purple; }
+.theme-acronis-white-label.nav-brown { @include nav-brown; }
+.theme-acronis-white-label.nav-sand { @include nav-sand; }
+.theme-acronis-white-label.nav-light-gray { @include nav-light-gray; }
+.theme-acronis-white-label.nav-dark-gray { @include nav-dark-gray; }
+.theme-acronis-white-label.nav-ingram-micro { @include nav-ingram-micro; }
+.theme-acronis-white-label.nav-red-fire-brick { @include nav-red-fire-brick; }
+.theme-acronis-white-label.nav-yellow-1c { @include nav-yellow-1c; }
+.theme-acronis-white-label.nav-deep-sky-itkontoret { @include nav-deep-sky-itkontoret; }
+.theme-acronis-white-label.nav-blue-yellow-uss-signal { @include nav-blue-yellow-uss-signal; }
+.theme-acronis-white-label.nav-red-home-pl { @include nav-red-home-pl; }
+.theme-acronis-white-label.nav-orange-tsukaeru-helpox { @include nav-orange-tsukaeru-helpox; }
+.theme-acronis-white-label.nav-green-also-choise-df { @include nav-green-also-choise-df; }
+.theme-acronis-white-label.nav-light-blue-hp { @include nav-light-blue-hp; }
+.theme-acronis-white-label.nav-purple-fusion-media { @include nav-purple-fusion-media; }
+.theme-acronis-white-label.nav-virtual-one { @include nav-virtual-one; }
+.theme-acronis-white-label.nav-telstra { @include nav-telstra; }
+.theme-acronis-white-label.nav-deep-purple { @include nav-deep-purple; }
+.theme-acronis-white-label.nav-pinky { @include nav-pinky; }
+.theme-acronis-white-label.nav-virtuozzo { @include nav-virtuozzo; }

--- a/packages/ui/src/styles/themes/index.scss
+++ b/packages/ui/src/styles/themes/index.scss
@@ -12,3 +12,4 @@
 @use 'acronis-default';
 @use 'acronis-ocean';
 @use 'acronis-electric';
+@use 'acronis-white-label';

--- a/packages/ui/src/utils/theme-switcher.ts
+++ b/packages/ui/src/utils/theme-switcher.ts
@@ -6,12 +6,20 @@
  * color mode switching (light/dark).
  */
 
-export type ThemeName = 'acronis-default' | 'acronis-ocean' | 'cyber-chat' | 'custom'
+export type ThemeName = 'acronis-default' | 'acronis-ocean' | 'acronis-white-label' | 'cyber-chat' | 'custom'
+export type WhiteLabelNavVariant =
+  | 'purple' | 'brown' | 'sand' | 'light-gray' | 'dark-gray'
+  | 'ingram-micro' | 'red-fire-brick' | 'yellow-1c' | 'deep-sky-itkontoret'
+  | 'blue-yellow-uss-signal' | 'red-home-pl' | 'orange-tsukaeru-helpox'
+  | 'green-also-choise-df' | 'light-blue-hp' | 'purple-fusion-media'
+  | 'virtual-one' | 'telstra' | 'deep-purple' | 'pinky' | 'virtuozzo'
 export type ColorMode = 'light' | 'dark' | 'system'
 
 const THEME_CLASS_PREFIX = 'theme-'
+const NAV_CLASS_PREFIX = 'nav-'
 const DARK_CLASS = 'dark'
 const THEME_STORAGE_KEY = 'av-theme'
+const NAV_VARIANT_STORAGE_KEY = 'av-nav-variant'
 const COLOR_MODE_STORAGE_KEY = 'av-color-mode'
 
 /**
@@ -29,16 +37,25 @@ const COLOR_MODE_STORAGE_KEY = 'av-color-mode'
  */
 export function applyTheme(theme: ThemeName, persist = true): void {
   const root = document.documentElement
-  
+
   root.classList.forEach((className) => {
     if (className.startsWith(THEME_CLASS_PREFIX)) {
       root.classList.remove(className)
     }
   })
-  
+
+  // Remove nav variant classes when switching away from white-label
+  if (theme !== 'acronis-white-label') {
+    root.classList.forEach((className) => {
+      if (className.startsWith(NAV_CLASS_PREFIX)) {
+        root.classList.remove(className)
+      }
+    })
+  }
+
   const themeClass = `${THEME_CLASS_PREFIX}${theme}`
   root.classList.add(themeClass)
-  
+
   if (persist) {
     try {
       localStorage.setItem(THEME_STORAGE_KEY, theme)
@@ -49,8 +66,58 @@ export function applyTheme(theme: ThemeName, persist = true): void {
 }
 
 /**
+ * Apply a white-label nav variant to the document root element
+ * Only effective when the white-label theme is active.
+ *
+ * @param variant - The nav variant name to apply
+ * @param persist - Whether to persist the choice to localStorage (default: true)
+ *
+ * @example
+ * ```typescript
+ * applyTheme('acronis-white-label')
+ * applyNavVariant('ingram-micro')
+ * ```
+ */
+export function applyNavVariant(variant: WhiteLabelNavVariant, persist = true): void {
+  const root = document.documentElement
+
+  root.classList.forEach((className) => {
+    if (className.startsWith(NAV_CLASS_PREFIX)) {
+      root.classList.remove(className)
+    }
+  })
+
+  root.classList.add(`${NAV_CLASS_PREFIX}${variant}`)
+
+  if (persist) {
+    try {
+      localStorage.setItem(NAV_VARIANT_STORAGE_KEY, variant)
+    } catch (error) {
+      console.warn('Failed to persist nav variant to localStorage:', error)
+    }
+  }
+}
+
+/**
+ * Get the currently applied nav variant
+ *
+ * @returns The current nav variant name or null if none is set
+ */
+export function getCurrentNavVariant(): WhiteLabelNavVariant | null {
+  const root = document.documentElement
+
+  for (const className of root.classList) {
+    if (className.startsWith(NAV_CLASS_PREFIX)) {
+      return className.replace(NAV_CLASS_PREFIX, '') as WhiteLabelNavVariant
+    }
+  }
+
+  return null
+}
+
+/**
  * Get the currently applied theme
- * 
+ *
  * @returns The current theme name or null if no theme is explicitly set
  */
 export function getCurrentTheme(): ThemeName | null {

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -55,6 +55,10 @@ export default defineConfig({
           __dirname,
           'src/styles/theme-acronis-electric.scss'
         ),
+        'themes/acronis-white-label': resolve(
+          __dirname,
+          'src/styles/theme-acronis-white-label.scss'
+        ),
       },
       formats: ['es'],
       fileName: (format, entryName) => `${entryName}.js`,


### PR DESCRIPTION
Add acronis-white-label theme supporting partner-specific nav color schemes. The base theme uses a neutral slate palette with shared brand, interactive, scroll, and fixed-link tokens. Each of the 20 nav variants (purple, brown, sand, light-gray, dark-gray, ingram-micro, red-fire-brick, yellow-1c, deep-sky-itkontoret, blue-yellow-uss-signal, red-home-pl, orange-tsukaeru-helpox, green-also-choise-df, light-blue-hp, purple-fusion-media, virtual-one, telstra, deep-purple, pinky, virtuozzo) is applied via a composable CSS class (e.g. .theme-acronis-white-label.nav-ingram-micro).