### PR TITLE
fix(ui): ship drawer.d.ts by declaring @radix-ui/react-dialog as a direct dep

### DIFF
--- a/.changeset/drawer-types.md
+++ b/.changeset/drawer-types.md
@@ -1,0 +1,15 @@
+---
+"@acronis-platform/shadcn-uikit": patch
+---
+
+Fix: `dist/components/ui/drawer.d.ts` now ships with the published
+tarball. Previously, `vite-plugin-dts` failed with TS2742 ("inferred type
+cannot be named") on six of the ten drawer exports because their types
+reach into `@radix-ui/react-dialog` (vaul's underlying primitive), which
+wasn't a declared dependency of the package — so the emitter had no
+portable specifier for the type imports.
+
+Adding `@radix-ui/react-dialog` as a direct dependency gives the `.d.ts`
+emitter a portable path. No source changes; the runtime tarball is
+identical. Consumers using `<Drawer />`, `<DrawerTrigger />`,
+`<DrawerContent />`, etc. now get full type information.

--- a/packages/legacy/ui/package.json
+++ b/packages/legacy/ui/package.json
@@ -92,6 +92,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "catalog:",
+    "@radix-ui/react-dialog": "1.1.15",
     "@radix-ui/react-navigation-menu": "1.2.14",
     "@radix-ui/react-slot": "1.2.4",
     "@tanstack/react-table": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,6 +357,9 @@ importers:
       '@hookform/resolvers':
         specifier: 'catalog:'
         version: 3.9.1(react-hook-form@7.69.0(react@19.2.6))
+      '@radix-ui/react-dialog':
+        specifier: 1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-navigation-menu':
         specifier: 1.2.14
         version: 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)


### PR DESCRIPTION
> **Depends on #52** ([refactor: establish pnpm monorepo foundations](https://github.com/acronis/shadcn-uikit/pull/52)). This branch was cut from `refactor/monorepo-foundations`; until #52 merges, this PR's diff will include all of #52's commits. The substantive change here is **one line** in `packages/legacy/ui/package.json` plus the matching lockfile and changeset entries. Reviewers can filter the "Files changed" view to `packages/legacy/ui/package.json`, `pnpm-lock.yaml`, and `.changeset/drawer-types.md`, or wait for #52 to land and the diff will narrow automatically.

## Why this PR exists

Consumers of `@acronis-platform/shadcn-uikit` who use the `<Drawer />` family of components get no type information today. `dist/components/ui/drawer.d.ts` is missing from the published tarball — verified against the live `0.36.1` artifact on npm. The build emits a JS bundle for drawer but silently drops the matching `.d.ts` because `vite-plugin-dts` errors out with TS2742 ("inferred type cannot be named") on six of the ten exports.

This was surfaced during the monorepo restructure (PR #52) when the full `pnpm -r build` was exercised end-to-end and the TS2742 output became visible. The bug itself predates the restructure — it ships in `0.35.0` too.

## Goal

Make `dist/components/ui/drawer.d.ts` part of the published library so consumers get proper IntelliSense, prop typing, and `tsc` checking when they import `Drawer`, `DrawerTrigger`, `DrawerContent`, etc.

## Rationale

The TS2742 errors trace to the prop types vaul re-exports from `@radix-ui/react-dialog` (e.g. `DialogPrimitive.DialogTriggerProps`). When `vite-plugin-dts` walks the inferred types to emit a `.d.ts`, it has to write an `import type { … } from '<package>'` statement for each external type. If the source package isn't a declared dependency of the workspace, there is no portable specifier the emitter can choose — pnpm's `.pnpm/<hash>/…` paths are not stable across consumer installs — so the emit fails and the `.d.ts` for that file is skipped.

`@radix-ui/react-dialog` is currently only present in this workspace transitively, via `vaul`. Declaring it as a direct dependency tells the resolver and the dts emitter that the type imports are sourced from a stable, declared package. The library already follows this pattern for the two Radix primitives it uses explicitly (`@radix-ui/react-slot`, `@radix-ui/react-navigation-menu` are both direct deps).

Alternatives considered:

- **Hand-rolling the prop types in `drawer.tsx`** — would lose fidelity to vaul's actual types, requires the author to track upstream changes, and clutters the source file.
- **Importing prop types as named exports from `vaul`** — vaul only exports `ContentProps` and `HandleProps` as named types; the others (Trigger, Close, Overlay, Title, Description) are not exposed.
- **Marking `@radix-ui/react-dialog` as a peer dep** — would force every consumer to install it themselves, which is heavier than declaring it as a regular dep where it costs nothing extra (vaul already pulls it in).

The chosen fix is one line in `packages/legacy/ui/package.json` and zero changes to `drawer.tsx`. The runtime tarball is byte-identical to `0.36.1` — only the `.d.ts` output changes.

## What changed

- `packages/legacy/ui/package.json` — added `"@radix-ui/react-dialog": "1.1.15"` to `dependencies`. Exact pinning matches the style of the two existing `@radix-ui/*` direct deps.
- `pnpm-lock.yaml` — three lines added (the new declared resolution; vaul's transitive resolution was already at the same version, so no duplicate install).
- `.changeset/drawer-types.md` — patch bump.

No source-code changes.

## Risk

Low. The change is additive — no existing imports break, no API surface changes, the bundled JS is identical. The only consumer-visible effect is that the published tarball now contains `dist/components/ui/drawer.d.ts`, which TypeScript will pick up automatically.

If a consumer previously worked around the missing types (e.g. by adding their own `.d.ts` shim or `// @ts-ignore` on drawer imports), they can remove that workaround after upgrading.

## Verification

Local checks all green on this branch:

- [x] `pnpm --filter @acronis-platform/shadcn-uikit build` completes with no TS2742 errors.
- [x] `dist/components/ui/drawer.d.ts` is present and includes all ten exports (`Drawer`, `DrawerPortal`, `DrawerOverlay`, `DrawerTrigger`, `DrawerClose`, `DrawerContent`, `DrawerHeader`, `DrawerFooter`, `DrawerTitle`, `DrawerDescription`).
- [x] `pnpm --filter @acronis-platform/shadcn-uikit typecheck` passes.
- [x] `pnpm --filter @acronis-platform/shadcn-uikit test` — 42 tests pass.
- [x] `pnpm --filter @acronis-platform/shadcn-uikit lint` — 0 errors (10 pre-existing warnings unchanged).
- [x] `pnpm install --frozen-lockfile` clean.

CI should mirror that.

## Notes on stacking

This PR is the first of the follow-up items tracked in `TO-DO.md` (the larger roadmap of pre-existing issues surfaced during the monorepo restructure). It is stacked on PR #52 because it depends on the new monorepo paths and the `packages/legacy/ui/` layout introduced there.

Because both PRs are opened from a fork (`heygabecom`) targeting `acronis:main`, GitHub doesn't let us set this PR's base to the parent branch — the base branch must exist in the target repo. The practical effect: this PR's commit list and diff will overlap with #52's until #52 lands, at which point the overlap clears and only the drawer fix remains. Once #52 merges, this PR's diff will narrow automatically with no rebase needed; if a rebase IS needed (e.g. review-fix commits on #52 change file contents this PR touches), I'll handle it with `git rebase --onto origin/main refactor/monorepo-foundations` and `git push --force-with-lease`.
