### PR TITLE
chore(ts): extract shared compiler options into tsconfig.base.json

### DIFF
--- a/apps/demo/tsconfig.json
+++ b/apps/demo/tsconfig.json
@@ -5,8 +5,6 @@
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
     "strict": false,

--- a/apps/demo/tsconfig.json
+++ b/apps/demo/tsconfig.json
@@ -11,7 +11,6 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@acronis-platform/shadcn-uikit": [

--- a/apps/demo/tsconfig.json
+++ b/apps/demo/tsconfig.json
@@ -1,11 +1,9 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/apps/demos/tsconfig.json
+++ b/apps/demos/tsconfig.json
@@ -1,11 +1,9 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "strict": true,
-    "skipLibCheck": true,
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/apps/demos/tsconfig.json
+++ b/apps/demos/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
     "strict": true,
     "paths": {

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": true,
     "strict": true,
     "noEmit": true,

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -7,8 +7,6 @@
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
     "typeRoots": ["./node_modules/@types"],

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -1,14 +1,12 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
-    "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/packages/legacy/ui/tsconfig.json
+++ b/packages/legacy/ui/tsconfig.json
@@ -1,11 +1,9 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/packages/legacy/ui/tsconfig.json
+++ b/packages/legacy/ui/tsconfig.json
@@ -11,7 +11,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/packages/legacy/ui/tsconfig.json
+++ b/packages/legacy/ui/tsconfig.json
@@ -5,8 +5,6 @@
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
     "strict": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
> **Depends on #52** ([refactor: relocate UI library to packages/legacy/ui](https://github.com/acronis/uikit/pull/52)). Cut from `refactor/monorepo-foundations` so PR-A's 3 commits are in this branch's history. After #52 lands, this PR's diff narrows to **5 tsconfig files**, +15 / −21 lines (net −6 — base config is shorter than 4× duplicated blocks).

## Why this PR exists

Across the four workspaces, the TypeScript compiler options have **silent drift**:

- `module`, `moduleResolution`, `skipLibCheck` — declared identically in all 4 workspaces.
- `isolatedModules`, `resolveJsonModule` — declared in 3 workspaces; missing in 1 (silently defaults to `false`).
- `lib` — declared with mixed casing across workspaces (`ESNext` vs `esnext`, `DOM` vs `dom`). TypeScript is case-insensitive here so it works, but it's noisy.
- `baseUrl: "."` — declared in `packages/legacy/ui/tsconfig.json` and `apps/demo/tsconfig.json`. **Deprecated in TS 5.x, will be removed in TS 7.0** per the TS roadmap.

Every change to a shared compiler option means touching 4 files. Drift creeps in. With TS 5.9.3 (the version the lib + apps will be on post-catalog) issuing deprecation warnings about `baseUrl`, it's time to consolidate.

## Goal

Introduce a single `tsconfig.base.json` at the repo root containing the compiler options that are identical (or safely promotable to identical) across every workspace. Each workspace's `tsconfig.json` adds `"extends": "../../tsconfig.base.json"` (or `"../../../tsconfig.base.json"` for the deeper-nested lib) and removes the now-redundant duplicates.

## Rationale

**Why a single base config and not multiple shared configs.** Considered:

- **One shared base** (chosen) — simplest, minimum surface area, easy to reason about. The shared options are genuinely shared.
- **A `tsconfig.lib.json` and a `tsconfig.app.json`** — common pattern. Rejected because we only have one published library; the duplication is minimal. Easy to refactor later if a second lib appears.
- **No base, leave drift** — defers the problem; doesn't address `baseUrl` deprecation.

**What's in the base, what's NOT.**

- **In:** `module: "ESNext"`, `moduleResolution: "bundler"`, `skipLibCheck: true`, `isolatedModules: true`, `resolveJsonModule: true`.
- **Out (intentionally workspace-specific):** `target`, `lib`, `jsx`, `strict`, `paths`, `outDir`, `rootDir`, `noEmit`, `allowImportingTsExtensions`. These differ per workspace by design (e.g. `apps/docs` uses `jsx: "preserve"` for Next.js; `apps/demo` has its own `paths` map; library has `outDir: "dist"`, apps have `noEmit: true`).

**Why drop `baseUrl: "."`.** Per [TS 5.0 release notes](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#deprecations-and-default-changes) and the [TS roadmap](https://github.com/microsoft/TypeScript/wiki/Roadmap), `baseUrl` is deprecated and slated for removal in TS 7.0. When `baseUrl` is absent, `paths` entries resolve **relative to the tsconfig file** instead of to `baseUrl` — semantically equivalent for path-mapped imports. Existing `paths` entries in `apps/demo/tsconfig.json` and `packages/legacy/ui/tsconfig.json` use `./src/*`-style relative values, which resolve correctly without `baseUrl`.

**One known consequence of dropping `baseUrl` — documented in Risk below:** two import statements in `apps/demo/src/types/playground/state.ts` use **bare-path** imports (`'src/types/playground/theme.ts'`) that relied on `baseUrl: "."` to resolve from project root. Without `baseUrl`, TypeScript can't resolve them. Switching the two lines to relative imports (`'./theme.ts'`) is a 2-line fix; it lives in the paused PR #55 and lands when that PR re-opens. **CI does not typecheck `apps/demo` today** so this regression isn't visible in CI; it's only seen if you run `pnpm --filter @acronis-platform/shadcn-uikit-demo typecheck` locally.

## What changed

Four commits, each its own small concern (kept as separate commits for readable git history; squash-merge will collapse them):

1. **`chore(ts): extract shared TypeScript compiler options into tsconfig.base.json`** (`937b4bf`) — Creates `tsconfig.base.json` with `module`, `moduleResolution`, `skipLibCheck`. Each workspace `tsconfig.json` gains `"extends": "..."` and drops the three options.

2. **`chore(ts): promote isolatedModules + resolveJsonModule into tsconfig.base.json`** (`e591fc6`) — Adds these two options to the base. Three workspaces already had them; the fourth gains them implicitly via extends. No behavior change.

3. **`chore(ts): unify lib casing across workspaces (PascalCase)`** (`4421a56`) — Normalises `lib` array entries to PascalCase (`ESNext`, `DOM`, `DOM.Iterable`). Cosmetic.

4. **`chore(tsconfig): drop deprecated baseUrl`** (`5f5077b`) — Removes `"baseUrl": "."` from `apps/demo/tsconfig.json` and `packages/legacy/ui/tsconfig.json`. See Risk for the one fallout.

## Risk

**Low — config-only changes. No source-code edits in this PR.**

- **Lib builds and ships unchanged.** `pnpm pack` produces an identical tarball — the consolidation is purely about how compiler options are *declared*, not what they are.
- **`apps/demo/src/types/playground/state.ts` regresses on typecheck** because two bare-path imports relied on `baseUrl`. CI doesn't run apps/demo typecheck today, so this is invisible to the CI gate. The 2-line fix (`'src/types/playground/theme.ts'` → `'./theme.ts'`, same for `tokens.ts`) is queued in paused PR #55 and lands when that PR re-opens. **Not a consumer-facing regression** — apps/demo is private.
- **No other typecheck or build changes observed** across the four workspaces.

**Rollback path**: single revert restores all four `tsconfig.json` files to their pre-PR state and removes `tsconfig.base.json`.

## Verification

All run on a clean checkout of this branch:

- [x] `pnpm install --frozen-lockfile` — clean.
- [x] `pnpm -r lint` — 0 errors, 84 warnings (pre-existing baseline; unchanged).
- [x] `pnpm --filter @acronis-platform/shadcn-uikit run type-check` — passes.
- [x] `pnpm --filter @acronis-platform/shadcn-uikit run test --run` — **42 / 42 passing**.
- [x] `pnpm -r build` — all four workspaces build successfully.
- [x] **Tarball**: identical to `refactor/monorepo-foundations`'s output (compiler options consolidation doesn't change emitted code).
- [⚠️] `pnpm --filter @acronis-platform/shadcn-uikit-demo run type-check` — fails on the 2 bare-path imports in `state.ts`. Fix is in paused PR #55. Not gating CI.

## Notes on stacking

Cross-fork PR opened from `heygabecom:chore/tsconfig-base` to `acronis:main`. Cut from `refactor/monorepo-foundations` so the workspace paths exist. Independent of every other split PR.