### PR TITLE
feat(design-tokens): sync tokens from Figma; add component/button/icon group

### DIFF
--- a/.changeset/design-tokens-figma-sync.md
+++ b/.changeset/design-tokens-figma-sync.md
@@ -35,6 +35,12 @@ link.strong-underline}` (5).
 - Typography: `note.default` / `note.heading` now alias `{font.font-size.11}`
   instead of an inline `11px`; `headings.display` letter-spacing refreshed.
 
+**Changed metadata**
+
+- `units.stroke.3` Figma scope changed from `STROKE_FLOAT` to **`EFFECT_FLOAT`**
+  only (`$extensions.com.figma.scopes`). The token value is unchanged; this only
+  affects which Figma properties the variable is offered for.
+
 **Removed / renamed (breaking for consumers of the old paths)**
 
 These paths no longer exist in Figma. Most are renames — migrate references:

--- a/.changeset/design-tokens-figma-sync.md
+++ b/.changeset/design-tokens-figma-sync.md
@@ -37,9 +37,10 @@ link.strong-underline}` (5).
 
 **Changed metadata**
 
-- `units.stroke.3` Figma scope changed from `STROKE_FLOAT` to **`EFFECT_FLOAT`**
-  only (`$extensions.com.figma.scopes`). The token value is unchanged; this only
-  affects which Figma properties the variable is offered for.
+- `units.stroke.3` is now scoped to **`EFFECT_FLOAT`** only
+  (`$extensions.com.figma.scopes`); previously it also carried `STROKE_FLOAT`.
+  The token value is unchanged — this only affects which Figma properties the
+  variable is offered for.
 
 **Removed / renamed (breaking for consumers of the old paths)**
 

--- a/.changeset/design-tokens-figma-sync.md
+++ b/.changeset/design-tokens-figma-sync.md
@@ -1,0 +1,54 @@
+---
+'@acronis-platform/design-tokens': minor
+---
+
+Full Figma → tokens re-sync. Regenerated `primitives.json`, `semantic.json`, and
+`components.json` from the current Figma state via the documented sync workflow
+(`context/figma-sync.md`). The JSON now mirrors Figma exactly; removed/renamed
+paths were accepted rather than aliased.
+
+**Added**
+
+- `components.button.icon.*` (16) — new icon-button color group: `background` /
+  `border` / `icon` / `label` × `idle` / `hover` / `active` / `disabled`,
+  mirroring the `ghost` group. (Backs the Figma `ButtonIcon` component, which was
+  rebound to these variables.)
+- `components.switch.*` (16) — switch promoted to its own top-level component
+  (`background` / `border` / `circle` states + `units.*`), moved out of `form`.
+- `components.item.*` (~30) — expanded successor to `sub-item` (adds `gap-x` /
+  `gap-y`, `height-min`, `padding-x-small`).
+- `components.form.{background,border,icon,circle,units}.*` (~30) — restructured
+  form tokens with a sized scale (`sm` / `md` / `lg` / `xlg`).
+- `colors.focus.{brand,error,primary,secondary}` (4) — new focus-ring colors.
+- `typography.{body.form-label, link.default, link.default-underline, link.strong,
+link.strong-underline}` (5).
+
+**Changed values**
+
+- **`brand-b` is now authored (teal).** 25 `semantic.colors.*` tokens flipped
+  their `brand-b` mode from `{palette.blue.*}` to `{palette.teal.*}`; the
+  `acronis` mode is unchanged. Previously `brand-b` mirrored `acronis`; designers
+  have now given it its own palette. This also refreshes 29 `components.button.*`
+  values that alias those semantics.
+- `palette.blue.7` dark-mode lightness `45.1 → 54.9` (light mode unchanged).
+- `button._global.padding-x` and `button._global.radius` updated.
+- Typography: `note.default` / `note.heading` now alias `{font.font-size.11}`
+  instead of an inline `11px`; `headings.display` letter-spacing refreshed.
+
+**Removed / renamed (breaking for consumers of the old paths)**
+
+These paths no longer exist in Figma. Most are renames — migrate references:
+
+- `form.input.*` → `form.background` / `form.border` / `form.icon.*` (same values).
+- `form.switch.*` → top-level `switch.*` (same values).
+- `form._global.*` → `form.units.*` — not 1:1; single values replaced by the
+  sized scale (e.g. height `32` → `units.height-lg` `48`, radius `4` →
+  `units.radius-lg` `24`).
+- `sub-item.*` → `item.*` (values largely identical; some `brand-b` values differ
+  due to teal authoring).
+- `typography.body.link`, `typography.body.strong-underlined`,
+  `typography.link.primary`, `typography.link.secondary` → renamed under
+  `typography.link.{default,default-underline,strong,strong-underline}`.
+
+No successor (genuinely dropped): `sub-item.gap` (split into `item.gap-x` /
+`item.gap-y`), `sub-item.height-header`, `sub-item.width-collapsed`.

--- a/packages/design-tokens/tokens/components.json
+++ b/packages/design-tokens/tokens/components.json
@@ -104,7 +104,7 @@
         "$type": "dimension",
         "values": {
           "acronis": "{units.gap.12}",
-          "brand-b": "{units.gap.12}"
+          "brand-b": "{units.gap.16}"
         },
         "platforms": ["PD"],
         "$extensions": {
@@ -128,7 +128,7 @@
         "$type": "dimension",
         "values": {
           "acronis": "{units.radius.4}",
-          "brand-b": "{units.radius.999}"
+          "brand-b": "{units.radius.8}"
         },
         "platforms": ["PD"],
         "$extensions": {
@@ -155,10 +155,7 @@
           "$type": "color",
           "values": {
             "acronis": "{colors.background.brand.secondary}",
-            "brand-b": {
-              "colorSpace": "hsl",
-              "components": [12.82, 84.52, 30.39]
-            }
+            "brand-b": "{palette.teal.2}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -170,7 +167,7 @@
           "$type": "color",
           "values": {
             "acronis": "{colors.background.brand.secondary-hover}",
-            "brand-b": "{colors.background.brand.secondary-hover}"
+            "brand-b": "{palette.teal.3}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -182,7 +179,7 @@
           "$type": "color",
           "values": {
             "acronis": "{colors.background.brand.secondary-active}",
-            "brand-b": "{colors.background.brand.secondary-active}"
+            "brand-b": "{palette.teal.4}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -194,7 +191,7 @@
           "$type": "color",
           "values": {
             "acronis": "{colors.background.brand.secondary-disabled}",
-            "brand-b": "{colors.background.brand.secondary-disabled}"
+            "brand-b": "{palette.teal.0}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -212,11 +209,7 @@
               "colorSpace": "hsl",
               "components": [0, 0, 100]
             },
-            "brand-b": {
-              "alpha": 0,
-              "colorSpace": "hsl",
-              "components": [0, 0, 100]
-            }
+            "brand-b": "{colors.background.brand.secondary}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -232,11 +225,7 @@
               "colorSpace": "hsl",
               "components": [0, 0, 100]
             },
-            "brand-b": {
-              "alpha": 0,
-              "colorSpace": "hsl",
-              "components": [0, 0, 100]
-            }
+            "brand-b": "{colors.background.brand.secondary-hover}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -252,11 +241,7 @@
               "colorSpace": "hsl",
               "components": [0, 0, 100]
             },
-            "brand-b": {
-              "alpha": 0,
-              "colorSpace": "hsl",
-              "components": [0, 0, 100]
-            }
+            "brand-b": "{colors.background.brand.secondary-active}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -272,11 +257,7 @@
               "colorSpace": "hsl",
               "components": [0, 0, 100]
             },
-            "brand-b": {
-              "alpha": 0,
-              "colorSpace": "hsl",
-              "components": [0, 0, 100]
-            }
+            "brand-b": "{colors.background.brand.secondary-disabled}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -340,7 +321,7 @@
           "$type": "color",
           "values": {
             "acronis": "{colors.text.on-brand.primary}",
-            "brand-b": "{colors.text.on-brand.primary}"
+            "brand-b": "{palette.teal.11}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -352,7 +333,7 @@
           "$type": "color",
           "values": {
             "acronis": "{colors.text.on-brand.primary}",
-            "brand-b": "{colors.text.on-brand.primary}"
+            "brand-b": "{palette.teal.12}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -364,7 +345,7 @@
           "$type": "color",
           "values": {
             "acronis": "{colors.text.on-brand.primary}",
-            "brand-b": "{colors.text.on-brand.primary}"
+            "brand-b": "{colors.background.brand.secondary-active}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -376,7 +357,7 @@
           "$type": "color",
           "values": {
             "acronis": "{colors.text.on-brand.disabled}",
-            "brand-b": "{colors.text.on-brand.disabled}"
+            "brand-b": "{colors.background.brand.secondary-disabled}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -397,8 +378,9 @@
               "components": [0, 0, 100]
             },
             "brand-b": {
+              "alpha": 0,
               "colorSpace": "hsl",
-              "components": [13.55, 72.09, 83.14]
+              "components": [0, 0, 100]
             }
           },
           "platforms": ["PD"],
@@ -457,11 +439,7 @@
           "$type": "color",
           "values": {
             "acronis": "{colors.border.on-surface.border}",
-            "brand-b": {
-              "alpha": 0,
-              "colorSpace": "hsl",
-              "components": [0, 0, 100]
-            }
+            "brand-b": "{colors.border.on-surface.border}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -473,11 +451,7 @@
           "$type": "color",
           "values": {
             "acronis": "{colors.border.on-surface.border}",
-            "brand-b": {
-              "alpha": 0,
-              "colorSpace": "hsl",
-              "components": [0, 0, 100]
-            }
+            "brand-b": "{colors.border.on-surface.border}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -489,11 +463,7 @@
           "$type": "color",
           "values": {
             "acronis": "{colors.border.on-surface.border}",
-            "brand-b": {
-              "alpha": 0,
-              "colorSpace": "hsl",
-              "components": [0, 0, 100]
-            }
+            "brand-b": "{colors.border.on-surface.border}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -538,8 +508,8 @@
         "hover": {
           "$type": "color",
           "values": {
-            "acronis": { "colorSpace": "hsl", "components": [300, 100, 50] },
-            "brand-b": { "colorSpace": "hsl", "components": [300, 100, 50] }
+            "acronis": "{colors.glyph.on-surface.primary}",
+            "brand-b": "{colors.glyph.on-surface.primary}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -550,8 +520,8 @@
         "active": {
           "$type": "color",
           "values": {
-            "acronis": { "colorSpace": "hsl", "components": [300, 100, 50] },
-            "brand-b": { "colorSpace": "hsl", "components": [300, 100, 50] }
+            "acronis": "{colors.glyph.on-surface.primary}",
+            "brand-b": "{colors.glyph.on-surface.primary}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -562,8 +532,8 @@
         "disabled": {
           "$type": "color",
           "values": {
-            "acronis": { "colorSpace": "hsl", "components": [300, 100, 50] },
-            "brand-b": { "colorSpace": "hsl", "components": [300, 100, 50] }
+            "acronis": "{colors.glyph.on-surface.disabled}",
+            "brand-b": "{colors.glyph.on-surface.disabled}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -577,10 +547,7 @@
           "$type": "color",
           "values": {
             "acronis": "{colors.text.on-surface.link}",
-            "brand-b": {
-              "colorSpace": "hsl",
-              "components": [12.82, 84.52, 30.39]
-            }
+            "brand-b": "{colors.text.on-surface.link}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -807,8 +774,8 @@
         "hover": {
           "$type": "color",
           "values": {
-            "acronis": { "colorSpace": "hsl", "components": [300, 100, 50] },
-            "brand-b": { "colorSpace": "hsl", "components": [300, 100, 50] }
+            "acronis": "{colors.glyph.on-surface.primary}",
+            "brand-b": "{colors.glyph.on-surface.primary}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -819,8 +786,8 @@
         "active": {
           "$type": "color",
           "values": {
-            "acronis": { "colorSpace": "hsl", "components": [300, 100, 50] },
-            "brand-b": { "colorSpace": "hsl", "components": [300, 100, 50] }
+            "acronis": "{colors.glyph.on-surface.primary}",
+            "brand-b": "{colors.glyph.on-surface.primary}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -933,8 +900,8 @@
         "disabled": {
           "$type": "color",
           "values": {
-            "acronis": { "colorSpace": "hsl", "components": [300, 100, 50] },
-            "brand-b": { "colorSpace": "hsl", "components": [300, 100, 50] }
+            "acronis": "{palette.red.3}",
+            "brand-b": "{palette.red.3}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -1041,8 +1008,8 @@
         "hover": {
           "$type": "color",
           "values": {
-            "acronis": { "colorSpace": "hsl", "components": [300, 100, 50] },
-            "brand-b": { "colorSpace": "hsl", "components": [300, 100, 50] }
+            "acronis": "{colors.glyph.on-inverted.primary}",
+            "brand-b": "{colors.glyph.on-inverted.primary}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -1053,8 +1020,8 @@
         "active": {
           "$type": "color",
           "values": {
-            "acronis": { "colorSpace": "hsl", "components": [300, 100, 50] },
-            "brand-b": { "colorSpace": "hsl", "components": [300, 100, 50] }
+            "acronis": "{colors.glyph.on-inverted.primary}",
+            "brand-b": "{colors.glyph.on-inverted.primary}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -1091,8 +1058,8 @@
         "hover": {
           "$type": "color",
           "values": {
-            "acronis": { "colorSpace": "hsl", "components": [300, 100, 50] },
-            "brand-b": { "colorSpace": "hsl", "components": [300, 100, 50] }
+            "acronis": "{colors.text.on-inverted.primary}",
+            "brand-b": "{colors.text.on-inverted.primary}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -1103,8 +1070,8 @@
         "active": {
           "$type": "color",
           "values": {
-            "acronis": { "colorSpace": "hsl", "components": [300, 100, 50] },
-            "brand-b": { "colorSpace": "hsl", "components": [300, 100, 50] }
+            "acronis": "{colors.text.on-inverted.primary}",
+            "brand-b": "{colors.text.on-inverted.primary}"
           },
           "platforms": ["PD"],
           "$extensions": {
@@ -1660,6 +1627,272 @@
           }
         }
       }
+    },
+    "icon": {
+      "background": {
+        "idle": {
+          "$type": "color",
+          "values": {
+            "acronis": {
+              "alpha": 0,
+              "colorSpace": "hsl",
+              "components": [0, 0, 100]
+            },
+            "brand-b": {
+              "alpha": 0,
+              "colorSpace": "hsl",
+              "components": [0, 0, 100]
+            }
+          },
+          "platforms": ["PD"],
+          "$extensions": {
+            "com.figma.scopes": ["FRAME_FILL"],
+            "com.figma.variableId": "VariableID:1856:6533"
+          }
+        },
+        "hover": {
+          "$type": "color",
+          "values": {
+            "acronis": {
+              "alpha": 0,
+              "colorSpace": "hsl",
+              "components": [0, 0, 100]
+            },
+            "brand-b": {
+              "alpha": 0,
+              "colorSpace": "hsl",
+              "components": [0, 0, 100]
+            }
+          },
+          "platforms": ["PD"],
+          "$extensions": {
+            "com.figma.scopes": ["FRAME_FILL"],
+            "com.figma.variableId": "VariableID:1856:6534"
+          }
+        },
+        "active": {
+          "$type": "color",
+          "values": {
+            "acronis": {
+              "alpha": 0,
+              "colorSpace": "hsl",
+              "components": [0, 0, 100]
+            },
+            "brand-b": {
+              "alpha": 0,
+              "colorSpace": "hsl",
+              "components": [0, 0, 100]
+            }
+          },
+          "platforms": ["PD"],
+          "$extensions": {
+            "com.figma.scopes": ["FRAME_FILL"],
+            "com.figma.variableId": "VariableID:1856:6535"
+          }
+        },
+        "disabled": {
+          "$type": "color",
+          "values": {
+            "acronis": {
+              "alpha": 0,
+              "colorSpace": "hsl",
+              "components": [0, 0, 100]
+            },
+            "brand-b": {
+              "alpha": 0,
+              "colorSpace": "hsl",
+              "components": [0, 0, 100]
+            }
+          },
+          "platforms": ["PD"],
+          "$extensions": {
+            "com.figma.scopes": ["FRAME_FILL"],
+            "com.figma.variableId": "VariableID:1856:6536"
+          }
+        }
+      },
+      "border": {
+        "idle": {
+          "$type": "color",
+          "values": {
+            "acronis": {
+              "alpha": 0,
+              "colorSpace": "hsl",
+              "components": [0, 0, 100]
+            },
+            "brand-b": {
+              "alpha": 0,
+              "colorSpace": "hsl",
+              "components": [0, 0, 100]
+            }
+          },
+          "platforms": ["PD"],
+          "$extensions": {
+            "com.figma.scopes": ["STROKE_COLOR"],
+            "com.figma.variableId": "VariableID:1856:6537"
+          }
+        },
+        "hover": {
+          "$type": "color",
+          "values": {
+            "acronis": {
+              "alpha": 0,
+              "colorSpace": "hsl",
+              "components": [0, 0, 100]
+            },
+            "brand-b": {
+              "alpha": 0,
+              "colorSpace": "hsl",
+              "components": [0, 0, 100]
+            }
+          },
+          "platforms": ["PD"],
+          "$extensions": {
+            "com.figma.scopes": ["STROKE_COLOR"],
+            "com.figma.variableId": "VariableID:1856:6538"
+          }
+        },
+        "active": {
+          "$type": "color",
+          "values": {
+            "acronis": {
+              "alpha": 0,
+              "colorSpace": "hsl",
+              "components": [0, 0, 100]
+            },
+            "brand-b": {
+              "alpha": 0,
+              "colorSpace": "hsl",
+              "components": [0, 0, 100]
+            }
+          },
+          "platforms": ["PD"],
+          "$extensions": {
+            "com.figma.scopes": ["STROKE_COLOR"],
+            "com.figma.variableId": "VariableID:1856:6539"
+          }
+        },
+        "disabled": {
+          "$type": "color",
+          "values": {
+            "acronis": {
+              "alpha": 0,
+              "colorSpace": "hsl",
+              "components": [0, 0, 100]
+            },
+            "brand-b": {
+              "alpha": 0,
+              "colorSpace": "hsl",
+              "components": [0, 0, 100]
+            }
+          },
+          "platforms": ["PD"],
+          "$extensions": {
+            "com.figma.scopes": ["STROKE_COLOR"],
+            "com.figma.variableId": "VariableID:1856:6540"
+          }
+        }
+      },
+      "icon": {
+        "idle": {
+          "$type": "color",
+          "values": {
+            "acronis": "{colors.glyph.on-surface.primary}",
+            "brand-b": "{colors.glyph.on-surface.primary}"
+          },
+          "platforms": ["PD"],
+          "$extensions": {
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.variableId": "VariableID:1856:6545"
+          }
+        },
+        "hover": {
+          "$type": "color",
+          "values": {
+            "acronis": "{colors.glyph.on-surface.primary}",
+            "brand-b": "{colors.glyph.on-surface.primary}"
+          },
+          "platforms": ["PD"],
+          "$extensions": {
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.variableId": "VariableID:1856:6546"
+          }
+        },
+        "active": {
+          "$type": "color",
+          "values": {
+            "acronis": "{colors.glyph.on-surface.primary}",
+            "brand-b": "{colors.glyph.on-surface.primary}"
+          },
+          "platforms": ["PD"],
+          "$extensions": {
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.variableId": "VariableID:1856:6547"
+          }
+        },
+        "disabled": {
+          "$type": "color",
+          "values": {
+            "acronis": "{colors.glyph.on-surface.disabled}",
+            "brand-b": "{colors.glyph.on-surface.disabled}"
+          },
+          "platforms": ["PD"],
+          "$extensions": {
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.variableId": "VariableID:1856:6548"
+          }
+        }
+      },
+      "label": {
+        "idle": {
+          "$type": "color",
+          "values": {
+            "acronis": "{colors.text.on-surface.link}",
+            "brand-b": "{colors.text.on-surface.link}"
+          },
+          "platforms": ["PD"],
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:1856:6541"
+          }
+        },
+        "hover": {
+          "$type": "color",
+          "values": {
+            "acronis": "{colors.text.on-surface.link-hover}",
+            "brand-b": "{colors.text.on-surface.link-hover}"
+          },
+          "platforms": ["PD"],
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:1856:6542"
+          }
+        },
+        "active": {
+          "$type": "color",
+          "values": {
+            "acronis": "{colors.text.on-surface.link-pressed}",
+            "brand-b": "{colors.text.on-surface.link-pressed}"
+          },
+          "platforms": ["PD"],
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:1856:6543"
+          }
+        },
+        "disabled": {
+          "$type": "color",
+          "values": {
+            "acronis": "{colors.text.on-surface.link-disabled}",
+            "brand-b": "{colors.text.on-surface.link-disabled}"
+          },
+          "platforms": ["PD"],
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:1856:6544"
+          }
+        }
+      }
     }
   },
   "chip": {
@@ -1715,244 +1948,6 @@
     }
   },
   "form": {
-    "_global": {
-      "border": {
-        "$type": "dimension",
-        "values": {
-          "acronis": "{units.stroke.1}",
-          "brand-b": "{units.stroke.1}"
-        },
-        "platforms": ["PD"],
-        "$extensions": {
-          "com.figma.scopes": ["STROKE_FLOAT"],
-          "com.figma.variableId": "VariableID:1331:550"
-        }
-      },
-      "gap": {
-        "$type": "dimension",
-        "values": {
-          "acronis": "{units.gap.4}",
-          "brand-b": "{units.gap.4}"
-        },
-        "platforms": ["PD"],
-        "$extensions": {
-          "com.figma.scopes": ["GAP"],
-          "com.figma.variableId": "VariableID:1331:548"
-        }
-      },
-      "gap-small": {
-        "$type": "dimension",
-        "values": {
-          "acronis": "{units.gap.2}",
-          "brand-b": "{units.gap.2}"
-        },
-        "platforms": ["PD"],
-        "$extensions": {
-          "com.figma.scopes": ["GAP"],
-          "com.figma.variableId": "VariableID:1331:2636"
-        }
-      },
-      "height": {
-        "$type": "dimension",
-        "values": {
-          "acronis": "{units.size.32}",
-          "brand-b": "{units.size.32}"
-        },
-        "platforms": ["PD"],
-        "$extensions": {
-          "com.figma.scopes": ["WIDTH_HEIGHT"],
-          "com.figma.variableId": "VariableID:1331:545"
-        }
-      },
-      "padding-x": {
-        "$type": "dimension",
-        "values": {
-          "acronis": "{units.gap.12}",
-          "brand-b": "{units.gap.12}"
-        },
-        "platforms": ["PD"],
-        "$extensions": {
-          "com.figma.scopes": ["GAP"],
-          "com.figma.variableId": "VariableID:1331:546"
-        }
-      },
-      "padding-y": {
-        "$type": "dimension",
-        "values": {
-          "acronis": "{units.gap.8}",
-          "brand-b": "{units.gap.8}"
-        },
-        "platforms": ["PD"],
-        "$extensions": {
-          "com.figma.scopes": ["GAP"],
-          "com.figma.variableId": "VariableID:1331:549"
-        }
-      },
-      "radius": {
-        "$type": "dimension",
-        "values": {
-          "acronis": "{units.radius.4}",
-          "brand-b": "{units.radius.4}"
-        },
-        "platforms": ["PD"],
-        "$extensions": {
-          "com.figma.scopes": ["CORNER_RADIUS"],
-          "com.figma.variableId": "VariableID:1331:544"
-        }
-      },
-      "width-min": {
-        "$type": "dimension",
-        "values": {
-          "acronis": "{units.size.256}",
-          "brand-b": "{units.size.256}"
-        },
-        "platforms": ["PD"],
-        "$extensions": {
-          "com.figma.scopes": ["WIDTH_HEIGHT"],
-          "com.figma.variableId": "VariableID:1331:547"
-        }
-      }
-    },
-    "input": {
-      "background": {
-        "idle": {
-          "$type": "color",
-          "values": {
-            "acronis": "{colors.background.surface.primary}",
-            "brand-b": "{colors.background.surface.primary}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL"],
-            "com.figma.variableId": "VariableID:738:6"
-          }
-        },
-        "disabled": {
-          "$type": "color",
-          "values": {
-            "acronis": "{colors.background.surface.secondary}",
-            "brand-b": "{colors.background.surface.secondary}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL"],
-            "com.figma.variableId": "VariableID:738:15"
-          }
-        }
-      },
-      "border": {
-        "active": {
-          "$type": "color",
-          "values": {
-            "acronis": "{colors.border.on-surface.border-active}",
-            "brand-b": "{colors.border.on-surface.border-active}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["STROKE_COLOR"],
-            "com.figma.variableId": "VariableID:738:11"
-          }
-        },
-        "disabled": {
-          "$type": "color",
-          "values": {
-            "acronis": "{colors.border.on-surface.border}",
-            "brand-b": "{colors.border.on-surface.border}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["STROKE_COLOR"],
-            "com.figma.variableId": "VariableID:738:16"
-          }
-        },
-        "error": {
-          "$type": "color",
-          "values": {
-            "acronis": "{colors.border.on-surface.border-error}",
-            "brand-b": "{colors.border.on-surface.border-error}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["STROKE_COLOR"],
-            "com.figma.variableId": "VariableID:738:17"
-          }
-        },
-        "focus": {
-          "$type": "color",
-          "values": {
-            "acronis": "{palette.blue.4}",
-            "brand-b": "{palette.blue.4}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["STROKE_COLOR"],
-            "com.figma.variableId": "VariableID:842:216"
-          }
-        },
-        "hover": {
-          "$type": "color",
-          "values": {
-            "acronis": "{colors.border.on-surface.border-active}",
-            "brand-b": "{colors.border.on-surface.border-active}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["STROKE_COLOR"],
-            "com.figma.variableId": "VariableID:738:10"
-          }
-        },
-        "idle": {
-          "$type": "color",
-          "values": {
-            "acronis": "{colors.border.on-surface.border}",
-            "brand-b": "{colors.border.on-surface.border}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["STROKE_COLOR"],
-            "com.figma.variableId": "VariableID:738:9"
-          }
-        }
-      },
-      "icon": {
-        "disabled": {
-          "$type": "color",
-          "values": {
-            "acronis": "{colors.glyph.on-surface.disabled}",
-            "brand-b": "{colors.glyph.on-surface.disabled}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
-            "com.figma.variableId": "VariableID:1248:66"
-          }
-        },
-        "error": {
-          "$type": "color",
-          "values": {
-            "acronis": "{colors.glyph.on-surface.destructive}",
-            "brand-b": "{colors.glyph.on-surface.destructive}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
-            "com.figma.variableId": "VariableID:1248:68"
-          }
-        },
-        "idle": {
-          "$type": "color",
-          "values": {
-            "acronis": "{colors.glyph.on-surface.primary}",
-            "brand-b": "{colors.glyph.on-surface.primary}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
-            "com.figma.variableId": "VariableID:1248:63"
-          }
-        }
-      }
-    },
     "text": {
       "description": {
         "$type": "color",
@@ -2027,107 +2022,373 @@
         }
       }
     },
-    "switch": {
-      "background": {
-        "active": {
-          "$type": "color",
-          "values": {
-            "acronis": "{colors.background.status.on}",
-            "brand-b": "{colors.background.status.on}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL"],
-            "com.figma.variableId": "VariableID:1205:133"
-          }
+    "background": {
+      "idle": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.background.surface.primary}",
+          "brand-b": "{colors.background.surface.primary}"
         },
-        "disabled": {
-          "$type": "color",
-          "values": {
-            "acronis": "{colors.background.surface.secondary}",
-            "brand-b": "{colors.background.surface.secondary}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL"],
-            "com.figma.variableId": "VariableID:1205:135"
-          }
-        },
-        "inactive": {
-          "$type": "color",
-          "values": {
-            "acronis": "{colors.background.status.off}",
-            "brand-b": "{colors.background.status.off}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL"],
-            "com.figma.variableId": "VariableID:1205:132"
-          }
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["FRAME_FILL"],
+          "com.figma.variableId": "VariableID:738:6"
         }
       },
-      "border": {
-        "disabled": {
-          "$type": "color",
-          "values": {
-            "acronis": "{colors.border.on-surface.border}",
-            "brand-b": "{colors.border.on-surface.border}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["STROKE_COLOR", "EFFECT_COLOR"],
-            "com.figma.variableId": "VariableID:1205:141"
-          }
+      "active": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.background.brand.secondary}",
+          "brand-b": "{colors.background.brand.secondary}"
         },
-        "focus": {
-          "$type": "color",
-          "values": {
-            "acronis": "{palette.blue.4}",
-            "brand-b": "{palette.blue.4}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["STROKE_COLOR", "EFFECT_COLOR"],
-            "com.figma.variableId": "VariableID:1205:142"
-          }
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["FRAME_FILL"],
+          "com.figma.variableId": "VariableID:1764:800"
         }
       },
-      "circle": {
-        "disabled": {
-          "$type": "color",
-          "values": {
-            "acronis": "{colors.glyph.on-status.disabled}",
-            "brand-b": "{colors.glyph.on-status.disabled}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL"],
-            "com.figma.variableId": "VariableID:1205:729"
-          }
+      "disabled": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.background.surface.secondary}",
+          "brand-b": "{colors.background.surface.secondary}"
         },
-        "off": {
-          "$type": "color",
-          "values": {
-            "acronis": "{colors.glyph.on-status.off}",
-            "brand-b": "{colors.glyph.on-status.off}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL"],
-            "com.figma.variableId": "VariableID:1205:728"
-          }
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["FRAME_FILL"],
+          "com.figma.variableId": "VariableID:738:15"
+        }
+      }
+    },
+    "border": {
+      "active": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.border.on-surface.border-active}",
+          "brand-b": "{colors.border.on-surface.border-active}"
         },
-        "on": {
-          "$type": "color",
-          "values": {
-            "acronis": "{colors.glyph.on-status.on}",
-            "brand-b": "{colors.glyph.on-status.on}"
-          },
-          "platforms": ["PD"],
-          "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL"],
-            "com.figma.variableId": "VariableID:1205:730"
-          }
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["STROKE_COLOR"],
+          "com.figma.variableId": "VariableID:738:11"
+        }
+      },
+      "disabled": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.border.on-surface.border}",
+          "brand-b": "{colors.border.on-surface.border}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["STROKE_COLOR"],
+          "com.figma.variableId": "VariableID:738:16"
+        }
+      },
+      "error": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.border.on-surface.border-error}",
+          "brand-b": "{colors.border.on-surface.border-error}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["STROKE_COLOR"],
+          "com.figma.variableId": "VariableID:738:17"
+        }
+      },
+      "hover": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.border.on-surface.border-active}",
+          "brand-b": "{colors.border.on-surface.border-active}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["STROKE_COLOR"],
+          "com.figma.variableId": "VariableID:738:10"
+        }
+      },
+      "idle": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.border.on-surface.border}",
+          "brand-b": "{colors.border.on-surface.border}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["STROKE_COLOR"],
+          "com.figma.variableId": "VariableID:738:9"
+        }
+      }
+    },
+    "circle": {
+      "active": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.glyph.on-status.on}",
+          "brand-b": "{colors.glyph.on-surface.primary}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["FRAME_FILL"],
+          "com.figma.variableId": "VariableID:1838:2070"
+        }
+      },
+      "disabled": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.glyph.on-status.disabled}",
+          "brand-b": "{colors.glyph.on-surface.disabled}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["FRAME_FILL"],
+          "com.figma.variableId": "VariableID:1838:2071"
+        }
+      }
+    },
+    "icon": {
+      "disabled": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.glyph.on-surface.disabled}",
+          "brand-b": "{colors.glyph.on-surface.disabled}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+          "com.figma.variableId": "VariableID:1248:66"
+        }
+      },
+      "error": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.glyph.on-surface.destructive}",
+          "brand-b": "{colors.glyph.on-surface.destructive}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+          "com.figma.variableId": "VariableID:1248:68"
+        }
+      },
+      "idle": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.glyph.on-surface.primary}",
+          "brand-b": "{colors.glyph.on-surface.primary}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+          "com.figma.variableId": "VariableID:1248:63"
+        }
+      }
+    },
+    "units": {
+      "border-lg": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.stroke.2}",
+          "brand-b": "{units.stroke.2}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["STROKE_FLOAT"],
+          "com.figma.variableId": "VariableID:1855:2533"
+        }
+      },
+      "border-sm": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.stroke.1}",
+          "brand-b": "{units.stroke.1}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["STROKE_FLOAT"],
+          "com.figma.variableId": "VariableID:1331:550"
+        }
+      },
+      "gap-lg": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.gap.8}",
+          "brand-b": "{units.gap.8}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:1331:549"
+        }
+      },
+      "gap-md": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.gap.4}",
+          "brand-b": "{units.gap.4}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:1331:548"
+        }
+      },
+      "gap-sm": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.gap.2}",
+          "brand-b": "{units.gap.2}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:1331:2636"
+        }
+      },
+      "height-lg": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.size.48}",
+          "brand-b": "{units.size.48}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:1855:2526"
+        }
+      },
+      "height-sm": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.size.32}",
+          "brand-b": "{units.size.32}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:1331:545"
+        }
+      },
+      "padding-x-lg": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.gap.16}",
+          "brand-b": "{units.gap.16}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:1855:2527"
+        }
+      },
+      "padding-x-sm": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.gap.12}",
+          "brand-b": "{units.gap.12}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:1331:546"
+        }
+      },
+      "radius-lg": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.radius.24}",
+          "brand-b": "{units.radius.24}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["CORNER_RADIUS"],
+          "com.figma.variableId": "VariableID:1855:2528"
+        }
+      },
+      "radius-md": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.radius.4}",
+          "brand-b": "{units.radius.4}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["CORNER_RADIUS"],
+          "com.figma.variableId": "VariableID:1331:544"
+        }
+      },
+      "radius-sm": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.radius.2}",
+          "brand-b": "{units.radius.2}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["CORNER_RADIUS"],
+          "com.figma.variableId": "VariableID:1828:1370"
+        }
+      },
+      "radius-xlg": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.radius.999}",
+          "brand-b": "{units.radius.999}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["CORNER_RADIUS"],
+          "com.figma.variableId": "VariableID:1838:2069"
+        }
+      },
+      "size-md": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.size.16}",
+          "brand-b": "{units.size.16}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:1844:1532"
+        }
+      },
+      "size-sm": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.size.8}",
+          "brand-b": "{units.size.8}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:1844:1523"
+        }
+      },
+      "width-max": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.size.512}",
+          "brand-b": "{units.size.512}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:1855:2525"
+        }
+      },
+      "width-min": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.size.256}",
+          "brand-b": "{units.size.256}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:1331:547"
         }
       }
     }
@@ -2209,6 +2470,242 @@
           "com.figma.scopes": ["STROKE_FLOAT"],
           "com.figma.variableId": "VariableID:609:3211"
         }
+      }
+    }
+  },
+  "item": {
+    "background": {
+      "idle": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.background.surface.primary}",
+          "brand-b": "{colors.background.surface.primary}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["FRAME_FILL"],
+          "com.figma.variableId": "VariableID:609:1651"
+        }
+      },
+      "hover": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.background.surface.hover}",
+          "brand-b": "{colors.background.surface.hover}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["FRAME_FILL"],
+          "com.figma.variableId": "VariableID:684:1722"
+        }
+      },
+      "active": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.background.surface.active}",
+          "brand-b": "{colors.background.surface.active}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["FRAME_FILL"],
+          "com.figma.variableId": "VariableID:684:1723"
+        }
+      }
+    },
+    "divider": {
+      "$type": "color",
+      "values": {
+        "acronis": "{colors.border.on-brand.divider}",
+        "brand-b": "{colors.border.on-brand.divider}"
+      },
+      "platforms": ["PD"],
+      "$extensions": {
+        "com.figma.scopes": ["STROKE_COLOR"],
+        "com.figma.variableId": "VariableID:684:3680"
+      }
+    },
+    "gap-x": {
+      "$type": "dimension",
+      "values": {
+        "acronis": "{units.gap.8}",
+        "brand-b": "{units.gap.8}"
+      },
+      "platforms": ["PD"],
+      "$extensions": {
+        "com.figma.scopes": ["GAP"],
+        "com.figma.variableId": "VariableID:788:15962"
+      }
+    },
+    "gap-y": {
+      "$type": "dimension",
+      "values": {
+        "acronis": "{units.gap.4}",
+        "brand-b": "{units.gap.4}"
+      },
+      "platforms": ["PD"],
+      "$extensions": {
+        "com.figma.scopes": ["GAP"],
+        "com.figma.variableId": "VariableID:1748:1482"
+      }
+    },
+    "height-min": {
+      "$type": "dimension",
+      "values": {
+        "acronis": "{units.size.40}",
+        "brand-b": "{units.size.40}"
+      },
+      "platforms": ["PD"],
+      "$extensions": {
+        "com.figma.scopes": ["WIDTH_HEIGHT"],
+        "com.figma.variableId": "VariableID:1748:2034"
+      }
+    },
+    "icon": {
+      "$type": "color",
+      "values": {
+        "acronis": "{colors.glyph.on-surface.primary}",
+        "brand-b": "{colors.glyph.on-surface.primary}"
+      },
+      "platforms": ["PD"],
+      "$extensions": {
+        "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+        "com.figma.variableId": "VariableID:747:10287"
+      }
+    },
+    "label": {
+      "idle": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.text.on-surface.primary}",
+          "brand-b": "{colors.text.on-surface.primary}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["TEXT_FILL"],
+          "com.figma.variableId": "VariableID:609:1714"
+        }
+      },
+      "active": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.text.on-surface.primary}",
+          "brand-b": "{colors.text.on-surface.primary}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["TEXT_FILL"],
+          "com.figma.variableId": "VariableID:684:1540"
+        }
+      }
+    },
+    "nesting": {
+      "padding-l1": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.gap.0}",
+          "brand-b": "{units.gap.0}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["WIDTH_HEIGHT", "GAP"],
+          "com.figma.variableId": "VariableID:1647:529"
+        }
+      },
+      "padding-l2": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.gap.24}",
+          "brand-b": "{units.gap.24}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["WIDTH_HEIGHT", "GAP"],
+          "com.figma.variableId": "VariableID:1647:530"
+        }
+      },
+      "padding-l3": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.gap.48}",
+          "brand-b": "{units.gap.48}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["WIDTH_HEIGHT", "GAP"],
+          "com.figma.variableId": "VariableID:1647:531"
+        }
+      },
+      "padding-l4": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.gap.72}",
+          "brand-b": "{units.gap.72}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["WIDTH_HEIGHT", "GAP"],
+          "com.figma.variableId": "VariableID:1647:532"
+        }
+      },
+      "padding-l5": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.gap.96}",
+          "brand-b": "{units.gap.96}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["WIDTH_HEIGHT", "GAP"],
+          "com.figma.variableId": "VariableID:1647:533"
+        }
+      }
+    },
+    "padding-x": {
+      "$type": "dimension",
+      "values": {
+        "acronis": "{units.gap.8}",
+        "brand-b": "{units.gap.8}"
+      },
+      "platforms": ["PD"],
+      "$extensions": {
+        "com.figma.scopes": ["GAP"],
+        "com.figma.variableId": "VariableID:684:1724"
+      }
+    },
+    "padding-x-small": {
+      "$type": "dimension",
+      "values": {
+        "acronis": "{units.gap.4}",
+        "brand-b": "{units.gap.4}"
+      },
+      "platforms": ["PD"],
+      "$extensions": {
+        "com.figma.scopes": ["GAP"],
+        "com.figma.variableId": "VariableID:1748:3052"
+      }
+    },
+    "padding-y": {
+      "$type": "dimension",
+      "values": {
+        "acronis": "{units.gap.8}",
+        "brand-b": "{units.gap.8}"
+      },
+      "platforms": ["PD"],
+      "$extensions": {
+        "com.figma.scopes": ["GAP"],
+        "com.figma.variableId": "VariableID:788:15960"
+      }
+    },
+    "width-min": {
+      "$type": "dimension",
+      "values": {
+        "acronis": "{units.size.128}",
+        "brand-b": "{units.size.128}"
+      },
+      "platforms": ["PD"],
+      "$extensions": {
+        "com.figma.scopes": ["WIDTH_HEIGHT"],
+        "com.figma.variableId": "VariableID:684:3709"
       }
     }
   },
@@ -2386,227 +2883,193 @@
       }
     }
   },
-  "sub-item": {
+  "switch": {
     "background": {
-      "idle": {
-        "$type": "color",
-        "values": {
-          "acronis": "{colors.background.surface.primary}",
-          "brand-b": "{colors.background.surface.primary}"
-        },
-        "platforms": ["PD"],
-        "$extensions": {
-          "com.figma.scopes": ["FRAME_FILL"],
-          "com.figma.variableId": "VariableID:609:1651"
-        }
-      },
-      "hover": {
-        "$type": "color",
-        "values": {
-          "acronis": "{colors.background.surface.hover}",
-          "brand-b": "{colors.background.surface.hover}"
-        },
-        "platforms": ["PD"],
-        "$extensions": {
-          "com.figma.scopes": ["FRAME_FILL"],
-          "com.figma.variableId": "VariableID:684:1722"
-        }
-      },
       "active": {
         "$type": "color",
         "values": {
-          "acronis": "{colors.background.surface.active}",
-          "brand-b": "{colors.background.surface.active}"
+          "acronis": "{colors.background.status.on}",
+          "brand-b": "{colors.background.status.on}"
         },
         "platforms": ["PD"],
         "$extensions": {
           "com.figma.scopes": ["FRAME_FILL"],
-          "com.figma.variableId": "VariableID:684:1723"
+          "com.figma.variableId": "VariableID:1205:133"
         }
-      }
-    },
-    "divider": {
-      "$type": "color",
-      "values": {
-        "acronis": "{colors.border.on-brand.divider}",
-        "brand-b": "{colors.border.on-brand.divider}"
       },
-      "platforms": ["PD"],
-      "$extensions": {
-        "com.figma.scopes": ["STROKE_COLOR"],
-        "com.figma.variableId": "VariableID:684:3680"
-      }
-    },
-    "gap": {
-      "$type": "dimension",
-      "values": {
-        "acronis": "{units.gap.8}",
-        "brand-b": "{units.gap.8}"
-      },
-      "platforms": ["PD"],
-      "$extensions": {
-        "com.figma.scopes": ["GAP"],
-        "com.figma.variableId": "VariableID:788:15962"
-      }
-    },
-    "height-header": {
-      "$type": "dimension",
-      "values": {
-        "acronis": "{units.size.64}",
-        "brand-b": "{units.size.64}"
-      },
-      "platforms": ["PD"],
-      "$extensions": {
-        "com.figma.scopes": ["WIDTH_HEIGHT"],
-        "com.figma.variableId": "VariableID:684:1710"
-      }
-    },
-    "icon": {
-      "$type": "color",
-      "values": {
-        "acronis": "{colors.glyph.on-surface.primary}",
-        "brand-b": "{colors.glyph.on-surface.primary}"
-      },
-      "platforms": ["PD"],
-      "$extensions": {
-        "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
-        "com.figma.variableId": "VariableID:747:10287"
-      }
-    },
-    "label": {
-      "idle": {
+      "disabled": {
         "$type": "color",
         "values": {
-          "acronis": "{colors.text.on-surface.primary}",
-          "brand-b": "{colors.text.on-surface.primary}"
+          "acronis": "{colors.background.surface.secondary}",
+          "brand-b": "{colors.background.surface.secondary}"
         },
         "platforms": ["PD"],
         "$extensions": {
-          "com.figma.scopes": ["TEXT_FILL"],
-          "com.figma.variableId": "VariableID:609:1714"
+          "com.figma.scopes": ["FRAME_FILL"],
+          "com.figma.variableId": "VariableID:1205:135"
         }
       },
-      "active": {
+      "inactive": {
         "$type": "color",
         "values": {
-          "acronis": "{colors.text.on-surface.primary}",
-          "brand-b": "{colors.text.on-surface.primary}"
+          "acronis": "{colors.background.status.off}",
+          "brand-b": "{colors.background.status.off}"
         },
         "platforms": ["PD"],
         "$extensions": {
-          "com.figma.scopes": ["TEXT_FILL"],
-          "com.figma.variableId": "VariableID:684:1540"
+          "com.figma.scopes": ["FRAME_FILL"],
+          "com.figma.variableId": "VariableID:1205:132"
         }
       }
     },
-    "nesting": {
-      "padding-l1": {
+    "border": {
+      "disabled": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.border.on-surface.border}",
+          "brand-b": "{colors.border.on-surface.border}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["STROKE_COLOR", "EFFECT_COLOR"],
+          "com.figma.variableId": "VariableID:1205:141"
+        }
+      }
+    },
+    "circle": {
+      "disabled": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.glyph.on-status.disabled}",
+          "brand-b": "{colors.glyph.on-status.disabled}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["FRAME_FILL"],
+          "com.figma.variableId": "VariableID:1205:729"
+        }
+      },
+      "off": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.glyph.on-status.off}",
+          "brand-b": "{colors.glyph.on-status.off}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["FRAME_FILL"],
+          "com.figma.variableId": "VariableID:1205:728"
+        }
+      },
+      "on": {
+        "$type": "color",
+        "values": {
+          "acronis": "{colors.glyph.on-status.on}",
+          "brand-b": "{colors.glyph.on-status.on}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["FRAME_FILL"],
+          "com.figma.variableId": "VariableID:1205:730"
+        }
+      }
+    },
+    "units": {
+      "border": {
         "$type": "dimension",
         "values": {
-          "acronis": "{units.gap.0}",
+          "acronis": "{units.stroke.1}",
+          "brand-b": "{units.stroke.1}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["STROKE_FLOAT"],
+          "com.figma.variableId": "VariableID:1838:1800"
+        }
+      },
+      "circle": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.size.12}",
+          "brand-b": "{units.size.12}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:1838:1804"
+        }
+      },
+      "gap": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.gap.8}",
           "brand-b": "{units.gap.8}"
         },
         "platforms": ["PD"],
         "$extensions": {
-          "com.figma.scopes": ["WIDTH_HEIGHT", "GAP"],
-          "com.figma.variableId": "VariableID:1647:529"
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:1838:1803"
         }
       },
-      "padding-l2": {
+      "height": {
         "$type": "dimension",
         "values": {
-          "acronis": "{units.gap.24}",
-          "brand-b": "{units.gap.32}"
+          "acronis": "{units.size.16}",
+          "brand-b": "{units.size.16}"
         },
         "platforms": ["PD"],
         "$extensions": {
-          "com.figma.scopes": ["WIDTH_HEIGHT", "GAP"],
-          "com.figma.variableId": "VariableID:1647:530"
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:1838:1799"
         }
       },
-      "padding-l3": {
+      "padding-x": {
         "$type": "dimension",
         "values": {
-          "acronis": "{units.gap.48}",
-          "brand-b": "{units.gap.56}"
+          "acronis": "{units.gap.2}",
+          "brand-b": "{units.gap.2}"
         },
         "platforms": ["PD"],
         "$extensions": {
-          "com.figma.scopes": ["WIDTH_HEIGHT", "GAP"],
-          "com.figma.variableId": "VariableID:1647:531"
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:1838:1801"
         }
       },
-      "padding-l4": {
+      "padding-y": {
         "$type": "dimension",
         "values": {
-          "acronis": "{units.gap.72}",
-          "brand-b": { "unit": "px", "value": 80 }
+          "acronis": "{units.gap.2}",
+          "brand-b": "{units.gap.2}"
         },
         "platforms": ["PD"],
         "$extensions": {
-          "com.figma.scopes": ["WIDTH_HEIGHT", "GAP"],
-          "com.figma.variableId": "VariableID:1647:532"
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:1838:1802"
         }
       },
-      "padding-l5": {
+      "radius": {
         "$type": "dimension",
         "values": {
-          "acronis": "{units.gap.96}",
-          "brand-b": { "unit": "px", "value": 104 }
+          "acronis": "{units.radius.999}",
+          "brand-b": "{units.radius.999}"
         },
         "platforms": ["PD"],
         "$extensions": {
-          "com.figma.scopes": ["WIDTH_HEIGHT", "GAP"],
-          "com.figma.variableId": "VariableID:1647:533"
+          "com.figma.scopes": ["CORNER_RADIUS"],
+          "com.figma.variableId": "VariableID:1838:1797"
         }
-      }
-    },
-    "padding-x": {
-      "$type": "dimension",
-      "values": {
-        "acronis": "{units.gap.8}",
-        "brand-b": "{units.gap.16}"
       },
-      "platforms": ["PD"],
-      "$extensions": {
-        "com.figma.scopes": ["GAP"],
-        "com.figma.variableId": "VariableID:684:1724"
-      }
-    },
-    "padding-y": {
-      "$type": "dimension",
-      "values": {
-        "acronis": "{units.gap.8}",
-        "brand-b": "{units.gap.8}"
-      },
-      "platforms": ["PD"],
-      "$extensions": {
-        "com.figma.scopes": ["GAP"],
-        "com.figma.variableId": "VariableID:788:15960"
-      }
-    },
-    "width-collapsed": {
-      "$type": "dimension",
-      "values": {
-        "acronis": "{units.size.48}",
-        "brand-b": "{units.size.48}"
-      },
-      "platforms": ["PD"],
-      "$extensions": {
-        "com.figma.scopes": ["WIDTH_HEIGHT"],
-        "com.figma.variableId": "VariableID:788:15959"
-      }
-    },
-    "width-min": {
-      "$type": "dimension",
-      "values": {
-        "acronis": "{units.size.128}",
-        "brand-b": "{units.size.128}"
-      },
-      "platforms": ["PD"],
-      "$extensions": {
-        "com.figma.scopes": ["WIDTH_HEIGHT"],
-        "com.figma.variableId": "VariableID:684:3709"
+      "width": {
+        "$type": "dimension",
+        "values": {
+          "acronis": "{units.size.32}",
+          "brand-b": "{units.size.32}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:1838:1798"
+        }
       }
     }
   },

--- a/packages/design-tokens/tokens/primitives.json
+++ b/packages/design-tokens/tokens/primitives.json
@@ -2032,7 +2032,7 @@
         "platforms": ["PD"],
         "$extensions": {
           "com.acronis.units": { "unit": "px", "value": 3 },
-          "com.figma.scopes": ["EFFECT_FLOAT"],
+          "com.figma.scopes": ["STROKE_FLOAT"],
           "com.figma.variableId": "VariableID:1330:10884"
         }
       },

--- a/packages/design-tokens/tokens/primitives.json
+++ b/packages/design-tokens/tokens/primitives.json
@@ -2032,7 +2032,7 @@
         "platforms": ["PD"],
         "$extensions": {
           "com.acronis.units": { "unit": "px", "value": 3 },
-          "com.figma.scopes": ["STROKE_FLOAT"],
+          "com.figma.scopes": ["EFFECT_FLOAT"],
           "com.figma.variableId": "VariableID:1330:10884"
         }
       },

--- a/packages/design-tokens/tokens/primitives.json
+++ b/packages/design-tokens/tokens/primitives.json
@@ -281,7 +281,7 @@
       },
       "7": {
         "values": {
-          "dark": { "colorSpace": "hsl", "components": [215.22, 80, 45.1] },
+          "dark": { "colorSpace": "hsl", "components": [214.89, 80, 54.9] },
           "light": { "colorSpace": "hsl", "components": [215.22, 80, 45.1] }
         },
         "platforms": ["PD"],
@@ -1832,6 +1832,22 @@
       }
     },
     "size": {
+      "8": {
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.acronis.units": { "unit": "px", "value": 8 },
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
+          "com.figma.variableId": "VariableID:1844:1524"
+        }
+      },
+      "12": {
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.acronis.units": { "unit": "px", "value": 12 },
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
+          "com.figma.variableId": "VariableID:1838:1805"
+        }
+      },
       "16": {
         "platforms": ["PD"],
         "$extensions": {
@@ -1904,6 +1920,14 @@
           "com.figma.variableId": "VariableID:1642:1394"
         }
       },
+      "224": {
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.acronis.units": { "unit": "px", "value": 224 },
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
+          "com.figma.variableId": "VariableID:1727:2084"
+        }
+      },
       "256": {
         "platforms": ["PD"],
         "$extensions": {
@@ -1970,6 +1994,14 @@
           "com.figma.variableId": "VariableID:1330:10913"
         }
       },
+      "24": {
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.acronis.units": { "unit": "px", "value": 24 },
+          "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
+          "com.figma.variableId": "VariableID:1855:2529"
+        }
+      },
       "999": {
         "platforms": ["PD"],
         "$extensions": {
@@ -2000,7 +2032,7 @@
         "platforms": ["PD"],
         "$extensions": {
           "com.acronis.units": { "unit": "px", "value": 3 },
-          "com.figma.scopes": ["STROKE_FLOAT", "EFFECT_FLOAT"],
+          "com.figma.scopes": ["EFFECT_FLOAT"],
           "com.figma.variableId": "VariableID:1330:10884"
         }
       },
@@ -2050,6 +2082,14 @@
           "com.acronis.units": { "unit": "px", "value": 10 },
           "com.figma.scopes": ["FONT_SIZE"],
           "com.figma.variableId": "VariableID:1339:11310"
+        }
+      },
+      "11": {
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.acronis.units": { "unit": "px", "value": 11 },
+          "com.figma.scopes": ["FONT_SIZE"],
+          "com.figma.variableId": "VariableID:1727:2411"
         }
       },
       "12": {
@@ -2182,6 +2222,14 @@
           "com.acronis.units": { "unit": "px", "value": 32 },
           "com.figma.scopes": ["LINE_HEIGHT", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:1339:11316"
+        }
+      },
+      "40": {
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.acronis.units": { "unit": "px", "value": 40 },
+          "com.figma.scopes": ["LINE_HEIGHT", "FONT_VARIATIONS"],
+          "com.figma.variableId": "VariableID:1727:2407"
         }
       },
       "48": {

--- a/packages/design-tokens/tokens/semantic.json
+++ b/packages/design-tokens/tokens/semantic.json
@@ -7,11 +7,10 @@
         "active": {
           "values": {
             "acronis": "{palette.blue.3}",
-            "brand-b": "{palette.blue.3}"
+            "brand-b": "{palette.teal.3}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:141:276"
           }
@@ -19,11 +18,10 @@
         "hover": {
           "values": {
             "acronis": "{palette.blue.2}",
-            "brand-b": "{palette.blue.2}"
+            "brand-b": "{palette.teal.2}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:141:275"
           }
@@ -35,7 +33,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1426"
           }
@@ -43,11 +40,10 @@
         "secondary": {
           "values": {
             "acronis": "{palette.blue.0}",
-            "brand-b": "{palette.blue.0}"
+            "brand-b": "{palette.teal.0}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1427"
           }
@@ -57,11 +53,10 @@
         "primary": {
           "values": {
             "acronis": "{palette.blue.13}",
-            "brand-b": "{palette.blue.13}"
+            "brand-b": "{palette.teal.13}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1428"
           }
@@ -69,11 +64,10 @@
         "primary-active": {
           "values": {
             "acronis": "{palette.blue.11}",
-            "brand-b": "{palette.blue.11}"
+            "brand-b": "{palette.teal.11}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:143:3"
           }
@@ -81,11 +75,10 @@
         "primary-disabled": {
           "values": {
             "acronis": "{palette.blue.5}",
-            "brand-b": "{palette.blue.5}"
+            "brand-b": "{palette.teal.5}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:383:39"
           }
@@ -93,11 +86,10 @@
         "primary-hover": {
           "values": {
             "acronis": "{palette.blue.12}",
-            "brand-b": "{palette.blue.12}"
+            "brand-b": "{palette.teal.12}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:143:2"
           }
@@ -105,11 +97,10 @@
         "secondary": {
           "values": {
             "acronis": "{palette.blue.7}",
-            "brand-b": "{palette.blue.7}"
+            "brand-b": "{palette.teal.7}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1429"
           }
@@ -117,11 +108,10 @@
         "secondary-active": {
           "values": {
             "acronis": "{palette.blue.9}",
-            "brand-b": "{palette.blue.9}"
+            "brand-b": "{palette.teal.9}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:265:59"
           }
@@ -129,11 +119,10 @@
         "secondary-disabled": {
           "values": {
             "acronis": "{palette.blue.3}",
-            "brand-b": "{palette.blue.3}"
+            "brand-b": "{palette.teal.3}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:227:24"
           }
@@ -141,11 +130,10 @@
         "secondary-hover": {
           "values": {
             "acronis": "{palette.blue.8}",
-            "brand-b": "{palette.blue.8}"
+            "brand-b": "{palette.teal.8}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:265:58"
           }
@@ -159,7 +147,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:202:38"
           }
@@ -171,7 +158,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1433"
           }
@@ -185,7 +171,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:14"
           }
@@ -197,7 +182,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:15"
           }
@@ -209,7 +193,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:16"
           }
@@ -221,7 +204,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:16"
           }
@@ -233,7 +215,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:17"
           }
@@ -245,7 +226,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:18"
           }
@@ -257,7 +237,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:8"
           }
@@ -269,7 +248,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:9"
           }
@@ -281,7 +259,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:10"
           }
@@ -293,7 +270,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263457"
           }
@@ -305,7 +281,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263458"
           }
@@ -317,7 +292,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263459"
           }
@@ -329,7 +303,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:1205:160"
           }
@@ -341,7 +314,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:1205:161"
           }
@@ -353,7 +325,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:10"
           }
@@ -365,7 +336,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:11"
           }
@@ -377,7 +347,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:12"
           }
@@ -389,7 +358,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:12"
           }
@@ -401,7 +369,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:13"
           }
@@ -413,7 +380,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:14"
           }
@@ -427,7 +393,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
             "com.figma.variableId": "VariableID:910:263451"
           }
@@ -439,7 +404,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
             "com.figma.variableId": "VariableID:910:263452"
           }
@@ -451,7 +415,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
             "com.figma.variableId": "VariableID:910:263453"
           }
@@ -463,7 +426,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
             "com.figma.variableId": "VariableID:910:263454"
           }
@@ -475,7 +437,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
             "com.figma.variableId": "VariableID:910:263455"
           }
@@ -487,7 +448,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
             "com.figma.variableId": "VariableID:910:263456"
           }
@@ -499,7 +459,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
             "com.figma.variableId": "VariableID:910:263442"
           }
@@ -511,7 +470,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
             "com.figma.variableId": "VariableID:910:263443"
           }
@@ -523,7 +481,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
             "com.figma.variableId": "VariableID:910:263444"
           }
@@ -535,7 +492,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
             "com.figma.variableId": "VariableID:911:263460"
           }
@@ -547,7 +503,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
             "com.figma.variableId": "VariableID:911:263461"
           }
@@ -559,7 +514,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
             "com.figma.variableId": "VariableID:911:263462"
           }
@@ -571,7 +525,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
             "com.figma.variableId": "VariableID:910:263445"
           }
@@ -583,7 +536,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
             "com.figma.variableId": "VariableID:910:263446"
           }
@@ -595,7 +547,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
             "com.figma.variableId": "VariableID:910:263447"
           }
@@ -607,7 +558,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
             "com.figma.variableId": "VariableID:910:263448"
           }
@@ -619,7 +569,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
             "com.figma.variableId": "VariableID:910:263449"
           }
@@ -631,7 +580,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
             "com.figma.variableId": "VariableID:910:263450"
           }
@@ -645,7 +593,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:305:124"
           }
@@ -657,7 +604,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:305:123"
           }
@@ -669,7 +615,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:305:122"
           }
@@ -796,11 +741,10 @@
         "border": {
           "values": {
             "acronis": "{palette.blue.3}",
-            "brand-b": "{palette.blue.3}"
+            "brand-b": "{palette.teal.3}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:50:1437"
           }
@@ -812,7 +756,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:138:187"
           }
@@ -824,7 +767,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:414:104"
           }
@@ -836,7 +778,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:1234:100"
           }
@@ -844,11 +785,10 @@
         "divider": {
           "values": {
             "acronis": "{palette.blue.3}",
-            "brand-b": "{palette.blue.3}"
+            "brand-b": "{palette.teal.3}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:50:1438"
           }
@@ -862,7 +802,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:52:1377"
           }
@@ -874,7 +813,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:139:5"
           }
@@ -886,7 +824,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:52:1378"
           }
@@ -900,7 +837,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:41"
           }
@@ -912,7 +848,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2005"
           }
@@ -924,7 +859,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:42"
           }
@@ -936,7 +870,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2004"
           }
@@ -948,7 +881,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:38"
           }
@@ -960,7 +892,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2008"
           }
@@ -972,7 +903,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:911:263463"
           }
@@ -984,7 +914,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:912:268723"
           }
@@ -996,7 +925,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:39"
           }
@@ -1008,7 +936,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2007"
           }
@@ -1020,7 +947,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:40"
           }
@@ -1032,7 +958,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2006"
           }
@@ -1048,7 +973,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:143:8"
           }
@@ -1056,11 +980,10 @@
         "disabled": {
           "values": {
             "acronis": "{palette.blue.3}",
-            "brand-b": "{palette.blue.3}"
+            "brand-b": "{palette.teal.3}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:56:1581"
           }
@@ -1072,7 +995,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:1024:122"
           }
@@ -1080,11 +1002,10 @@
         "primary": {
           "values": {
             "acronis": "{palette.blue.7}",
-            "brand-b": "{palette.blue.7}"
+            "brand-b": "{palette.teal.7}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:50:1436"
           }
@@ -1098,7 +1019,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:179:195"
           }
@@ -1110,7 +1030,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:52:2202"
           }
@@ -1122,7 +1041,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:179:196"
           }
@@ -1136,7 +1054,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:143:179"
           }
@@ -1150,7 +1067,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:796:1732"
           }
@@ -1162,7 +1078,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:796:1731"
           }
@@ -1174,7 +1089,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:151:43"
           }
@@ -1186,7 +1100,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:796:1735"
           }
@@ -1198,7 +1111,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:911:263464"
           }
@@ -1210,7 +1122,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:1205:724"
           }
@@ -1222,7 +1133,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:1205:723"
           }
@@ -1234,7 +1144,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:149:7"
           }
@@ -1246,7 +1155,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:796:1734"
           }
@@ -1258,7 +1166,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:796:1733"
           }
@@ -1272,7 +1179,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:305:126"
           }
@@ -1284,7 +1190,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:305:125"
           }
@@ -1296,7 +1201,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:915:272935"
           }
@@ -1312,7 +1216,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:150"
           }
@@ -1324,7 +1227,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:52:1357"
           }
@@ -1332,11 +1234,10 @@
         "link": {
           "values": {
             "acronis": "{palette.blue.7}",
-            "brand-b": "{palette.blue.7}"
+            "brand-b": "{palette.teal.7}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:155"
           }
@@ -1344,11 +1245,10 @@
         "link-disabled": {
           "values": {
             "acronis": "{palette.blue.5}",
-            "brand-b": "{palette.blue.5}"
+            "brand-b": "{palette.teal.5}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:160"
           }
@@ -1356,11 +1256,10 @@
         "link-hover": {
           "values": {
             "acronis": "{palette.blue.8}",
-            "brand-b": "{palette.blue.8}"
+            "brand-b": "{palette.teal.8}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:156"
           }
@@ -1368,11 +1267,10 @@
         "link-pressed": {
           "values": {
             "acronis": "{palette.blue.11}",
-            "brand-b": "{palette.blue.11}"
+            "brand-b": "{palette.teal.11}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:159"
           }
@@ -1384,7 +1282,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:50:1425"
           }
@@ -1396,7 +1293,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:50:1434"
           }
@@ -1410,7 +1306,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:52:1358"
           }
@@ -1418,11 +1313,10 @@
         "link": {
           "values": {
             "acronis": "{palette.blue.7}",
-            "brand-b": "{palette.blue.7}"
+            "brand-b": "{palette.teal.7}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:169"
           }
@@ -1434,7 +1328,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:172"
           }
@@ -1442,11 +1335,10 @@
         "link-hover": {
           "values": {
             "acronis": "{palette.blue.5}",
-            "brand-b": "{palette.blue.5}"
+            "brand-b": "{palette.teal.5}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:170"
           }
@@ -1454,11 +1346,10 @@
         "link-pressed": {
           "values": {
             "acronis": "{palette.blue.3}",
-            "brand-b": "{palette.blue.3}"
+            "brand-b": "{palette.teal.2}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:171"
           }
@@ -1470,7 +1361,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:52:1353"
           }
@@ -1482,7 +1372,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:52:1354"
           }
@@ -1492,11 +1381,10 @@
         "link": {
           "values": {
             "acronis": "{palette.blue.7}",
-            "brand-b": "{palette.blue.7}"
+            "brand-b": "{palette.teal.7}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:188"
           }
@@ -1504,11 +1392,10 @@
         "link-hover": {
           "values": {
             "acronis": "{palette.blue.5}",
-            "brand-b": "{palette.blue.5}"
+            "brand-b": "{palette.teal.5}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:141:189"
           }
@@ -1516,11 +1403,10 @@
         "link-pressed": {
           "values": {
             "acronis": "{palette.blue.3}",
-            "brand-b": "{palette.blue.3}"
+            "brand-b": "{palette.teal.3}"
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:141:190"
           }
@@ -1532,7 +1418,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:52:1355"
           }
@@ -1544,7 +1429,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:52:1356"
           }
@@ -1558,7 +1442,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:912:266569"
           }
@@ -1570,7 +1453,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:201:20"
           }
@@ -1582,7 +1464,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:201:19"
           }
@@ -1594,7 +1475,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:201:17"
           }
@@ -1606,7 +1486,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:149:4"
           }
@@ -1618,7 +1497,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:149:8"
           }
@@ -1630,7 +1508,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:149:5"
           }
@@ -1642,7 +1519,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:149:6"
           }
@@ -1654,7 +1530,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:911:263465"
           }
@@ -1666,7 +1541,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:149:2"
           }
@@ -1678,7 +1552,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:149:3"
           }
@@ -1690,7 +1563,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:201:21"
           }
@@ -1702,7 +1574,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:201:18"
           }
@@ -1716,7 +1587,6 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:305:132"
           }
@@ -1728,10 +1598,55 @@
           },
           "platforms": ["PD"],
           "$extensions": {
-            "com.figma.hiddenFromPublishing": false,
             "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:305:127"
           }
+        }
+      }
+    },
+    "focus": {
+      "brand": {
+        "values": {
+          "acronis": "{palette.blue.6}",
+          "brand-b": "{palette.teal.6}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["EFFECT_COLOR"],
+          "com.figma.variableId": "VariableID:1838:1394"
+        }
+      },
+      "error": {
+        "values": {
+          "acronis": "{palette.red.4}",
+          "brand-b": "{palette.red.4}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["EFFECT_COLOR"],
+          "com.figma.variableId": "VariableID:1828:1379"
+        }
+      },
+      "primary": {
+        "values": {
+          "acronis": "{palette.blue.4}",
+          "brand-b": "{palette.teal.4}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["EFFECT_COLOR"],
+          "com.figma.variableId": "VariableID:1828:1378"
+        }
+      },
+      "secondary": {
+        "values": {
+          "acronis": "{palette.blue.4}",
+          "brand-b": "{palette.teal.4}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.scopes": ["EFFECT_COLOR"],
+          "com.figma.variableId": "VariableID:1838:1393"
         }
       }
     }
@@ -1745,7 +1660,7 @@
           "fontSize": "{font.font-size.32}",
           "fontWeight": "{font.font-weight.regular}",
           "letterSpacing": "{font.letter-spacing.0}",
-          "lineHeight": { "unit": "px", "value": 40 }
+          "lineHeight": "{font.line-height.40}"
         },
         "platforms": ["PD"],
         "$extensions": {
@@ -1806,20 +1721,6 @@
           "com.figma.styleId": "S:370e51bf0854d130794d30019cf2ecba966d8264,"
         }
       },
-      "strong-underlined": {
-        "$value": {
-          "fontFamily": "{font.font-family.default}",
-          "fontSize": "{font.font-size.14}",
-          "fontWeight": "{font.font-weight.semibold}",
-          "letterSpacing": "{font.letter-spacing.0}",
-          "lineHeight": "{font.line-height.24}"
-        },
-        "platforms": ["PD"],
-        "$extensions": {
-          "com.acronis.textDecoration": "UNDERLINE",
-          "com.figma.styleId": "S:a451d4c9cb98b20bc426381248dcd75747de2e85,"
-        }
-      },
       "heading": {
         "$value": {
           "fontFamily": "{font.font-family.default}",
@@ -1847,23 +1748,49 @@
           "com.figma.styleId": "S:682a89d4e80492ccd040ed0902d7586063f54cec,"
         }
       },
-      "link": {
+      "form-label": {
         "$value": {
           "fontFamily": "{font.font-family.default}",
           "fontSize": "{font.font-size.14}",
-          "fontWeight": "{font.font-weight.semibold}",
+          "fontWeight": "{font.font-weight.regular}",
           "letterSpacing": "{font.letter-spacing.0}",
-          "lineHeight": "{font.line-height.24}"
+          "lineHeight": "{font.line-height.16}"
         },
         "platforms": ["PD"],
         "$extensions": {
-          "com.acronis.textDecoration": "UNDERLINE",
-          "com.figma.styleId": "S:76704e81b82496daf14ac42569f218a879da590a,"
+          "com.figma.styleId": "S:b44be8f3fabe30023a200eb551b32c22125726bf,"
         }
       }
     },
     "link": {
-      "primary": {
+      "default": {
+        "$value": {
+          "fontFamily": "{font.font-family.default}",
+          "fontSize": "{font.font-size.14}",
+          "fontWeight": "{font.font-weight.regular}",
+          "letterSpacing": "{font.letter-spacing.0}",
+          "lineHeight": "{font.line-height.24}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.figma.styleId": "S:e6708b02f258a60f1349baf2107f23de0b32bd98,"
+        }
+      },
+      "default-underline": {
+        "$value": {
+          "fontFamily": "{font.font-family.default}",
+          "fontSize": "{font.font-size.14}",
+          "fontWeight": "{font.font-weight.regular}",
+          "letterSpacing": "{font.letter-spacing.0}",
+          "lineHeight": "{font.line-height.24}"
+        },
+        "platforms": ["PD"],
+        "$extensions": {
+          "com.acronis.textDecoration": "UNDERLINE",
+          "com.figma.styleId": "S:6060ea27d58a686cd6f949e3aeb969828ce9d0a4,"
+        }
+      },
+      "strong": {
         "$value": {
           "fontFamily": "{font.font-family.default}",
           "fontSize": "{font.font-size.14}",
@@ -1873,11 +1800,10 @@
         },
         "platforms": ["PD"],
         "$extensions": {
-          "com.acronis.textDecoration": "UNDERLINE",
           "com.figma.styleId": "S:48319df2de2af8c0ca92099a2933581ec8e19df9,"
         }
       },
-      "secondary": {
+      "strong-underline": {
         "$value": {
           "fontFamily": "{font.font-family.default}",
           "fontSize": "{font.font-size.14}",
@@ -1888,7 +1814,7 @@
         "platforms": ["PD"],
         "$extensions": {
           "com.acronis.textDecoration": "UNDERLINE",
-          "com.figma.styleId": "S:e6708b02f258a60f1349baf2107f23de0b32bd98,"
+          "com.figma.styleId": "S:8558f4afc56ed692b63a08aecbd26ac6db225326,"
         }
       }
     },
@@ -1937,7 +1863,7 @@
       "default": {
         "$value": {
           "fontFamily": "{font.font-family.default}",
-          "fontSize": { "unit": "px", "value": 11 },
+          "fontSize": "{font.font-size.11}",
           "fontWeight": "{font.font-weight.semibold}",
           "letterSpacing": "{font.letter-spacing.1}",
           "lineHeight": "{font.line-height.16}"
@@ -1950,7 +1876,7 @@
       "heading": {
         "$value": {
           "fontFamily": "{font.font-family.default}",
-          "fontSize": { "unit": "px", "value": 11 },
+          "fontSize": "{font.font-size.11}",
           "fontWeight": "{font.font-weight.bold}",
           "letterSpacing": "{font.letter-spacing.1}",
           "lineHeight": "{font.line-height.16}"


### PR DESCRIPTION
## Summary

Full **Figma → tokens re-sync** of `@acronis-platform/design-tokens`, regenerating `primitives.json`, `semantic.json`, and `components.json` from the current Figma state via the documented workflow (`packages/design-tokens/context/figma-sync.md`). The JSON now mirrors Figma exactly; removed/renamed paths were **accepted, not aliased**.

Net leaf change: **+89 added, −49 removed, ~58 changed**. Full per-token detail is in the changeset (`.changeset/design-tokens-figma-sync.md`).

## Highlights

**Added**
- `components.button.icon.*` (16) — new icon-button color group mirroring `ghost` (background / border / icon / label × idle / hover / active / disabled). Backs the Figma `ButtonIcon` component, which was rebound to these variables.
- `components.switch.*` (16), expanded `components.item.*` (~30), restructured `components.form.*` (~30), `colors.focus.*` (4), and 5 new `typography.*` link/form-label styles.

**Changed values**
- **`brand-b` authored as teal** — 25 `semantic.colors.*` flip their `brand-b` mode from `{palette.blue.*}` → `{palette.teal.*}` (acronis unchanged), flowing through to 29 `components.button.*` values.
- `palette.blue.7` dark-mode lightness `45.1 → 54.9`; minor typography alias cleanup.

**Changed metadata**
- `units.stroke.3` is now scoped to **`EFFECT_FLOAT`** only (previously also `STROKE_FLOAT`). Value unchanged.

**Removed / renamed** (mirrors Figma — see changeset for the full migration map)
- `form.input.*` → `form.{background,border,icon}.*`; `form.switch.*` → top-level `switch.*`; `form._global.*` → `form.units.*` (sized scale); `sub-item.*` → `item.*`; `typography.link.{primary,secondary}` + `body.{link,strong-underlined}` → `typography.link.{default,default-underline,strong,strong-underline}`.
- Genuinely dropped (no successor): `sub-item.gap` (→ `item.gap-x`/`gap-y`), `sub-item.height-header`, `sub-item.width-collapsed`.

## Release

Changeset included — **minor** bump. Note: the removed/renamed published paths are technically breaking for any consumer referencing the old names; the changeset documents migrations so consumers can adjust.

## Validation
- `pnpm --filter @acronis-platform/design-tokens validate` — all three files ajv-valid.
- Snapshot under `.tmp/figma-tokens/` is intentionally not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)