### PR TITLE
feat(kitchen-sink): migrate to tokens-pd --ui-* tokens

### DIFF
--- a/apps/kitchen-sink/AGENTS.md
+++ b/apps/kitchen-sink/AGENTS.md
@@ -1,10 +1,10 @@
 # AGENTS.md — `apps/kitchen-sink`
 
 `@acronis-platform/kitchen-sink` — a single-page "kitchen sink" that renders
-**everything at once**: the `--av-*` design tokens / colors, default HTML
-element styles, the implemented `@acronis-platform/ui-react` components, and
-the `@acronis-platform/icons-react` packs. A visual reference / QA surface.
-**Private**, not published.
+**everything at once**: the `--ui-*` design tokens / colors (from
+`@acronis-platform/tokens-pd`), default HTML element styles, the implemented
+`@acronis-platform/ui-react` components, and the `@acronis-platform/icons-react`
+packs. A visual reference / QA surface. **Private**, not published.
 
 Cross-cutting topics live in `../../context/*.md`. This file documents only
 what's specific to this workspace.
@@ -25,24 +25,37 @@ Consequence: the dependency libraries must be built before this app's `dev`,
   (see `.github/workflows/ci.yml`, mirroring the `ui-legacy` step). `pnpm -r`
   is topological, so a plain `pnpm -r build` also builds them before this app.
 
-## Styling
+## Styling & tokens
 
 `src/main.tsx` imports `@acronis-platform/ui-react/styles` — the built CSS that
-already bundles the reset (default element styles), the `--av-*` tokens
-(`:root` + `.dark`), and the component utilities. The page's own layout uses
-inline styles + `var(--av-*)` tokens; there is **no Tailwind pipeline here**.
+bundles the reset (default element styles), the **semantic** `--ui-*` tokens
+(`@acronis-platform/tokens-pd/css/acronis.css`), and the component utilities.
+The page's own layout uses inline styles + `var(--ui-*)` tokens; there is **no
+Tailwind pipeline here**.
+
+`src/lib/tokens.ts` owns the rest of the token wiring, because tokens-pd's
+delivery model differs from the retired `design-theme`:
+
+- **Per-component tokens** (`--ui-button-*`, `--ui-switch-*`, …) are NOT bundled
+  by `ui-react/styles`, so `tokens.ts` imports the `css/<component>/acronis.css`
+  files and injects them once (needed both to render components and to enumerate
+  their names).
+- **Brand switching** injects `brand-b`'s _override-only_ `:root` stylesheet
+  (`applyBrand`) — it is not a class toggle.
+- **Light/dark** flips `color-scheme` (drives the tokens' `light-dark()`) and
+  mirrors `[data-theme]` for ui-react's `dark:` variant (`applyTheme`) — it is
+  not a `.dark` class.
 
 ## Sections (`src/sections/`)
 
-- `colors.tsx` — enumerates `--av-*` custom properties from the loaded
-  stylesheets at runtime (`src/lib/tokens.ts`); values resolve live per theme.
+- `colors.tsx` — enumerates `--ui-*` custom properties (semantic + per-component,
+  e.g. `--ui-button-*`) parsed from the tokens-pd CSS in `src/lib/tokens.ts`;
+  values resolve live per brand/scheme.
 - `elements.tsx` — raw HTML elements (headings, lists, table, native form
   controls) as the reset renders them.
 - `components.tsx` — `ui-react` `Button` (variants/sizes/states/with-icons) and
   `Switch`.
 - `icons.tsx` — galleries for all four `icons-react` packs.
-
-Light/dark is toggled by adding the `dark` class to `<html>` (`src/App.tsx`).
 
 ## Run
 

--- a/apps/kitchen-sink/AGENTS.md
+++ b/apps/kitchen-sink/AGENTS.md
@@ -51,6 +51,8 @@ delivery model differs from the retired `design-theme`:
 - `colors.tsx` — enumerates `--ui-*` custom properties (semantic + per-component,
   e.g. `--ui-button-*`) parsed from the tokens-pd CSS in `src/lib/tokens.ts`;
   values resolve live per brand/scheme.
+- `typography.tsx` — the `.ui-typography-*` utility classes (headings/body/link/
+  caption/note/fineprint), each shown as live sample text + its name and metrics.
 - `elements.tsx` — raw HTML elements (headings, lists, table, native form
   controls) as the reset renders them.
 - `components.tsx` — `ui-react` `Button` (variants/sizes/states/with-icons) and

--- a/apps/kitchen-sink/package.json
+++ b/apps/kitchen-sink/package.json
@@ -17,8 +17,8 @@
     "test:watch": "echo \"no tests in this workspace\" && exit 0"
   },
   "dependencies": {
-    "@acronis-platform/design-theme": "workspace:*",
     "@acronis-platform/icons-react": "workspace:*",
+    "@acronis-platform/tokens-pd": "workspace:*",
     "@acronis-platform/ui-react": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:"

--- a/apps/kitchen-sink/src/App.tsx
+++ b/apps/kitchen-sink/src/App.tsx
@@ -1,17 +1,18 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
-import {
-  brands,
-  defaultBrand,
-  tokens,
-  type Brand,
-} from '@acronis-platform/design-theme/js';
+import { useEffect, useState, type ReactNode } from 'react';
 
+import {
+  applyBrand,
+  applyTheme,
+  brandOverrideCount,
+  BRANDS,
+  DEFAULT_BRAND,
+  type Brand,
+  type ColorMode,
+} from '@/lib/tokens';
 import { ColorsSection } from '@/sections/colors';
 import { ComponentsSection } from '@/sections/components';
 import { ElementsSection } from '@/sections/elements';
 import { IconsSection } from '@/sections/icons';
-
-type ColorMode = 'light' | 'dark';
 
 function Section({
   id,
@@ -29,7 +30,7 @@ function Section({
           fontSize: 20,
           marginBottom: 20,
           paddingBottom: 8,
-          borderBottom: '1px solid var(--av-colors-border-on-surface-divider)',
+          borderBottom: '1px solid var(--ui-border-on-surface-divider)',
         }}
       >
         {title}
@@ -48,34 +49,28 @@ const SECTIONS = [
 
 export default function App() {
   const [mode, setMode] = useState<ColorMode>('light');
-  const [brand, setBrand] = useState<Brand>(defaultBrand);
+  const [brand, setBrand] = useState<Brand>(DEFAULT_BRAND);
 
+  // Light/dark drives the tokens' `light-dark()` via `color-scheme`.
   useEffect(() => {
-    const html = document.documentElement;
-    // Non-default brands are applied as a class (e.g. `brand-b`); the default
-    // brand lives on `:root` so it carries no class.
-    for (const b of brands) {
-      if (b !== defaultBrand) html.classList.remove(b);
-    }
-    if (brand !== defaultBrand) html.classList.add(brand);
-    html.classList.toggle('dark', mode === 'dark');
-  }, [brand, mode]);
+    applyTheme(mode);
+  }, [mode]);
 
-  // How many tokens the selected brand overrides vs the default, for the
-  // current scheme — 0 means the brand renders identically to the default.
-  const overrides = useMemo(() => {
-    if (brand === defaultBrand) return 0;
-    const base = tokens[defaultBrand][mode] as Record<string, string>;
-    const current = tokens[brand][mode] as Record<string, string>;
-    return Object.keys(current).filter((k) => base[k] !== current[k]).length;
-  }, [brand, mode]);
+  // A brand applies its `:root` override stylesheet (brand-b) or removes it.
+  useEffect(() => {
+    applyBrand(brand);
+  }, [brand]);
+
+  // How many tokens the selected brand overrides vs the default — 0 means the
+  // brand renders identically to the default.
+  const overrides = brandOverrideCount(brand);
 
   return (
     <div
       style={{
         minHeight: '100vh',
-        background: 'var(--av-colors-background-surface-primary)',
-        color: 'var(--av-colors-text-on-surface-primary)',
+        background: 'var(--ui-background-surface-primary)',
+        color: 'var(--ui-text-on-surface-primary)',
       }}
     >
       <header
@@ -88,8 +83,8 @@ export default function App() {
           justifyContent: 'space-between',
           gap: 16,
           padding: '12px 24px',
-          background: 'var(--av-colors-background-surface-primary)',
-          borderBottom: '1px solid var(--av-colors-border-on-surface-divider)',
+          background: 'var(--ui-background-surface-primary)',
+          borderBottom: '1px solid var(--ui-border-on-surface-divider)',
         }}
       >
         <strong>Acronis UI — Kitchen Sink</strong>
@@ -100,7 +95,7 @@ export default function App() {
             <a
               key={s.id}
               href={`#${s.id}`}
-              style={{ color: 'var(--av-colors-text-on-surface-link)' }}
+              style={{ color: 'var(--ui-text-on-surface-link)' }}
             >
               {s.title}
             </a>
@@ -121,19 +116,19 @@ export default function App() {
             style={{
               padding: '6px 8px',
               borderRadius: 6,
-              border: '1px solid var(--av-colors-border-on-surface-border)',
-              background: 'var(--av-colors-background-surface-secondary)',
+              border: '1px solid var(--ui-border-on-surface-border)',
+              background: 'var(--ui-background-surface-secondary)',
               color: 'inherit',
             }}
           >
-            {brands.map((b) => (
+            {BRANDS.map((b) => (
               <option key={b} value={b}>
                 {b}
               </option>
             ))}
           </select>
-          <span style={{ color: 'var(--av-colors-text-on-surface-secondary)' }}>
-            {brand === defaultBrand
+          <span style={{ color: 'var(--ui-text-on-surface-secondary)' }}>
+            {brand === DEFAULT_BRAND
               ? '(default)'
               : `(${overrides} override${overrides === 1 ? '' : 's'})`}
           </span>
@@ -145,8 +140,8 @@ export default function App() {
             padding: '6px 12px',
             borderRadius: 6,
             cursor: 'pointer',
-            border: '1px solid var(--av-colors-border-on-surface-border)',
-            background: 'var(--av-colors-background-surface-secondary)',
+            border: '1px solid var(--ui-border-on-surface-border)',
+            background: 'var(--ui-background-surface-secondary)',
             color: 'inherit',
           }}
         >

--- a/apps/kitchen-sink/src/App.tsx
+++ b/apps/kitchen-sink/src/App.tsx
@@ -13,6 +13,7 @@ import { ColorsSection } from '@/sections/colors';
 import { ComponentsSection } from '@/sections/components';
 import { ElementsSection } from '@/sections/elements';
 import { IconsSection } from '@/sections/icons';
+import { TypographySection } from '@/sections/typography';
 
 function Section({
   id,
@@ -42,6 +43,7 @@ function Section({
 
 const SECTIONS = [
   { id: 'colors', title: 'Colors & tokens', Component: ColorsSection },
+  { id: 'typography', title: 'Typography', Component: TypographySection },
   { id: 'elements', title: 'Default elements', Component: ElementsSection },
   { id: 'components', title: 'Components', Component: ComponentsSection },
   { id: 'icons', title: 'Icons', Component: IconsSection },

--- a/apps/kitchen-sink/src/lib/tokens.ts
+++ b/apps/kitchen-sink/src/lib/tokens.ts
@@ -1,8 +1,165 @@
 /**
+ * Token data layer for the kitchen sink, sourced from
+ * `@acronis-platform/tokens-pd` — the generated `--ui-*` CSS.
+ *
+ * `@acronis-platform/ui-react/styles` already loads the **semantic** acronis
+ * tokens (`css/acronis.css`). It does NOT bundle the **per-component** token
+ * files (`css/<component>/acronis.css`), so we load those here — both to render
+ * the components correctly and to enumerate their `--ui-<component>-*` names.
+ *
+ * Brand switching: `brand-b` ships *override-only* CSS scoped to `:root`, so a
+ * brand is applied by injecting its override stylesheet (not a class toggle).
+ * Light/dark is driven by the tokens' `light-dark()` + `color-scheme`, so we
+ * flip `color-scheme` (and mirror `[data-theme]` for ui-react's `dark:` variant).
+ */
+
+// --- acronis (default brand): semantic is applied by ui-react/styles; we read
+//     it here only to enumerate names. Per-component files we both apply + read.
+import semanticAcronis from '@acronis-platform/tokens-pd/css/acronis.css?raw';
+import breadcrumbAcronis from '@acronis-platform/tokens-pd/css/breadcrumb/acronis.css?raw';
+import buttonAcronis from '@acronis-platform/tokens-pd/css/button/acronis.css?raw';
+import chipAcronis from '@acronis-platform/tokens-pd/css/chip/acronis.css?raw';
+import formAcronis from '@acronis-platform/tokens-pd/css/form/acronis.css?raw';
+import iconAcronis from '@acronis-platform/tokens-pd/css/icon/acronis.css?raw';
+import itemAcronis from '@acronis-platform/tokens-pd/css/item/acronis.css?raw';
+import menuItemAcronis from '@acronis-platform/tokens-pd/css/menu-item/acronis.css?raw';
+import switchAcronis from '@acronis-platform/tokens-pd/css/switch/acronis.css?raw';
+import tagAcronis from '@acronis-platform/tokens-pd/css/tag/acronis.css?raw';
+import tooltipAcronis from '@acronis-platform/tokens-pd/css/tooltip/acronis.css?raw';
+import treeAcronis from '@acronis-platform/tokens-pd/css/tree/acronis.css?raw';
+
+// --- brand-b: override-only CSS, applied on demand.
+import semanticBrandB from '@acronis-platform/tokens-pd/css/brand-b.css?raw';
+import breadcrumbBrandB from '@acronis-platform/tokens-pd/css/breadcrumb/brand-b.css?raw';
+import buttonBrandB from '@acronis-platform/tokens-pd/css/button/brand-b.css?raw';
+import chipBrandB from '@acronis-platform/tokens-pd/css/chip/brand-b.css?raw';
+import formBrandB from '@acronis-platform/tokens-pd/css/form/brand-b.css?raw';
+import iconBrandB from '@acronis-platform/tokens-pd/css/icon/brand-b.css?raw';
+import itemBrandB from '@acronis-platform/tokens-pd/css/item/brand-b.css?raw';
+import menuItemBrandB from '@acronis-platform/tokens-pd/css/menu-item/brand-b.css?raw';
+import switchBrandB from '@acronis-platform/tokens-pd/css/switch/brand-b.css?raw';
+import tagBrandB from '@acronis-platform/tokens-pd/css/tag/brand-b.css?raw';
+import tooltipBrandB from '@acronis-platform/tokens-pd/css/tooltip/brand-b.css?raw';
+import treeBrandB from '@acronis-platform/tokens-pd/css/tree/brand-b.css?raw';
+
+export type Brand = 'acronis' | 'brand-b';
+export type ColorMode = 'light' | 'dark';
+
+export const BRANDS: Brand[] = ['acronis', 'brand-b'];
+export const DEFAULT_BRAND: Brand = 'acronis';
+
+export interface TokenGroup {
+  /** First path segment after `--ui-` (e.g. `button`, `background`). */
+  tier: string;
+  tokens: { name: string }[];
+}
+
+/** Per-component token CSS (not bundled by ui-react/styles). */
+const COMPONENT_SOURCES: { tier: string; css: string }[] = [
+  { tier: 'breadcrumb', css: breadcrumbAcronis },
+  { tier: 'button', css: buttonAcronis },
+  { tier: 'chip', css: chipAcronis },
+  { tier: 'form', css: formAcronis },
+  { tier: 'icon', css: iconAcronis },
+  { tier: 'item', css: itemAcronis },
+  { tier: 'menu-item', css: menuItemAcronis },
+  { tier: 'switch', css: switchAcronis },
+  { tier: 'tag', css: tagAcronis },
+  { tier: 'tooltip', css: tooltipAcronis },
+  { tier: 'tree', css: treeAcronis },
+];
+
+const BRAND_B_CSS = [
+  semanticBrandB,
+  breadcrumbBrandB,
+  buttonBrandB,
+  chipBrandB,
+  formBrandB,
+  iconBrandB,
+  itemBrandB,
+  menuItemBrandB,
+  switchBrandB,
+  tagBrandB,
+  tooltipBrandB,
+  treeBrandB,
+].join('\n');
+
+/** Extract the unique `--ui-*` custom-property names declared in a CSS string. */
+function tokenNames(css: string): string[] {
+  const set = new Set<string>();
+  for (const m of css.matchAll(/(--ui-[a-z0-9-]+)\s*:/g)) set.add(m[1]);
+  return [...set].sort();
+}
+
+/** Semantic groups (`--ui-background-*`, `--ui-text-*`, …), grouped by tier. */
+export const semanticGroups: TokenGroup[] = (() => {
+  const byTier = new Map<string, string[]>();
+  for (const name of tokenNames(semanticAcronis)) {
+    const tier = name.slice('--ui-'.length).split('-')[0];
+    const list = byTier.get(tier) ?? [];
+    list.push(name);
+    byTier.set(tier, list);
+  }
+  return [...byTier.entries()].map(([tier, names]) => ({
+    tier,
+    tokens: names.map((name) => ({ name })),
+  }));
+})();
+
+/** Per-component groups (`--ui-button-*`, `--ui-switch-*`, …). */
+export const componentGroups: TokenGroup[] = COMPONENT_SOURCES.map((s) => ({
+  tier: s.tier,
+  tokens: tokenNames(s.css).map((name) => ({ name })),
+}));
+
+/** How many tokens a non-default brand overrides. */
+export function brandOverrideCount(brand: Brand): number {
+  return brand === DEFAULT_BRAND ? 0 : tokenNames(BRAND_B_CSS).length;
+}
+
+const COMPONENT_TOKENS_STYLE_ID = 'ks-component-tokens';
+const BRAND_OVERRIDES_STYLE_ID = 'ks-brand-overrides';
+
+/** Apply the per-component token CSS once (ui-react/styles omits it). */
+function injectComponentTokens(): void {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(COMPONENT_TOKENS_STYLE_ID)) return;
+  const el = document.createElement('style');
+  el.id = COMPONENT_TOKENS_STYLE_ID;
+  el.textContent = COMPONENT_SOURCES.map((s) => s.css).join('\n');
+  document.head.appendChild(el);
+}
+injectComponentTokens();
+
+/** Apply a brand by injecting (or removing) its `:root` override stylesheet. */
+export function applyBrand(brand: Brand): void {
+  if (typeof document === 'undefined') return;
+  const existing = document.getElementById(BRAND_OVERRIDES_STYLE_ID);
+  if (brand === DEFAULT_BRAND) {
+    existing?.remove();
+    return;
+  }
+  const el = existing ?? document.createElement('style');
+  el.id = BRAND_OVERRIDES_STYLE_ID;
+  el.textContent = BRAND_B_CSS;
+  // Append last so brand overrides win over the base `:root` declarations.
+  document.head.appendChild(el);
+}
+
+/** Flip light/dark: `color-scheme` drives `light-dark()`; `[data-theme]` drives ui-react's `dark:`. */
+export function applyTheme(mode: ColorMode): void {
+  if (typeof document === 'undefined') return;
+  const html = document.documentElement;
+  html.dataset.theme = mode;
+  html.style.colorScheme = mode;
+}
+
+/**
  * Resolve a CSS custom property's current value (theme-aware — reflects the
- * active brand/scheme classes on `<html>`).
+ * active brand/scheme on the document).
  */
 export function resolveToken(name: string): string {
+  if (typeof document === 'undefined') return '';
   return getComputedStyle(document.documentElement)
     .getPropertyValue(name)
     .trim();

--- a/apps/kitchen-sink/src/lib/tokens.ts
+++ b/apps/kitchen-sink/src/lib/tokens.ts
@@ -112,6 +112,51 @@ export const componentGroups: TokenGroup[] = COMPONENT_SOURCES.map((s) => ({
   tokens: tokenNames(s.css).map((name) => ({ name })),
 }));
 
+export interface TypographyStyle {
+  /** e.g. `ui-typography-body-default`. */
+  className: string;
+  /** First segment, e.g. `body`, `headings`, `link`. */
+  group: string;
+  /** Remaining segments, e.g. `default`, `form-label`, `default-underline`. */
+  variant: string;
+  fontFamily: string;
+  fontSize: string;
+  fontWeight: string;
+  lineHeight: string;
+  letterSpacing: string;
+}
+
+/**
+ * Typography tokens are emitted as `.ui-typography-*` utility classes (in the
+ * semantic CSS, already applied by ui-react/styles), not custom properties.
+ * Parse the class rules so the demo can show each style + its metrics.
+ */
+export const typographyStyles: TypographyStyle[] = (() => {
+  const out: TypographyStyle[] = [];
+  const blockRe = /\.(ui-typography-[a-z0-9-]+)\s*\{([^}]*)\}/g;
+  for (const m of semanticAcronis.matchAll(blockRe)) {
+    const className = m[1];
+    const decls: Record<string, string> = {};
+    for (const d of m[2].split(';')) {
+      const i = d.indexOf(':');
+      if (i === -1) continue;
+      decls[d.slice(0, i).trim()] = d.slice(i + 1).trim();
+    }
+    const parts = className.slice('ui-typography-'.length).split('-');
+    out.push({
+      className,
+      group: parts[0],
+      variant: parts.slice(1).join('-'),
+      fontFamily: decls['font-family'] ?? '',
+      fontSize: decls['font-size'] ?? '',
+      fontWeight: decls['font-weight'] ?? '',
+      lineHeight: decls['line-height'] ?? '',
+      letterSpacing: decls['letter-spacing'] ?? '',
+    });
+  }
+  return out;
+})();
+
 /** How many tokens a non-default brand overrides. */
 export function brandOverrideCount(brand: Brand): number {
   return brand === DEFAULT_BRAND ? 0 : tokenNames(BRAND_B_CSS).length;

--- a/apps/kitchen-sink/src/main.tsx
+++ b/apps/kitchen-sink/src/main.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 
-// The published library stylesheet: CSS reset (default element styles),
-// the `--av-*` design tokens (:root + .dark), and the component utilities.
+// The published library stylesheet: CSS reset (default element styles), the
+// semantic `--ui-*` design tokens (from @acronis-platform/tokens-pd, with
+// `light-dark()` driven by `color-scheme`), and the component utilities.
+// Per-component token CSS (`--ui-button-*`, …) is loaded in `@/lib/tokens`.
 import '@acronis-platform/ui-react/styles';
 
 import App from '@/App';

--- a/apps/kitchen-sink/src/sections/colors.tsx
+++ b/apps/kitchen-sink/src/sections/colors.tsx
@@ -1,8 +1,18 @@
-import { groups, type TokenGroup } from '@acronis-platform/design-theme/js';
+import {
+  componentGroups,
+  resolveToken,
+  semanticGroups,
+  type TokenGroup,
+} from '@/lib/tokens';
 
-import { resolveToken } from '@/lib/tokens';
+const SWATCH_BORDER = '1px solid var(--ui-border-on-surface-border)';
 
-const SWATCH_BORDER = '1px solid var(--av-colors-border-on-surface-border)';
+/** A value that can be shown as a color/gradient swatch. */
+function isColorValue(value: string): boolean {
+  return /^(#|rgb|hsl|light-dark|linear-gradient|radial-gradient|var\()/.test(
+    value
+  );
+}
 
 function GroupHeading({ label, count }: { label: string; count: number }) {
   return (
@@ -20,177 +30,109 @@ function GroupHeading({ label, count }: { label: string; count: number }) {
   );
 }
 
-/** Semantic groups: a labelled grid of swatch cards. */
-function SemanticGroup({ group }: { group: TokenGroup }) {
+/** One token: a swatch (colors/gradients) or a value chip (dimensions/etc.),
+ *  plus the full `--ui-*` custom-property name. */
+function TokenCard({ name }: { name: string }) {
+  const value = resolveToken(name);
+  const isColor = isColorValue(value);
   return (
-    <div>
-      <GroupHeading label={group.label} count={group.tokens.length} />
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))',
-          gap: 12,
-        }}
-      >
-        {group.tokens.map((token) => {
-          const cssVar = `--av-${token.name}`;
-          return (
-            <div key={token.name} style={{ minWidth: 0 }}>
-              <div
-                style={{
-                  height: 44,
-                  borderRadius: 6,
-                  background: `var(${cssVar})`,
-                  border: SWATCH_BORDER,
-                }}
-              />
-              <div style={{ fontSize: 11, fontWeight: 500, marginTop: 4 }}>
-                {token.label}
-              </div>
-              <div
-                style={{
-                  fontSize: 10,
-                  color: 'var(--av-colors-text-on-surface-secondary)',
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-              >
-                {resolveToken(cssVar)}
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-/** Palette families: a contiguous ramp with shade labels underneath. */
-function PaletteRamp({ group }: { group: TokenGroup }) {
-  const family = group.label.replace('palette · ', '');
-  return (
-    <div>
-      <GroupHeading label={family} count={group.tokens.length} />
-      <div
-        style={{ borderRadius: 8, overflow: 'hidden', border: SWATCH_BORDER }}
-      >
-        <div style={{ display: 'flex' }}>
-          {group.tokens.map((token) => {
-            const cssVar = `--av-${token.name}`;
-            return (
-              <div
-                key={token.name}
-                title={`${token.label}\n${resolveToken(cssVar)}`}
-                style={{ flex: 1, height: 48, background: `var(${cssVar})` }}
-              />
-            );
-          })}
-        </div>
+    <div style={{ minWidth: 0 }}>
+      {isColor ? (
         <div
           style={{
+            height: 44,
+            borderRadius: 6,
+            background: `var(${name})`,
+            border: SWATCH_BORDER,
+          }}
+        />
+      ) : (
+        <div
+          style={{
+            height: 44,
+            borderRadius: 6,
+            border: SWATCH_BORDER,
             display: 'flex',
-            background: 'var(--av-colors-background-surface-secondary)',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '0 6px',
+            fontSize: 12,
+            fontFamily: 'monospace',
+            color: 'var(--ui-text-on-surface-primary)',
+            background: 'var(--ui-background-surface-secondary)',
+            overflow: 'hidden',
           }}
         >
-          {group.tokens.map((token) => (
-            <span
-              key={token.name}
-              style={{
-                flex: 1,
-                fontSize: 9,
-                textAlign: 'center',
-                padding: '2px 0',
-                color: 'var(--av-colors-text-on-surface-secondary)',
-              }}
-            >
-              {token.label}
-            </span>
-          ))}
+          {value || '—'}
         </div>
+      )}
+      <div
+        style={{
+          fontSize: 10,
+          fontFamily: 'monospace',
+          marginTop: 4,
+          wordBreak: 'break-all',
+          color: 'var(--ui-text-on-surface-primary)',
+        }}
+      >
+        {name}
       </div>
+      {isColor && (
+        <div
+          style={{
+            fontSize: 9,
+            color: 'var(--ui-text-on-surface-secondary)',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {value}
+        </div>
+      )}
     </div>
   );
 }
 
-/** Gradient groups: larger cards showing the resolved CSS gradient + value. */
-function GradientGroup({ group }: { group: TokenGroup }) {
+function Group({ group }: { group: TokenGroup }) {
   return (
     <div>
-      <GroupHeading label={group.label} count={group.tokens.length} />
+      <GroupHeading label={group.tier} count={group.tokens.length} />
       <div
         style={{
           display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(150px, 1fr))',
           gap: 12,
         }}
       >
-        {group.tokens.map((token) => {
-          const cssVar = `--av-${token.name}`;
-          return (
-            <div key={token.name} style={{ minWidth: 0 }}>
-              <div
-                style={{
-                  height: 72,
-                  borderRadius: 8,
-                  background: `var(${cssVar})`,
-                  border: SWATCH_BORDER,
-                }}
-              />
-              <div style={{ fontSize: 11, fontWeight: 500, marginTop: 6 }}>
-                {token.label}
-              </div>
-              <div
-                style={{
-                  fontSize: 10,
-                  color: 'var(--av-colors-text-on-surface-secondary)',
-                  wordBreak: 'break-all',
-                }}
-              >
-                {resolveToken(cssVar)}
-              </div>
-            </div>
-          );
-        })}
+        {group.tokens.map((token) => (
+          <TokenCard key={token.name} name={token.name} />
+        ))}
       </div>
     </div>
   );
 }
 
-const isGradientToken = (name: string): boolean =>
-  resolveToken(`--av-${name}`).startsWith('linear-gradient');
-
 export function ColorsSection() {
-  const isPalette = (g: TokenGroup) => g.label.startsWith('palette ·');
-  const isGradient = (g: TokenGroup) =>
-    g.tokens.length > 0 && isGradientToken(g.tokens[0].name);
-
-  const gradient = groups.filter((g) => !isPalette(g) && isGradient(g));
-  const semantic = groups.filter((g) => !isPalette(g) && !isGradient(g));
-  const palette = groups.filter(isPalette);
-
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 32 }}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 40 }}>
+      <p style={{ fontSize: 13, color: 'var(--ui-text-on-surface-secondary)' }}>
+        Generated <code>--ui-*</code> tokens from{' '}
+        <code>@acronis-platform/tokens-pd</code>. Values reflect the active brand
+        and light/dark scheme.
+      </p>
+
       <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
-        <h3 style={{ fontSize: 14, fontWeight: 600 }}>Semantic</h3>
-        {semantic.map((group) => (
-          <SemanticGroup key={group.label} group={group} />
+        <h3 style={{ fontSize: 14, fontWeight: 600 }}>Semantic tokens</h3>
+        {semanticGroups.map((group) => (
+          <Group key={group.tier} group={group} />
         ))}
       </div>
 
-      {gradient.length > 0 && (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-          <h3 style={{ fontSize: 14, fontWeight: 600 }}>Gradients</h3>
-          {gradient.map((group) => (
-            <GradientGroup key={group.label} group={group} />
-          ))}
-        </div>
-      )}
-
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-        <h3 style={{ fontSize: 14, fontWeight: 600 }}>Palette</h3>
-        {palette.map((group) => (
-          <PaletteRamp key={group.label} group={group} />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+        <h3 style={{ fontSize: 14, fontWeight: 600 }}>Component tokens</h3>
+        {componentGroups.map((group) => (
+          <Group key={group.tier} group={group} />
         ))}
       </div>
     </div>

--- a/apps/kitchen-sink/src/sections/colors.tsx
+++ b/apps/kitchen-sink/src/sections/colors.tsx
@@ -101,7 +101,7 @@ function Group({ group }: { group: TokenGroup }) {
       <div
         style={{
           display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, minmax(150px, 1fr))',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
           gap: 12,
         }}
       >

--- a/apps/kitchen-sink/src/sections/components.tsx
+++ b/apps/kitchen-sink/src/sections/components.tsx
@@ -28,7 +28,7 @@ function Row({
       <span
         style={{
           fontSize: 12,
-          color: 'var(--av-colors-text-on-surface-secondary)',
+          color: 'var(--ui-text-on-surface-secondary)',
         }}
       >
         {label}

--- a/apps/kitchen-sink/src/sections/icons.tsx
+++ b/apps/kitchen-sink/src/sections/icons.tsx
@@ -33,14 +33,14 @@ function Gallery({ icons }: { icons: IconMap }) {
             gap: 6,
             padding: 8,
             borderRadius: 6,
-            border: '1px solid var(--av-colors-border-on-surface-border)',
+            border: '1px solid var(--ui-border-on-surface-border)',
           }}
         >
           <Icon size={24} />
           <span
             style={{
               fontSize: 9,
-              color: 'var(--av-colors-text-on-surface-secondary)',
+              color: 'var(--ui-text-on-surface-secondary)',
               textAlign: 'center',
               overflow: 'hidden',
               textOverflow: 'ellipsis',

--- a/apps/kitchen-sink/src/sections/typography.tsx
+++ b/apps/kitchen-sink/src/sections/typography.tsx
@@ -1,0 +1,99 @@
+import { typographyStyles, type TypographyStyle } from '@/lib/tokens';
+
+/** Preferred display order; any unlisted groups are appended after these. */
+const GROUP_ORDER = ['headings', 'body', 'link', 'caption', 'note', 'fineprint'];
+
+const SAMPLE = 'The quick brown fox jumps over the lazy dog';
+
+function GroupHeading({ label, count }: { label: string; count: number }) {
+  return (
+    <h3
+      style={{
+        fontSize: 12,
+        textTransform: 'uppercase',
+        letterSpacing: 0.5,
+        opacity: 0.6,
+        marginBottom: 4,
+      }}
+    >
+      {label} <span style={{ fontWeight: 400 }}>({count})</span>
+    </h3>
+  );
+}
+
+/** A single typography token: live sample text + its name and metrics. */
+function StyleRow({ style }: { style: TypographyStyle }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: 24,
+        alignItems: 'baseline',
+        justifyContent: 'space-between',
+        padding: '12px 0',
+        borderBottom: '1px solid var(--ui-border-on-surface-divider)',
+      }}
+    >
+      <div style={{ flex: '1 1 auto', minWidth: 0, overflow: 'hidden' }}>
+        <span className={style.className}>{SAMPLE}</span>
+      </div>
+      <div
+        style={{
+          flex: '0 0 auto',
+          fontFamily: 'monospace',
+          fontSize: 11,
+          textAlign: 'right',
+          color: 'var(--ui-text-on-surface-secondary)',
+        }}
+      >
+        <div style={{ color: 'var(--ui-text-on-surface-primary)' }}>
+          .{style.className}
+        </div>
+        <div>
+          {style.fontSize} / {style.lineHeight} · {style.fontWeight}
+          {style.letterSpacing && style.letterSpacing !== '0px'
+            ? ` · ${style.letterSpacing}`
+            : ''}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function TypographySection() {
+  const seen = new Set<string>();
+  const orderedGroups = [
+    ...GROUP_ORDER,
+    ...typographyStyles
+      .map((s) => s.group)
+      .filter((g) => !GROUP_ORDER.includes(g)),
+  ].filter((g) => (seen.has(g) ? false : seen.add(g)));
+
+  const groups = orderedGroups
+    .map((group) => ({
+      group,
+      items: typographyStyles.filter((s) => s.group === group),
+    }))
+    .filter((g) => g.items.length > 0);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 32 }}>
+      <p style={{ fontSize: 13, color: 'var(--ui-text-on-surface-secondary)' }}>
+        Typography tokens from <code>@acronis-platform/tokens-pd</code>, emitted
+        as <code>.ui-typography-*</code> utility classes. Samples render live, so
+        the font of the active brand applies.
+      </p>
+
+      {groups.map(({ group, items }) => (
+        <div key={group}>
+          <GroupHeading label={group} count={items.length} />
+          <div>
+            {items.map((style) => (
+              <StyleRow key={style.className} style={style} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,6 +367,43 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
 
+  apps/kitchen-sink:
+    dependencies:
+      '@acronis-platform/icons-react':
+        specifier: workspace:*
+        version: link:../../packages/icons-react
+      '@acronis-platform/tokens-pd':
+        specifier: workspace:*
+        version: link:../../packages/tokens-pd
+      '@acronis-platform/ui-react':
+        specifier: workspace:*
+        version: link:../../packages/ui-react
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
+      '@vitejs/plugin-react':
+        specifier: 5.1.1
+        version: 5.1.1(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
+      eslint:
+        specifier: 'catalog:'
+        version: 9.39.4(jiti@2.7.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0)
+
   packages/design-assets:
     devDependencies:
       ajv:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,11 +2,6 @@ packages:
   - 'apps/*'
   - 'packages/*'
   - 'tools/*'
-  # Temporarily excluded: apps/kitchen-sink still consumes the retired
-  # design-theme `/js` export + `--av-*` names. It is left untouched and out of
-  # the workspace until a follow-up migrates it to @acronis-platform/tokens-pd
-  # (the new `--ui-*` CSS + the pd-tailwind preset).
-  - '!apps/kitchen-sink'
 
 # Single source of truth for dependency versions used by more than one
 # workspace. Workspaces refer to these with "catalog:" — pnpm rewrites


### PR DESCRIPTION
## What

Re-enables and migrates `apps/kitchen-sink` off the retired `design-theme` onto **`@acronis-platform/tokens-pd`** (the new `--ui-*` CSS). It had been excluded from the workspace pending exactly this follow-up (see the removed `pnpm-workspace.yaml` comment).

## Changes
- **Workspace**: swap the dead `@acronis-platform/design-theme` dep for `tokens-pd`; drop the `!apps/kitchen-sink` exclusion so it installs/builds again.
- **`src/lib/tokens.ts`**: source `--ui-*` names from the tokens-pd CSS (semantic + per-component); inject the per-component token CSS (`ui-react/styles` bundles only semantic); apply `brand-b` via its `:root` override stylesheet; flip light/dark via `color-scheme` + `[data-theme]` (the new `light-dark()` model — no more `.dark` class).
- **`colors.tsx`**: shows the full `--ui-*` names — including `--ui-button-*` — with swatches for colors/gradients and value chips for dimension tokens (e.g. `--ui-breadcrumb-gap: 4px`).
- Replace remaining `--av-*` refs across `App`/sections; refresh workspace `AGENTS.md`.

## Verification
- `build` (deps + app), `typecheck`, `lint` all pass.
- ui-react dist now emits **185 `--ui-*`** tokens (was stale `--av-*`).
- Ran the built app: token names render as `--ui-...`; **brand switch** (acronis ↔ brand-b, '92 overrides') and **light/dark** confirmed working.