### PR TITLE
feat(ui-spec): framework-agnostic component specs — proposal + phase 0 spike

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,9 @@ that workspace**, never here.
   `context/backlog-p2-primitives.md`, `context/backlog-p3-p4.md`.
 - `context/project-board.md` — how we run Project #3: epic/task model, status
   lifecycle + gates, fields, views, and automation.
+- `context/component-specs-proposal.md` — **Proposed** (not yet adopted):
+  framework-agnostic component specs + a machine-readable design grammar, to
+  support future non-React implementations and agent tooling.
 
 ## Tooling preconditions
 

--- a/context/component-specs-proposal.md
+++ b/context/component-specs-proposal.md
@@ -1,0 +1,146 @@
+# Proposal: framework-agnostic component specs + design grammar
+
+- **Status:** Proposed (not yet adopted)
+- **Date:** 2026-06-07
+- **Owner:** Leonid Romanov
+- **Affects:** `packages/ui-react`, `packages/tokens-pd`, future Vue / Web
+  Component implementations; the `ui-kit-pipeline` agent workflow.
+- **Related:** [`roadmap.md`](roadmap.md) (ui-react replaces legacy by Q3 2026;
+  future non-React implementations), [`conventions.md`](conventions.md).
+
+## Problem
+
+Today a component's "truth" is spread across several places: the React source
+(`cva` variants, props), Storybook stories, Vitest tests, the Figma file, the
+Figma Code Connect mapping, and prose in `AGENTS.md` / `context/*`. Nothing is a
+single, framework-neutral, machine-readable description of **what a component
+is** — its API contract, anatomy, states, behavior, accessibility obligations,
+and how it composes with other components.
+
+Two consequences:
+
+1. **The roadmap wants more than React.** When a Vue or Web Component
+   implementation lands, there is no shared contract for it to target — each
+   implementation would re-derive the component's behavior from the React code
+   or from Figma, and drift.
+2. **Agents and tooling have no structured ground truth.** Our workflow is
+   heavily agent-driven (`AGENTS.md`, the `ui-kit-pipeline`), but agents read
+   prose, not a queryable contract. Docs, story scaffolds, and conformance
+   checks can't be generated from a source that doesn't exist.
+
+A precedent exists: the Acronis **Vue** UI Kit (`@uikit/ui-kit`, a separate
+repo) ships two packages — `grammar` and `specs` — that solve exactly this. This
+proposal evaluates adopting an **adapted** version here.
+
+## The reference model (from the Vue ui-kit)
+
+- **`grammar`** — a "design constitution" above any single component: a
+  machine-readable registry of cross-component **rules** (`spacing/8px-grid`,
+  `accessibility/focus-trap`, `interaction/escape-close`; each typed with
+  `severity` `must`/`should`/`may`, `category`, `wcag`, `relatedRules`), plus
+  **composition patterns** (confirmation dialog, table toolbar, master-detail…)
+  that name the components they involve and the rules that govern them, plus a
+  documented **override** mechanism. This is the **WHEN/WHY** layer and is where
+  "live interaction between components" is captured.
+- **`specs`** — one directory per component, a strict **7-file format**:
+  - `index.yaml` — identity, status, category, Open UI mapping, dependencies.
+  - `anatomy.yaml` — root element/role, named parts (incl. `::part()`), layout,
+    and exhaustive visual states with triggers / `affects` / `exclusive_with`.
+  - `api.yaml` — a **framework-agnostic `contract`** (properties, events, slots,
+    methods) **plus an `adapters` block** with Vue / React / Web Component usage
+    examples. This is the keystone for multi-framework implementation.
+  - `tokens.yaml` — design tokens the component consumes.
+  - `behavior.md` — Given/When/Then scenarios, incl. cross-component ones.
+  - `accessibility.md` — ARIA, keyboard map, SR announcements, contrast.
+  - `README.md` — when to use / not use, quick examples per framework.
+
+Crucially, in the reference repo specs are **not documentation-only**: scripts
+validate the YAML against JSON Schemas, validate that implementations conform,
+and **generate Storybook stories and tests from the specs**. That generative /
+conformance loop is what makes the model worth more than a wiki.
+
+## Decision drivers
+
+- **Multi-framework future** (roadmap): one contract, many implementations.
+- **Agent-first repo:** structured, queryable ground truth beats prose.
+- **Single source of truth** to end the kind of drift we already hit (Figma vs
+  `tokens-pd` values on the Button work).
+- **Timing:** `ui-react` has ~3 components today. Specs can _lead_
+  implementation now, instead of retrofitting ~90 components later (as the Vue
+  repo had to).
+
+## Options considered
+
+1. **Do nothing.** Keep truth spread across source/stories/tests/Figma.
+   Cheapest now; pays the multi-framework and drift costs later, repeatedly.
+2. **Lean on Storybook + Figma Code Connect only.** Improves docs and
+   design↔code mapping, but neither is framework-neutral nor a queryable
+   behavior/anatomy contract; neither drives conformance.
+3. **Adopt the Vue system wholesale.** Maximum capability, but duplicates assets
+   this repo already does _better_ (tokens) and imports Vue-specific shape.
+4. **Adopt an adapted subset (recommended).** Take the framework-agnostic
+   contract + anatomy + behavior + a11y + composition grammar; reference our
+   existing token pipeline instead of duplicating it; require a conformance
+   check from day one.
+
+## Recommendation
+
+Adopt **Option 4**: a new framework-agnostic spec package (working name
+`packages/ui-spec`) plus a small machine-readable grammar, **spec-leads-
+implementation**, with these scope decisions:
+
+| Layer                                             | Decision                                                                                                                                                                                  |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `api.yaml` contract + adapters                    | **Adopt fully** — the neutral contract future Vue/WC target.                                                                                                                              |
+| `anatomy.yaml`, `behavior.md`, `accessibility.md` | **Adopt** — consolidates today's scattered knowledge.                                                                                                                                     |
+| grammar rules + composition patterns              | **Adopt selectively** — start with the `must` rules (a11y, focus, escape-close). Overlaps `context/*` prose, but machine-readable is the upgrade.                                         |
+| `tokens.yaml`                                     | **Do NOT duplicate values.** Our `design-tokens → tokens-pd` pipeline is more mature (DTCG, multi-brand, `light-dark()`). Specs **reference `--ui-*` token names**, never restate values. |
+| `index.yaml` Figma link                           | Point at the existing Code Connect mapping; don't re-map.                                                                                                                                 |
+
+### Non-negotiable: conformance, or it rots
+
+A spec with no check degrades into stale documentation. Required from the start:
+
+1. JSON-Schema validation of the YAML (specs are well-formed).
+2. At least one **conformance test** — e.g. assert `button.tsx`'s `cva`
+   `variant`/`size` keys match `api.yaml`'s `contract.properties` — reusing the
+   existing Vitest setup. Story/test/doc generation from specs is the
+   high-leverage follow-on, but the conformance check is what keeps it honest.
+
+## Phased plan
+
+- **Phase 0 — Spike (1 package, 3 components).** Stand up `packages/ui-spec`;
+  author specs for `button`, `button-icon`, `switch` (tokens **by reference**);
+  add JSON-Schema validation + one `cva`↔contract conformance test. Review.
+- **Phase 1 — Grammar seed.** Encode the `must` rules as a typed registry; wire
+  it into the `ui-kit-pipeline` so the Design/QA gates can cite rule IDs.
+- **Phase 2 — Generation.** Generate Storybook story scaffolds (and/or test
+  skeletons) from specs to prove the loop.
+- **Phase 3 — Scale with the library.** Author a spec alongside every new
+  `ui-react` component (it becomes part of the component's definition of done),
+  growing coverage as ui-react expands toward replacing legacy.
+
+## Risks & mitigations
+
+- **Maintenance burden at scale** → specs lead, not retrofit; one spec per
+  component is part of DoD, not a separate migration.
+- **Spec/impl drift** → the conformance check (above) is mandatory, not optional.
+- **Duplication with tokens-pd / Code Connect** → reference, never restate.
+- **Adapter examples going stale** → keep examples minimal; consider generating
+  them, or lint them against the public API.
+
+## Open questions
+
+- Package name/placement: `packages/ui-spec` (published?) vs a private tool.
+- Does the grammar live in the same package or its own?
+- How much of the Vue repo's `generate-*-from-specs` tooling do we port vs.
+  rebuild around our Vite/Vitest/Storybook 10 setup?
+- Do we align component/prop naming to Open UI now (as the Vue repo does), or
+  keep the current shadcn-derived names?
+
+## References
+
+- Reference implementation: `@uikit/ui-kit` `packages/grammar` and
+  `packages/specs` (separate Vue repo). 7-file spec format; ~90 components;
+  `validate-specs` / `validate-components` / `generate-stories-from-specs` /
+  `generate-tests-from-specs`.

--- a/packages/ui-react/src/components/ui/button-icon/__stories__/button-icon.generated.stories.tsx
+++ b/packages/ui-react/src/components/ui/button-icon/__stories__/button-icon.generated.stories.tsx
@@ -1,7 +1,9 @@
 // AUTO-GENERATED from @acronis-platform/ui-spec — DO NOT EDIT.
 // Regenerate: pnpm --filter @acronis-platform/ui-spec generate:stories
+// `:hover` / `:active` stories require a Storybook pseudo-states addon to paint.
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { userEvent } from 'storybook/test';
 import { PlusIcon } from '@acronis-platform/icons-react/stroke-mono';
 import { ButtonIcon } from '../button-icon';
 
@@ -20,4 +22,22 @@ export const States: Story = {
       <ButtonIcon aria-label="Action" disabled><PlusIcon /></ButtonIcon>
     </div>
   ),
+};
+
+export const Hover: Story = {
+  parameters: { pseudo: { hover: true } },
+  render: () => <ButtonIcon aria-label="Action"><PlusIcon /></ButtonIcon>,
+};
+
+export const Active: Story = {
+  parameters: { pseudo: { active: true } },
+  render: () => <ButtonIcon aria-label="Action"><PlusIcon /></ButtonIcon>,
+};
+
+export const FocusVisible: Story = {
+  render: () => <ButtonIcon aria-label="Action"><PlusIcon /></ButtonIcon>,
+  // Real keyboard focus — paints :focus-visible without a pseudo-states addon.
+  play: async () => {
+    await userEvent.tab();
+  },
 };

--- a/packages/ui-react/src/components/ui/button-icon/__stories__/button-icon.generated.stories.tsx
+++ b/packages/ui-react/src/components/ui/button-icon/__stories__/button-icon.generated.stories.tsx
@@ -1,0 +1,23 @@
+// AUTO-GENERATED from @acronis-platform/ui-spec — DO NOT EDIT.
+// Regenerate: pnpm --filter @acronis-platform/ui-spec generate:stories
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { PlusIcon } from '@acronis-platform/icons-react/stroke-mono';
+import { ButtonIcon } from '../button-icon';
+
+const meta = {
+  title: 'UI/ButtonIcon/All States (generated)',
+  component: ButtonIcon,
+} satisfies Meta<typeof ButtonIcon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const States: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16, alignItems: 'center' }}>
+      <ButtonIcon aria-label="Action"><PlusIcon /></ButtonIcon>
+      <ButtonIcon aria-label="Action" disabled><PlusIcon /></ButtonIcon>
+    </div>
+  ),
+};

--- a/packages/ui-react/src/components/ui/button/__stories__/button.generated.stories.tsx
+++ b/packages/ui-react/src/components/ui/button/__stories__/button.generated.stories.tsx
@@ -1,7 +1,9 @@
 // AUTO-GENERATED from @acronis-platform/ui-spec — DO NOT EDIT.
 // Regenerate: pnpm --filter @acronis-platform/ui-spec generate:stories
+// `:hover` / `:active` stories require a Storybook pseudo-states addon to paint.
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { userEvent } from 'storybook/test';
 import { Button } from '../button';
 
 const meta = {
@@ -35,9 +37,7 @@ export const Matrix: Story = {
         <span key={`${v}-label`} style={{ fontSize: 12, opacity: 0.6 }}>
           {v}
         </span>,
-        ...SIZES.map((s) => (
-          <Button key={`${v}-${s}`} variant={v} size={s}>Label</Button>
-        )),
+        ...SIZES.map((s) => <Button key={`${v}-${s}`} variant={v} size={s}>Label</Button>),
       ])}
     </div>
   ),
@@ -46,9 +46,25 @@ export const Matrix: Story = {
 export const Disabled: Story = {
   render: () => (
     <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12 }}>
-      {VARIANTS.map((v) => (
-        <Button key={v} variant={v} disabled>Label</Button>
-      ))}
+      {VARIANTS.map((v) => <Button key={v} variant={v} disabled>Label</Button>)}
     </div>
   ),
+};
+
+export const Hover: Story = {
+  parameters: { pseudo: { hover: true } },
+  render: () => <Button>Label</Button>,
+};
+
+export const Active: Story = {
+  parameters: { pseudo: { active: true } },
+  render: () => <Button>Label</Button>,
+};
+
+export const FocusVisible: Story = {
+  render: () => <Button>Label</Button>,
+  // Real keyboard focus — paints :focus-visible without a pseudo-states addon.
+  play: async () => {
+    await userEvent.tab();
+  },
 };

--- a/packages/ui-react/src/components/ui/button/__stories__/button.generated.stories.tsx
+++ b/packages/ui-react/src/components/ui/button/__stories__/button.generated.stories.tsx
@@ -1,0 +1,54 @@
+// AUTO-GENERATED from @acronis-platform/ui-spec — DO NOT EDIT.
+// Regenerate: pnpm --filter @acronis-platform/ui-spec generate:stories
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from '../button';
+
+const meta = {
+  title: 'UI/Button/All States (generated)',
+  component: Button,
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const VARIANTS = ['default', 'secondary', 'ghost', 'destructive', 'ai', 'inverted'] as const;
+const SIZES = ['default', 'sm', 'lg'] as const;
+
+export const Matrix: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: `repeat(${SIZES.length + 1}, max-content)`,
+        gap: 12,
+        alignItems: 'center',
+      }}
+    >
+      <span />
+      {SIZES.map((s) => (
+        <span key={s} style={{ fontSize: 12, opacity: 0.6 }}>
+          {s}
+        </span>
+      ))}
+      {VARIANTS.flatMap((v) => [
+        <span key={`${v}-label`} style={{ fontSize: 12, opacity: 0.6 }}>
+          {v}
+        </span>,
+        ...SIZES.map((s) => (
+          <Button key={`${v}-${s}`} variant={v} size={s}>Label</Button>
+        )),
+      ])}
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12 }}>
+      {VARIANTS.map((v) => (
+        <Button key={v} variant={v} disabled>Label</Button>
+      ))}
+    </div>
+  ),
+};

--- a/packages/ui-react/src/components/ui/switch/__stories__/switch.generated.stories.tsx
+++ b/packages/ui-react/src/components/ui/switch/__stories__/switch.generated.stories.tsx
@@ -33,8 +33,8 @@ export const FocusVisible: Story = {
   },
 };
 
-// Internal state "checked" — click / Space / Enter toggles it (when uncontrolled).
-export const Interaction: Story = {
+// transition "toggle": click / Space / Enter -> toggle (!checked) [guard: not disabled]
+export const Toggle: Story = {
   render: () => <Switch aria-label="Toggle" />,
   play: async ({ canvasElement }) => {
     const el = canvasElement.querySelector('[role="switch"]');

--- a/packages/ui-react/src/components/ui/switch/__stories__/switch.generated.stories.tsx
+++ b/packages/ui-react/src/components/ui/switch/__stories__/switch.generated.stories.tsx
@@ -1,7 +1,9 @@
 // AUTO-GENERATED from @acronis-platform/ui-spec — DO NOT EDIT.
 // Regenerate: pnpm --filter @acronis-platform/ui-spec generate:stories
+// `:hover` / `:active` stories require a Storybook pseudo-states addon to paint.
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { userEvent } from 'storybook/test';
 import { Switch } from '../switch';
 
 const meta = {
@@ -21,4 +23,21 @@ export const States: Story = {
       <Switch aria-label="Disabled on" disabled defaultChecked />
     </div>
   ),
+};
+
+export const FocusVisible: Story = {
+  render: () => <Switch aria-label="Toggle" />,
+  // Real keyboard focus — paints :focus-visible without a pseudo-states addon.
+  play: async () => {
+    await userEvent.tab();
+  },
+};
+
+// Internal state "checked" — click / Space / Enter toggles it (when uncontrolled).
+export const Interaction: Story = {
+  render: () => <Switch aria-label="Toggle" />,
+  play: async ({ canvasElement }) => {
+    const el = canvasElement.querySelector('[role="switch"]');
+    if (el) await userEvent.click(el as HTMLElement);
+  },
 };

--- a/packages/ui-react/src/components/ui/switch/__stories__/switch.generated.stories.tsx
+++ b/packages/ui-react/src/components/ui/switch/__stories__/switch.generated.stories.tsx
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from @acronis-platform/ui-spec — DO NOT EDIT.
+// Regenerate: pnpm --filter @acronis-platform/ui-spec generate:stories
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Switch } from '../switch';
+
+const meta = {
+  title: 'UI/Switch/All States (generated)',
+  component: Switch,
+} satisfies Meta<typeof Switch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const States: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, alignItems: 'center' }}>
+      <Switch aria-label="Off" />
+      <Switch aria-label="On" defaultChecked />
+      <Switch aria-label="Disabled off" disabled />
+      <Switch aria-label="Disabled on" disabled defaultChecked />
+    </div>
+  ),
+};

--- a/packages/ui-spec/AGENTS.md
+++ b/packages/ui-spec/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md — `packages/ui-spec`
+
+`@acronis-platform/ui-spec` — **framework-agnostic** component specifications for
+the Acronis UI Kit. **Private** (not published). This is the **Phase 0 spike** of
+the proposal in [`context/component-specs-proposal.md`](../../context/component-specs-proposal.md):
+prove the spec format and its conformance check on three existing components
+(`button`, `button-icon`, `switch`) before scaling.
+
+Repo-wide rules live in the repo root `./context/`. This file documents only
+what's specific to this workspace.
+
+## What a spec is
+
+A spec describes **what a component is** — contract, anatomy, states, behavior,
+accessibility, and the tokens it consumes — independent of any framework. React
+is the only implementation today; the contract is written so a future Vue or Web
+Component implementation can target the same definition.
+
+## The 7-file format
+
+One directory per component under `components/<name>/`:
+
+| File               | Format | Purpose                                                               |
+| ------------------ | ------ | --------------------------------------------------------------------- |
+| `index.yaml`       | YAML   | Identity: component name, status, category, dependencies, Figma link  |
+| `anatomy.yaml`     | YAML   | Root element/role, named parts, visual states + triggers              |
+| `api.yaml`         | YAML   | Framework-agnostic contract (props/events/content/methods) + adapters |
+| `tokens.yaml`      | YAML   | **References** to the `--ui-*` tokens consumed — see below            |
+| `behavior.md`      | MD     | Given/When/Then behavior scenarios (incl. cross-component)            |
+| `accessibility.md` | MD     | ARIA, keyboard map, focus, contrast                                   |
+| `README.md`        | MD     | When to use / not use, quick examples                                 |
+
+YAML for structured/queryable data, Markdown for prose. The four YAML files are
+validated against JSON Schemas in `schema/`.
+
+## Tokens by reference — never duplicate values
+
+`tokens.yaml` lists **only token names** (`--ui-button-primary-background-idle`),
+the part each affects, and a description. **It must not restate values** — those
+live in `@acronis-platform/tokens-pd` (generated from `@acronis-platform/design-tokens`).
+The token-schema forbids a `value`/`default` key to enforce this. This is the
+single-source-of-truth rule that keeps specs from drifting from the design data.
+
+## Validation + conformance (this is the point)
+
+`pnpm --filter @acronis-platform/ui-spec test` runs `__tests__/specs.test.ts`:
+
+1. **Schema validation** — every YAML file validates against its `schema/*.json`.
+2. **Conformance** — for components built with `cva`, the spec's `api.yaml`
+   `variant`/`size` enums must match the actual `cva` keys in the
+   `@acronis-platform/ui-react` source (parsed via the TypeScript AST in
+   `lib/cva.ts`). This is what stops the spec from rotting into stale docs.
+
+When you add or change a component spec, run `test`. When you change a
+component's variants in `ui-react`, update its `api.yaml` or the conformance
+test fails.
+
+## Scripts
+
+`build`/`dev`/`clean` are no-ops (ships source YAML/MD). `lint`/`typecheck` run
+eslint/tsc over the `.ts` tooling. `test` (= `validate`) runs the vitest suite.

--- a/packages/ui-spec/CLAUDE.md
+++ b/packages/ui-spec/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/ui-spec/README.md
+++ b/packages/ui-spec/README.md
@@ -1,0 +1,40 @@
+# @acronis-platform/ui-spec
+
+Framework-agnostic component specifications for the Acronis UI Kit. Each spec
+describes a component's contract, anatomy, states, behavior, accessibility, and
+the design tokens it consumes — independent of any rendering framework, so a
+single definition can drive the React implementation today and Vue / Web
+Component implementations in the future.
+
+> **Status: Phase 0 spike.** Private package. Covers three components
+> (`button`, `button-icon`, `switch`) to validate the format and its conformance
+> check. See [`context/component-specs-proposal.md`](../../context/component-specs-proposal.md).
+
+## Layout
+
+```
+packages/ui-spec/
+├── index.ts                 # component registry + spec loader + types
+├── types.ts                 # TypeScript interfaces for the YAML shapes
+├── schema/                  # JSON Schemas for the four YAML files
+├── lib/                     # spec loader + cva-key extractor (used by tests)
+├── __tests__/specs.test.ts  # schema validation + cva↔contract conformance
+└── components/<name>/        # the 7-file spec per component
+```
+
+## Use
+
+```sh
+pnpm --filter @acronis-platform/ui-spec test   # validate + conformance
+```
+
+```ts
+import { components, loadSpec } from '@acronis-platform/ui-spec';
+
+components; // [{ name: 'button', component: 'Button', status, category }, ...]
+const button = loadSpec('button'); // { index, anatomy, api, tokens }
+button.api.contract.properties; // queryable, framework-agnostic contract
+```
+
+See [`AGENTS.md`](AGENTS.md) for the 7-file format, the tokens-by-reference rule,
+and how conformance works.

--- a/packages/ui-spec/__tests__/specs.test.ts
+++ b/packages/ui-spec/__tests__/specs.test.ts
@@ -64,9 +64,10 @@ describe('state classification is coherent', () => {
         if (s.kind === 'pseudo') {
           expect(s.pseudo, `${name}/${s.id} (pseudo) needs a pseudo selector`).toBeTruthy();
         }
-        if (s.kind === 'prop' && s.prop) {
+        if (s.kind === 'prop') {
+          expect(s.prop, `${name}/${s.id} (prop) needs a prop name`).toBeTruthy();
           expect(
-            propNames.has(s.prop),
+            propNames.has(s.prop ?? ''),
             `${name}/${s.id} references unknown prop "${s.prop}"`
           ).toBe(true);
         }

--- a/packages/ui-spec/__tests__/specs.test.ts
+++ b/packages/ui-spec/__tests__/specs.test.ts
@@ -77,7 +77,10 @@ describe('state classification is coherent', () => {
           ).toBeGreaterThan(0);
         }
       }
-      // Any declared internal state must be readable/overridable by a real prop.
+      // Internal state must be wired to the real API: its controlling prop, its
+      // uncontrolled-default prop, and its change event must all exist.
+      const eventNames = new Set((api.contract.events ?? []).map((e) => e.name));
+      const internalIds = new Set((anatomy.internal_state ?? []).map((s) => s.id));
       for (const st of anatomy.internal_state ?? []) {
         for (const prop of st.controllable_via ?? []) {
           expect(
@@ -85,6 +88,26 @@ describe('state classification is coherent', () => {
             `${name}: internal_state "${st.id}" controllable_via unknown prop "${prop}"`
           ).toBe(true);
         }
+        if (st.controlled_default) {
+          expect(
+            propNames.has(st.controlled_default),
+            `${name}: internal_state "${st.id}" controlled_default unknown prop "${st.controlled_default}"`
+          ).toBe(true);
+        }
+        if (st.emits) {
+          expect(
+            eventNames.has(st.emits),
+            `${name}: internal_state "${st.id}" emits unknown event "${st.emits}"`
+          ).toBe(true);
+        }
+      }
+
+      // Every transition must mutate a declared internal state.
+      for (const t of anatomy.transitions ?? []) {
+        expect(
+          internalIds.has(t.state),
+          `${name}: transition "${t.id}" targets unknown internal_state "${t.state}"`
+        ).toBe(true);
       }
     });
   }

--- a/packages/ui-spec/__tests__/specs.test.ts
+++ b/packages/ui-spec/__tests__/specs.test.ts
@@ -55,6 +55,41 @@ describe('anatomy schematic depicts every declared part', () => {
   }
 });
 
+describe('state classification is coherent', () => {
+  for (const name of componentNames) {
+    it(`${name}: each state's kind lines up with the spec`, () => {
+      const { anatomy, api } = loadSpec(name);
+      const propNames = new Set(api.contract.properties.map((p) => p.name));
+      for (const s of anatomy.states ?? []) {
+        if (s.kind === 'pseudo') {
+          expect(s.pseudo, `${name}/${s.id} (pseudo) needs a pseudo selector`).toBeTruthy();
+        }
+        if (s.kind === 'prop' && s.prop) {
+          expect(
+            propNames.has(s.prop),
+            `${name}/${s.id} references unknown prop "${s.prop}"`
+          ).toBe(true);
+        }
+        if (s.kind === 'internal') {
+          expect(
+            (anatomy.internal_state ?? []).length,
+            `${name}/${s.id} is internal but no internal_state is declared`
+          ).toBeGreaterThan(0);
+        }
+      }
+      // Any declared internal state must be readable/overridable by a real prop.
+      for (const st of anatomy.internal_state ?? []) {
+        for (const prop of st.controllable_via ?? []) {
+          expect(
+            propNames.has(prop),
+            `${name}: internal_state "${st.id}" controllable_via unknown prop "${prop}"`
+          ).toBe(true);
+        }
+      }
+    });
+  }
+});
+
 /** Pull the string-union members out of an `api.yaml` property `type`. */
 function enumMembers(api: ApiSpec, propName: string): string[] {
   const prop = api.contract.properties.find((p) => p.name === propName);

--- a/packages/ui-spec/__tests__/specs.test.ts
+++ b/packages/ui-spec/__tests__/specs.test.ts
@@ -39,6 +39,22 @@ describe('every component spec validates against its schema', () => {
   }
 });
 
+describe('anatomy schematic depicts every declared part', () => {
+  for (const name of componentNames) {
+    it(`${name}/anatomy.yaml schematic`, () => {
+      const { anatomy } = loadSpec(name);
+      expect(anatomy.schematic, `${name} has no schematic`).toBeTruthy();
+      const schematic = anatomy.schematic ?? '';
+      for (const part of anatomy.parts) {
+        expect(
+          schematic.includes(part.id),
+          `part "${part.id}" is not labelled in the schematic`
+        ).toBe(true);
+      }
+    });
+  }
+});
+
 /** Pull the string-union members out of an `api.yaml` property `type`. */
 function enumMembers(api: ApiSpec, propName: string): string[] {
   const prop = api.contract.properties.find((p) => p.name === propName);

--- a/packages/ui-spec/__tests__/specs.test.ts
+++ b/packages/ui-spec/__tests__/specs.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020';
+import { describe, expect, it } from 'vitest';
+
+import { extractCvaGroups } from '../lib/cva';
+import {
+  YAML_FILES,
+  listComponentNames,
+  loadSpec,
+  readSchema,
+  readYaml,
+  specFilePath,
+  type YamlFile,
+} from '../lib/load';
+import type { ApiSpec } from '../types';
+
+const ajv = new Ajv2020({ strict: false, allErrors: true });
+const validators = Object.fromEntries(
+  YAML_FILES.map((file) => [file, ajv.compile(readSchema(file))])
+) as Record<YamlFile, ReturnType<typeof ajv.compile>>;
+
+const componentNames = listComponentNames();
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+describe('every component spec validates against its schema', () => {
+  for (const name of componentNames) {
+    for (const file of YAML_FILES) {
+      it(`${name}/${file}.yaml`, () => {
+        const data = readYaml<unknown>(specFilePath(name, file));
+        const valid = validators[file](data);
+        expect(
+          valid,
+          ajv.errorsText(validators[file].errors, { separator: '\n' })
+        ).toBe(true);
+      });
+    }
+  }
+});
+
+/** Pull the string-union members out of an `api.yaml` property `type`. */
+function enumMembers(api: ApiSpec, propName: string): string[] {
+  const prop = api.contract.properties.find((p) => p.name === propName);
+  if (!prop) return [];
+  return [...prop.type.matchAll(/'([^']+)'/g)].map((m) => m[1]).sort();
+}
+
+describe('cva ↔ contract conformance', () => {
+  it('Button: api.yaml variant/size enums match the cva keys in ui-react', () => {
+    const source = readFileSync(
+      resolve(HERE, '../../ui-react/src/components/ui/button/button.tsx'),
+      'utf8'
+    );
+    const groups = extractCvaGroups(source);
+    const api = loadSpec('button').api;
+
+    expect(Object.keys(groups).sort()).toEqual(['size', 'variant']);
+    expect(groups.variant.sort()).toEqual(enumMembers(api, 'variant'));
+    expect(groups.size.sort()).toEqual(enumMembers(api, 'size'));
+  });
+});

--- a/packages/ui-spec/components/button-icon/README.md
+++ b/packages/ui-spec/components/button-icon/README.md
@@ -1,0 +1,29 @@
+# ButtonIcon
+
+An icon-only button: 32×32 with a single 16px glyph, one visual style, and
+idle/hover/active/disabled states.
+
+## When to use
+
+- A compact action represented by an icon alone (e.g. a toolbar action) where a
+  text label would be redundant or there's no room for one.
+
+## When not to use
+
+- An action that needs a text label — use **Button** (it also sizes a leading
+  icon).
+- A toggle — use a toggle/switch control.
+
+## Example (React — implemented)
+
+```tsx
+import { ButtonIcon } from '@acronis-platform/ui-react';
+import { PlusIcon } from '@acronis-platform/icons-react/stroke-mono';
+
+<ButtonIcon aria-label="Add">
+  <PlusIcon />
+</ButtonIcon>;
+```
+
+Always provide an `aria-label` — the control has no text. Vue and Web Component
+implementations are planned against the same contract.

--- a/packages/ui-spec/components/button-icon/accessibility.md
+++ b/packages/ui-spec/components/button-icon/accessibility.md
@@ -1,0 +1,16 @@
+# ButtonIcon — Accessibility
+
+- **Role:** native `<button>`.
+- **Accessible name (required):** the control is icon-only, so it MUST be given
+  an `aria-label` (or `aria-labelledby`). The icon itself should be
+  `aria-hidden`. Without a label the button is unusable to screen readers.
+- **Keyboard:** Enter and Space activate (native). `disabled` removes it from
+  the tab order.
+- **Focus visible:** 2px `--ui-focus-brand` ring with 2px offset via
+  `:focus-visible`.
+- **Touch target:** 32×32 is below the 44×44 guideline; place with adequate
+  spacing, or extend the hit area with transparent padding where touch is a
+  primary input.
+- **Contrast:** glyph/background pairs come from the design tokens (authored for
+  contrast).
+- **WCAG:** 2.1.1, 2.4.7, 1.4.11, 4.1.2.

--- a/packages/ui-spec/components/button-icon/anatomy.yaml
+++ b/packages/ui-spec/components/button-icon/anatomy.yaml
@@ -17,12 +17,33 @@ parts:
     description: The single glyph (the button's content), sized to 16px.
     element: svg
 
+# Pure function of its props — no internal state.
 states:
-  - { id: hover, trigger: pointer hover, affects: [root, icon] }
+  - {
+      id: hover,
+      trigger: pointer hover,
+      kind: pseudo,
+      pseudo: ':hover',
+      affects: [root, icon],
+    }
   - {
       id: active,
       trigger: pointer or keyboard activation,
+      kind: pseudo,
+      pseudo: ':active',
       affects: [root, icon],
     }
-  - { id: focus-visible, trigger: keyboard focus, affects: [root] }
-  - { id: disabled, trigger: 'disabled === true', affects: [root, icon] }
+  - {
+      id: focus-visible,
+      trigger: keyboard focus,
+      kind: pseudo,
+      pseudo: ':focus-visible',
+      affects: [root],
+    }
+  - {
+      id: disabled,
+      trigger: 'disabled === true',
+      kind: prop,
+      prop: disabled,
+      affects: [root, icon],
+    }

--- a/packages/ui-spec/components/button-icon/anatomy.yaml
+++ b/packages/ui-spec/components/button-icon/anatomy.yaml
@@ -1,0 +1,22 @@
+spec_version: '1.0'
+component: ButtonIcon
+
+root:
+  element: button
+  role: button
+  description: 32×32 square icon-only button surface (background, border, radius).
+
+parts:
+  - id: icon
+    description: The single glyph (the button's content), sized to 16px.
+    element: svg
+
+states:
+  - { id: hover, trigger: pointer hover, affects: [root, icon] }
+  - {
+      id: active,
+      trigger: pointer or keyboard activation,
+      affects: [root, icon],
+    }
+  - { id: focus-visible, trigger: keyboard focus, affects: [root] }
+  - { id: disabled, trigger: 'disabled === true', affects: [root, icon] }

--- a/packages/ui-spec/components/button-icon/anatomy.yaml
+++ b/packages/ui-spec/components/button-icon/anatomy.yaml
@@ -1,6 +1,12 @@
 spec_version: '1.0'
 component: ButtonIcon
 
+schematic: |
+  +----------+
+  |   icon   |   root: <button> 32x32
+  +----------+
+  icon: single glyph, 16px, centered
+
 root:
   element: button
   role: button

--- a/packages/ui-spec/components/button-icon/api.yaml
+++ b/packages/ui-spec/components/button-icon/api.yaml
@@ -1,0 +1,54 @@
+spec_version: '1.0'
+component: ButtonIcon
+
+contract:
+  properties:
+    - name: disabled
+      type: boolean
+      required: false
+      default: false
+      description: >-
+        Disables interaction. Applies the explicit disabled tokens (not opacity)
+        and suppresses click.
+    - name: type
+      type: "'button' | 'submit' | 'reset'"
+      required: false
+      default: "'button'"
+      description: Native HTML button type.
+    - name: aria-label
+      type: string
+      required: false
+      description: >-
+        Accessible name. Required in practice — this control is icon-only and
+        has no text to name it.
+
+  events:
+    - name: click
+      payload: MouseEvent
+      description: Fired on activation. Not fired while disabled.
+
+  content:
+    - name: default
+      description: A single icon (SVG), sized to 16px and tinted via currentColor.
+
+adapters:
+  react:
+    component: ButtonIcon
+    status: implemented
+    import: "import { ButtonIcon } from '@acronis-platform/ui-react'"
+    example: |
+      <ButtonIcon aria-label="Add">
+        <PlusIcon />
+      </ButtonIcon>
+  vue:
+    element: AvButtonIcon
+    status: planned
+    import: "import { AvButtonIcon } from '@acronis-platform/ui-vue'"
+    example: |
+      <AvButtonIcon aria-label="Add"><PlusIcon /></AvButtonIcon>
+  web-components:
+    element: ui-button-icon
+    status: planned
+    import: "import '@acronis-platform/ui-wc/button-icon'"
+    example: |
+      <ui-button-icon aria-label="Add"><!-- icon --></ui-button-icon>

--- a/packages/ui-spec/components/button-icon/behavior.md
+++ b/packages/ui-spec/components/button-icon/behavior.md
@@ -1,0 +1,35 @@
+# ButtonIcon — Behavior
+
+## Rendering
+
+### Renders a square icon-only button
+
+**Given** a ButtonIcon with a single icon child
+**When** it renders
+**Then** it is a 32×32 square with the icon centered at 16px
+**And** background, glyph, and border resolve from `--ui-button-icon-*` for the
+current state.
+
+## Interaction states
+
+### Tracks each state from its own token
+
+**Given** the button is idle, hovered, activated, or disabled
+**When** it renders
+**Then** background, glyph, and border each resolve from the matching
+`*-idle` / `*-hover` / `*-active` / `*-disabled` token (brand/theme overrides
+honored per state).
+
+### Disabled suppresses click
+
+**Given** a ButtonIcon with `disabled`
+**When** the user activates it
+**Then** no `click` is emitted and the disabled tokens apply (not opacity).
+
+## Composition
+
+### Renders as another element
+
+**Given** a `render` prop (React)
+**When** it renders
+**Then** the classes/props merge onto that element (e.g. an `<a>`).

--- a/packages/ui-spec/components/button-icon/index.yaml
+++ b/packages/ui-spec/components/button-icon/index.yaml
@@ -1,0 +1,13 @@
+spec_version: '1.0'
+component: ButtonIcon
+name: button-icon
+status: ready
+category: actions
+description: >-
+  Icon-only button (32×32, 16px glyph). A single visual style with idle, hover,
+  active, and disabled states. Use when an action is represented by an icon
+  alone.
+since: 0.4.0
+figma:
+  node: '1210-918'
+  codeConnect: packages/ui-react/src/components/ui/button-icon/button-icon.figma.tsx

--- a/packages/ui-spec/components/button-icon/tokens.yaml
+++ b/packages/ui-spec/components/button-icon/tokens.yaml
@@ -1,0 +1,25 @@
+spec_version: '1.0'
+component: ButtonIcon
+
+# References only — values live in @acronis-platform/tokens-pd. Geometry (32×32,
+# 4px radius, 1px border) comes from layout utilities, not tokens.
+source: '@acronis-platform/tokens-pd'
+
+tokens:
+  - { name: --ui-button-icon-background-idle, affects: root }
+  - { name: --ui-button-icon-background-hover, affects: root }
+  - { name: --ui-button-icon-background-active, affects: root }
+  - { name: --ui-button-icon-background-disabled, affects: root }
+  - { name: --ui-button-icon-icon-idle, affects: icon }
+  - { name: --ui-button-icon-icon-hover, affects: icon }
+  - { name: --ui-button-icon-icon-active, affects: icon }
+  - { name: --ui-button-icon-icon-disabled, affects: icon }
+  - { name: --ui-button-icon-border-idle, affects: root }
+  - { name: --ui-button-icon-border-hover, affects: root }
+  - { name: --ui-button-icon-border-active, affects: root }
+  - { name: --ui-button-icon-border-disabled, affects: root }
+  - {
+      name: --ui-focus-brand,
+      affects: root,
+      description: Focus-visible ring color,
+    }

--- a/packages/ui-spec/components/button/README.md
+++ b/packages/ui-spec/components/button/README.md
@@ -1,0 +1,27 @@
+# Button
+
+Triggers an action or event. Six styles — `default` (Primary), `secondary`,
+`ghost`, `destructive`, `ai`, `inverted` — across three sizes (`sm`, `default`,
+`lg`).
+
+## When to use
+
+- A user-initiated action: submit, save, cancel, open a dialog, run a command.
+
+## When not to use
+
+- Navigation to another page that should be a real link — compose with the
+  `render` prop so it renders an `<a>` (keeps link semantics), or use a link.
+- An icon-only control — use **ButtonIcon**.
+
+## Example (React — implemented)
+
+```tsx
+import { Button } from '@acronis-platform/ui-react';
+
+<Button variant="default" onClick={onSave}>Save changes</Button>
+<Button variant="destructive" disabled>Delete</Button>
+```
+
+Vue and Web Component implementations are planned and will target the same
+contract — see `api.yaml` `adapters`.

--- a/packages/ui-spec/components/button/accessibility.md
+++ b/packages/ui-spec/components/button/accessibility.md
@@ -1,0 +1,16 @@
+# Button — Accessibility
+
+- **Role:** native `<button>` (implicit `role="button"`); when composed as a
+  link via `render`, it becomes a native `<a>` with link semantics.
+- **Accessible name:** from the text content. An **icon-only** button has no
+  text, so it MUST be given an `aria-label` (or `aria-labelledby`). For
+  icon-only buttons prefer the dedicated `ButtonIcon` component.
+- **Keyboard:** Enter and Space activate (native). Tab focuses; a `disabled`
+  button is removed from the tab order (native).
+- **Focus visible:** keyboard focus shows a 2px ring in `--ui-focus-brand` with
+  a 2px offset, via `:focus-visible` (no ring on pointer activation).
+- **Contrast:** label/background pairs come from the design tokens, which are
+  authored to meet WCAG contrast. State is never conveyed by color alone — the
+  disabled state also removes interactivity.
+- **WCAG:** 2.1.1 (keyboard), 2.4.7 (focus visible), 1.4.3 / 1.4.11 (contrast),
+  4.1.2 (name/role/value).

--- a/packages/ui-spec/components/button/anatomy.yaml
+++ b/packages/ui-spec/components/button/anatomy.yaml
@@ -34,26 +34,93 @@ layout:
   align: center
   order: [icon, label]
 
+# Button is a pure function of its props — it owns no internal state, so there
+# is no `internal_state`. Every state below is reached by a prop or a CSS
+# pseudo-class.
 states:
-  - { id: default, trigger: "variant === 'default'", affects: [root] }
-  - { id: secondary, trigger: "variant === 'secondary'", affects: [root] }
-  - { id: ghost, trigger: "variant === 'ghost'", affects: [root] }
-  - { id: destructive, trigger: "variant === 'destructive'", affects: [root] }
-  - { id: ai, trigger: "variant === 'ai'", affects: [root] }
-  - { id: inverted, trigger: "variant === 'inverted'", affects: [root] }
+  - {
+      id: default,
+      trigger: "variant === 'default'",
+      kind: prop,
+      prop: variant,
+      affects: [root],
+    }
+  - {
+      id: secondary,
+      trigger: "variant === 'secondary'",
+      kind: prop,
+      prop: variant,
+      affects: [root],
+    }
+  - {
+      id: ghost,
+      trigger: "variant === 'ghost'",
+      kind: prop,
+      prop: variant,
+      affects: [root],
+    }
+  - {
+      id: destructive,
+      trigger: "variant === 'destructive'",
+      kind: prop,
+      prop: variant,
+      affects: [root],
+    }
+  - {
+      id: ai,
+      trigger: "variant === 'ai'",
+      kind: prop,
+      prop: variant,
+      affects: [root],
+    }
+  - {
+      id: inverted,
+      trigger: "variant === 'inverted'",
+      kind: prop,
+      prop: variant,
+      affects: [root],
+    }
   - {
       id: small,
       trigger: "size === 'sm'",
+      kind: prop,
+      prop: size,
       affects: [root],
       exclusive_with: [large],
     }
   - {
       id: large,
       trigger: "size === 'lg'",
+      kind: prop,
+      prop: size,
       affects: [root],
       exclusive_with: [small],
     }
-  - { id: hover, trigger: pointer hover, affects: [root] }
-  - { id: active, trigger: pointer or keyboard activation, affects: [root] }
-  - { id: focus-visible, trigger: keyboard focus, affects: [root] }
-  - { id: disabled, trigger: 'disabled === true', affects: [root, label] }
+  - {
+      id: hover,
+      trigger: pointer hover,
+      kind: pseudo,
+      pseudo: ':hover',
+      affects: [root],
+    }
+  - {
+      id: active,
+      trigger: pointer or keyboard activation,
+      kind: pseudo,
+      pseudo: ':active',
+      affects: [root],
+    }
+  - {
+      id: focus-visible,
+      trigger: keyboard focus,
+      kind: pseudo,
+      pseudo: ':focus-visible',
+      affects: [root],
+    }
+  - {
+      id: disabled,
+      trigger: 'disabled === true',
+      kind: prop,
+      prop: disabled,
+      affects: [root, label],
+    }

--- a/packages/ui-spec/components/button/anatomy.yaml
+++ b/packages/ui-spec/components/button/anatomy.yaml
@@ -1,0 +1,51 @@
+spec_version: '1.0'
+component: Button
+
+root:
+  element: button
+  role: button
+  description: >-
+    Native button element — the interactive surface and the styled box
+    (background, border, radius, height).
+
+parts:
+  - id: icon
+    description: >-
+      Leading or trailing icon. Any SVG child is sized to 16px via the
+      `[&_svg]:size-4` rule and inherits the label color through currentColor.
+    element: svg
+    optional: true
+    visible_when: an SVG child is present
+  - id: label
+    description: Text content passed as children.
+    optional: true
+
+layout:
+  type: flex
+  direction: row
+  align: center
+  order: [icon, label]
+
+states:
+  - { id: default, trigger: "variant === 'default'", affects: [root] }
+  - { id: secondary, trigger: "variant === 'secondary'", affects: [root] }
+  - { id: ghost, trigger: "variant === 'ghost'", affects: [root] }
+  - { id: destructive, trigger: "variant === 'destructive'", affects: [root] }
+  - { id: ai, trigger: "variant === 'ai'", affects: [root] }
+  - { id: inverted, trigger: "variant === 'inverted'", affects: [root] }
+  - {
+      id: small,
+      trigger: "size === 'sm'",
+      affects: [root],
+      exclusive_with: [large],
+    }
+  - {
+      id: large,
+      trigger: "size === 'lg'",
+      affects: [root],
+      exclusive_with: [small],
+    }
+  - { id: hover, trigger: pointer hover, affects: [root] }
+  - { id: active, trigger: pointer or keyboard activation, affects: [root] }
+  - { id: focus-visible, trigger: keyboard focus, affects: [root] }
+  - { id: disabled, trigger: 'disabled === true', affects: [root, label] }

--- a/packages/ui-spec/components/button/anatomy.yaml
+++ b/packages/ui-spec/components/button/anatomy.yaml
@@ -1,6 +1,14 @@
 spec_version: '1.0'
 component: Button
 
+schematic: |
+  +---------------------------------+
+  |  [icon]  label                  |   root: <button>
+  +---------------------------------+
+     ^         ^
+     icon      label (children / text)
+  variant -> colors    size -> height & padding
+
 root:
   element: button
   role: button

--- a/packages/ui-spec/components/button/api.yaml
+++ b/packages/ui-spec/components/button/api.yaml
@@ -1,0 +1,70 @@
+spec_version: '1.0'
+component: Button
+
+# Framework-agnostic contract. Property names are neutral; see `adapters` for
+# the per-framework syntax. Native button attributes (e.g. type, disabled,
+# autofocus, name, value) pass through in every framework.
+contract:
+  properties:
+    - name: variant
+      type: "'default' | 'secondary' | 'ghost' | 'destructive' | 'ai' | 'inverted'"
+      required: false
+      default: "'default'"
+      description: >-
+        Visual style. `default` is the Figma "Primary" style. Each variant maps
+        to its dedicated `--ui-button-<style>-*` tokens.
+    - name: size
+      type: "'default' | 'sm' | 'lg'"
+      required: false
+      default: "'default'"
+      description: Controls height and horizontal padding. `default` is 32px tall.
+    - name: disabled
+      type: boolean
+      required: false
+      default: false
+      description: >-
+        Disables interaction. Applies the design's explicit per-variant disabled
+        tokens (not an opacity dim) and suppresses click.
+    - name: type
+      type: "'button' | 'submit' | 'reset'"
+      required: false
+      default: "'button'"
+      description: Native HTML button type.
+
+  events:
+    - name: click
+      payload: MouseEvent
+      description: Fired on activation (pointer or keyboard). Not fired while disabled.
+
+  content:
+    - name: default
+      description: >-
+        Label content. Plain text and/or an icon. An SVG child is auto-sized to
+        16px and tinted with the label color.
+
+adapters:
+  react:
+    component: Button
+    status: implemented
+    import: "import { Button } from '@acronis-platform/ui-react'"
+    example: |
+      <Button variant="default" onClick={onSave}>
+        Save changes
+      </Button>
+
+      {/* Polymorphic: render as another element via the `render` prop */}
+      <Button render={<a href="/docs" />} variant="ghost">Docs</Button>
+
+  vue:
+    component: AvButton
+    status: planned
+    import: "import { AvButton } from '@acronis-platform/ui-vue'"
+    example: |
+      <AvButton variant="default" @click="onSave">Save changes</AvButton>
+
+  web-components:
+    element: ui-button
+    status: planned
+    import: "import '@acronis-platform/ui-wc/button'"
+    example: |
+      <ui-button variant="default">Save changes</ui-button>

--- a/packages/ui-spec/components/button/behavior.md
+++ b/packages/ui-spec/components/button/behavior.md
@@ -1,0 +1,58 @@
+# Button — Behavior
+
+## Variants
+
+### Renders the requested visual style
+
+**Given** a Button with `variant` set to one of `default`, `secondary`, `ghost`,
+`destructive`, `ai`, or `inverted`
+**When** it renders
+**Then** background, label, and border resolve from that variant's
+`--ui-button-<style>-*` tokens for the current interaction state.
+
+### Defaults to `default` (Primary)
+
+**Given** a Button with no `variant`
+**When** it renders
+**Then** it uses the `default` (Primary) style.
+
+## Interaction states
+
+### Tracks each state from its own token
+
+**Given** any variant
+**When** the button is idle, hovered, activated, or disabled
+**Then** background, label, and border each resolve from the matching
+`*-idle` / `*-hover` / `*-active` / `*-disabled` token — so brand/theme
+overrides that differ per state are honored.
+
+### Disabled uses design tokens, not opacity
+
+**Given** a Button with `disabled`
+**When** it renders
+**Then** it applies the variant's `*-disabled` tokens (not a blanket opacity)
+**And** it does not emit `click`.
+
+## Sizes
+
+**Given** `size` of `default`, `sm`, or `lg`
+**When** it renders
+**Then** the height/padding change accordingly; `default` is 32px tall.
+
+## Content
+
+### Sizes and tints an icon child
+
+**Given** an SVG child
+**When** it renders
+**Then** the icon is sized to 16px and inherits the label color via
+`currentColor`.
+
+## Composition
+
+### Renders as another element
+
+**Given** a `render` prop (React) targeting e.g. an anchor
+**When** it renders
+**Then** the Button's classes/props merge onto that element instead of a
+`<button>` (Base UI `useRender`), so a Button can be a link.

--- a/packages/ui-spec/components/button/index.yaml
+++ b/packages/ui-spec/components/button/index.yaml
@@ -1,0 +1,12 @@
+spec_version: '1.0'
+component: Button
+name: button
+status: ready
+category: actions
+description: >-
+  Triggers an action or event when activated. Six visual styles (default,
+  secondary, ghost, destructive, ai, inverted) across three sizes.
+since: 0.4.0
+figma:
+  node: '1173-2789'
+  codeConnect: packages/ui-react/src/components/ui/button/button.figma.tsx

--- a/packages/ui-spec/components/button/tokens.yaml
+++ b/packages/ui-spec/components/button/tokens.yaml
@@ -1,0 +1,128 @@
+spec_version: '1.0'
+component: Button
+
+# References only. Values live in @acronis-platform/tokens-pd (generated from
+# @acronis-platform/design-tokens) and resolve per brand/theme at paint time.
+# The token schema forbids a value/default key here — never restate values.
+source: '@acronis-platform/tokens-pd'
+
+tokens:
+  # ── Global geometry / typography (root) ──
+  - {
+      name: --ui-button-global-height,
+      affects: root,
+      description: Default (medium) height — 32px,
+    }
+  - { name: --ui-button-global-padding-x, affects: root }
+  - { name: --ui-button-global-padding-y, affects: root }
+  - {
+      name: --ui-button-global-gap,
+      affects: root,
+      description: Space between icon and label,
+    }
+  - { name: --ui-button-global-radius, affects: root }
+  - { name: --ui-button-global-border, affects: root }
+  - { name: --ui-button-global-width-min, affects: root }
+  - {
+      name: --ui-focus-brand,
+      affects: root,
+      description: Focus-visible ring color,
+    }
+
+  # ── default (Primary) ──
+  - { name: --ui-button-primary-background-idle, affects: root }
+  - { name: --ui-button-primary-background-hover, affects: root }
+  - { name: --ui-button-primary-background-active, affects: root }
+  - { name: --ui-button-primary-background-disabled, affects: root }
+  - { name: --ui-button-primary-label-idle, affects: label }
+  - { name: --ui-button-primary-label-hover, affects: label }
+  - { name: --ui-button-primary-label-active, affects: label }
+  - { name: --ui-button-primary-label-disabled, affects: label }
+  - { name: --ui-button-primary-border-idle, affects: root }
+  - { name: --ui-button-primary-border-hover, affects: root }
+  - { name: --ui-button-primary-border-active, affects: root }
+  - { name: --ui-button-primary-border-disabled, affects: root }
+
+  # ── secondary ──
+  - { name: --ui-button-secondary-background-idle, affects: root }
+  - { name: --ui-button-secondary-background-hover, affects: root }
+  - { name: --ui-button-secondary-background-active, affects: root }
+  - { name: --ui-button-secondary-background-disabled, affects: root }
+  - { name: --ui-button-secondary-label-idle, affects: label }
+  - { name: --ui-button-secondary-label-hover, affects: label }
+  - { name: --ui-button-secondary-label-active, affects: label }
+  - { name: --ui-button-secondary-label-disabled, affects: label }
+  - { name: --ui-button-secondary-border-idle, affects: root }
+  - { name: --ui-button-secondary-border-hover, affects: root }
+  - { name: --ui-button-secondary-border-active, affects: root }
+  - { name: --ui-button-secondary-border-disabled, affects: root }
+
+  # ── ghost ──
+  - { name: --ui-button-ghost-background-idle, affects: root }
+  - { name: --ui-button-ghost-background-hover, affects: root }
+  - { name: --ui-button-ghost-background-active, affects: root }
+  - { name: --ui-button-ghost-background-disabled, affects: root }
+  - { name: --ui-button-ghost-label-idle, affects: label }
+  - { name: --ui-button-ghost-label-hover, affects: label }
+  - { name: --ui-button-ghost-label-active, affects: label }
+  - { name: --ui-button-ghost-label-disabled, affects: label }
+  - { name: --ui-button-ghost-border-idle, affects: root }
+  - { name: --ui-button-ghost-border-hover, affects: root }
+  - { name: --ui-button-ghost-border-active, affects: root }
+  - { name: --ui-button-ghost-border-disabled, affects: root }
+
+  # ── destructive ──
+  - { name: --ui-button-destructive-background-idle, affects: root }
+  - { name: --ui-button-destructive-background-hover, affects: root }
+  - { name: --ui-button-destructive-background-active, affects: root }
+  - { name: --ui-button-destructive-background-disabled, affects: root }
+  - { name: --ui-button-destructive-label-idle, affects: label }
+  - { name: --ui-button-destructive-label-hover, affects: label }
+  - { name: --ui-button-destructive-label-active, affects: label }
+  - { name: --ui-button-destructive-label-disabled, affects: label }
+  - { name: --ui-button-destructive-border-idle, affects: root }
+  - { name: --ui-button-destructive-border-hover, affects: root }
+  - { name: --ui-button-destructive-border-active, affects: root }
+  - { name: --ui-button-destructive-border-disabled, affects: root }
+
+  # ── ai (background is a gradient from the semantic ai tokens) ──
+  - {
+      name: --ui-background-ai-idle,
+      affects: root,
+      description: AI gradient (idle),
+    }
+  - {
+      name: --ui-background-ai-hover,
+      affects: root,
+      description: AI gradient (hover),
+    }
+  - {
+      name: --ui-background-ai-active,
+      affects: root,
+      description: AI gradient (active),
+    }
+  - {
+      name: --ui-background-ai-disabled,
+      affects: root,
+      description: AI gradient (disabled),
+    }
+  - { name: --ui-button-ai-label-idle, affects: label }
+  - { name: --ui-button-ai-label-disabled, affects: label }
+  - { name: --ui-button-ai-border-idle, affects: root }
+  - { name: --ui-button-ai-border-hover, affects: root }
+  - { name: --ui-button-ai-border-active, affects: root }
+  - { name: --ui-button-ai-border-disabled, affects: root }
+
+  # ── inverted ──
+  - { name: --ui-button-inverted-background-idle, affects: root }
+  - { name: --ui-button-inverted-background-hover, affects: root }
+  - { name: --ui-button-inverted-background-active, affects: root }
+  - { name: --ui-button-inverted-background-disabled, affects: root }
+  - { name: --ui-button-inverted-label-idle, affects: label }
+  - { name: --ui-button-inverted-label-hover, affects: label }
+  - { name: --ui-button-inverted-label-active, affects: label }
+  - { name: --ui-button-inverted-label-disabled, affects: label }
+  - { name: --ui-button-inverted-border-idle, affects: root }
+  - { name: --ui-button-inverted-border-hover, affects: root }
+  - { name: --ui-button-inverted-border-active, affects: root }
+  - { name: --ui-button-inverted-border-disabled, affects: root }

--- a/packages/ui-spec/components/switch/README.md
+++ b/packages/ui-spec/components/switch/README.md
@@ -1,0 +1,26 @@
+# Switch
+
+A binary on/off toggle whose change takes effect immediately.
+
+## When to use
+
+- Toggling a single setting that applies instantly (e.g. "Enable notifications").
+
+## When not to use
+
+- A choice that only applies after submitting a form — use a checkbox.
+- Selecting one of several options — use radios or a segmented control.
+
+## Example (React — implemented)
+
+```tsx
+import { Switch } from '@acronis-platform/ui-react';
+
+const [enabled, setEnabled] = useState(false);
+
+<Switch aria-label="Wireless" checked={enabled} onCheckedChange={setEnabled} />;
+```
+
+> **Note:** the implementation is not yet wired to the `--ui-switch-*` tokens
+> (see `tokens.yaml`/`behavior.md`). Vue and Web Component implementations are
+> planned against the same contract.

--- a/packages/ui-spec/components/switch/accessibility.md
+++ b/packages/ui-spec/components/switch/accessibility.md
@@ -1,0 +1,14 @@
+# Switch — Accessibility
+
+- **Role:** `switch` (Base UI Switch.Root), with `aria-checked` reflecting the
+  on/off state.
+- **Accessible name:** associate a visible label (e.g. wrap with a `<label>` or
+  use `aria-labelledby`); when there is no visible label, provide `aria-label`.
+- **Keyboard:** Space (and Enter) toggle the switch while focused; Tab moves
+  focus. A `disabled` switch is not focusable.
+- **Focus visible:** 2px `--ui-focus-brand` ring with 2px offset via
+  `:focus-visible`.
+- **State, not color alone:** the on/off state is exposed via `aria-checked` and
+  the thumb position, not color alone.
+- **WCAG:** 2.1.1 (keyboard), 2.4.7 (focus visible), 4.1.2 (name/role/value),
+  1.4.11 (non-text contrast).

--- a/packages/ui-spec/components/switch/anatomy.yaml
+++ b/packages/ui-spec/components/switch/anatomy.yaml
@@ -20,18 +20,32 @@ parts:
     description: The sliding knob that moves between the off and on positions.
     element: span
 
-# Switch owns one piece of internal state: `checked`. When uncontrolled it is
-# toggled by interaction; when controlled it mirrors the `checked` prop. The
-# checked/unchecked visual states below are therefore `internal` (driven by
-# this state), not `prop` — reaching them in a story needs either the controlled
-# prop or a play interaction.
+# Switch owns one piece of internal state, `checked`, plus the logic that maps
+# interaction -> state -> visuals. The checked/unchecked visual states below are
+# therefore `internal` (driven by this state), reached via the controlled prop or
+# a play interaction (see transitions).
 internal_state:
   - id: checked
     type: boolean
+    values: [false, true]
     initial: false
-    controllable_via: [checked, default-checked]
+    controllable_via: [checked]
+    controlled_default: default-checked
+    emits: checked-change
     changed_by: click / Space / Enter toggles it (when uncontrolled)
     description: On/off state; reflected to aria-checked and the thumb position.
+
+transitions:
+  - id: toggle
+    state: checked
+    on: click / Space / Enter
+    to: toggle (!checked)
+    guard: not disabled
+    effect: emits checked-change(next)
+    when_controlled: >-
+      internal value does NOT change; the component only emits checked-change and
+      the consumer must update the `checked` prop to reflect the new value.
+    interactive: true
 
 states:
   - {

--- a/packages/ui-spec/components/switch/anatomy.yaml
+++ b/packages/ui-spec/components/switch/anatomy.yaml
@@ -20,16 +20,43 @@ parts:
     description: The sliding knob that moves between the off and on positions.
     element: span
 
+# Switch owns one piece of internal state: `checked`. When uncontrolled it is
+# toggled by interaction; when controlled it mirrors the `checked` prop. The
+# checked/unchecked visual states below are therefore `internal` (driven by
+# this state), not `prop` — reaching them in a story needs either the controlled
+# prop or a play interaction.
+internal_state:
+  - id: checked
+    type: boolean
+    initial: false
+    controllable_via: [checked, default-checked]
+    changed_by: click / Space / Enter toggles it (when uncontrolled)
+    description: On/off state; reflected to aria-checked and the thumb position.
+
 states:
   - {
       id: checked,
-      trigger: 'checked === true (data-[checked])',
+      trigger: 'internal checked === true (data-[checked])',
+      kind: internal,
       affects: [root, thumb],
     }
   - {
       id: unchecked,
-      trigger: 'checked === false (data-[unchecked])',
+      trigger: 'internal checked === false (data-[unchecked])',
+      kind: internal,
       affects: [root, thumb],
     }
-  - { id: focus-visible, trigger: keyboard focus, affects: [root] }
-  - { id: disabled, trigger: 'disabled === true', affects: [root, thumb] }
+  - {
+      id: focus-visible,
+      trigger: keyboard focus,
+      kind: pseudo,
+      pseudo: ':focus-visible',
+      affects: [root],
+    }
+  - {
+      id: disabled,
+      trigger: 'disabled === true',
+      kind: prop,
+      prop: disabled,
+      affects: [root, thumb],
+    }

--- a/packages/ui-spec/components/switch/anatomy.yaml
+++ b/packages/ui-spec/components/switch/anatomy.yaml
@@ -1,6 +1,13 @@
 spec_version: '1.0'
 component: Switch
 
+schematic: |
+  unchecked                 checked
+  +---------------+         +---------------+
+  | (thumb)       |         |       (thumb) |   root: track
+  +---------------+         +---------------+
+  thumb slides left <-> right with the checked state
+
 root:
   element: button
   role: switch

--- a/packages/ui-spec/components/switch/anatomy.yaml
+++ b/packages/ui-spec/components/switch/anatomy.yaml
@@ -1,0 +1,28 @@
+spec_version: '1.0'
+component: Switch
+
+root:
+  element: button
+  role: switch
+  description: >-
+    The track. A button with role="switch" and aria-checked reflecting state
+    (Base UI Switch.Root).
+
+parts:
+  - id: thumb
+    description: The sliding knob that moves between the off and on positions.
+    element: span
+
+states:
+  - {
+      id: checked,
+      trigger: 'checked === true (data-[checked])',
+      affects: [root, thumb],
+    }
+  - {
+      id: unchecked,
+      trigger: 'checked === false (data-[unchecked])',
+      affects: [root, thumb],
+    }
+  - { id: focus-visible, trigger: keyboard focus, affects: [root] }
+  - { id: disabled, trigger: 'disabled === true', affects: [root, thumb] }

--- a/packages/ui-spec/components/switch/api.yaml
+++ b/packages/ui-spec/components/switch/api.yaml
@@ -1,0 +1,63 @@
+spec_version: '1.0'
+component: Switch
+
+contract:
+  properties:
+    - name: checked
+      type: boolean
+      required: false
+      description: Controlled checked state. Pair with the change event.
+    - name: default-checked
+      type: boolean
+      required: false
+      default: false
+      description: Initial checked state when uncontrolled.
+    - name: disabled
+      type: boolean
+      required: false
+      default: false
+      description: Disables interaction.
+    - name: required
+      type: boolean
+      required: false
+      default: false
+      description: Marks the control as required in a form.
+    - name: name
+      type: string
+      required: false
+      description: Form field name submitted with the form.
+    - name: value
+      type: string
+      required: false
+      description: Form field value when checked.
+
+  events:
+    - name: checked-change
+      payload: boolean
+      description: >-
+        Fired when the checked state changes (React: `onCheckedChange`). Payload
+        is the new checked value.
+
+adapters:
+  react:
+    component: Switch
+    status: implemented
+    import: "import { Switch } from '@acronis-platform/ui-react'"
+    example: |
+      <Switch
+        aria-label="Wireless"
+        checked={enabled}
+        onCheckedChange={setEnabled}
+      />
+  vue:
+    component: AvSwitch
+    status: planned
+    import: "import { AvSwitch } from '@acronis-platform/ui-vue'"
+    example: |
+      <AvSwitch v-model="enabled" aria-label="Wireless" />
+  web-components:
+    element: ui-switch
+    status: planned
+    import: "import '@acronis-platform/ui-wc/switch'"
+    example: |
+      <ui-switch aria-label="Wireless"></ui-switch>

--- a/packages/ui-spec/components/switch/behavior.md
+++ b/packages/ui-spec/components/switch/behavior.md
@@ -1,0 +1,39 @@
+# Switch — Behavior
+
+## Toggling
+
+### Toggles on activation
+
+**Given** an enabled Switch
+**When** the user clicks it or presses Space/Enter while focused
+**Then** the checked state flips
+**And** a `checked-change` event fires with the new boolean value
+**And** the thumb slides to the new position.
+
+## Controlled vs uncontrolled
+
+### Uncontrolled
+
+**Given** a Switch with `default-checked` and no `checked`
+**When** it renders
+**Then** it manages its own state, starting from `default-checked`.
+
+### Controlled
+
+**Given** a Switch with `checked`
+**When** the user toggles it
+**Then** it emits `checked-change` but does not change visually until the owner
+updates `checked`.
+
+## Disabled
+
+**Given** a Switch with `disabled`
+**When** the user attempts to toggle it
+**Then** the state does not change and no event fires.
+
+## Known gap
+
+The current React implementation renders correctly but is **not yet wired to the
+`--ui-switch-*` tokens** (see `tokens.yaml`). It uses the shared semantic bridge
+and `opacity-50` for disabled. This spec is the target contract; aligning the
+implementation is tracked follow-up.

--- a/packages/ui-spec/components/switch/index.yaml
+++ b/packages/ui-spec/components/switch/index.yaml
@@ -1,0 +1,11 @@
+spec_version: '1.0'
+component: Switch
+name: switch
+status: ready
+category: forms
+description: >-
+  A binary on/off toggle. Wraps the Base UI Switch primitive; the change takes
+  effect immediately (no separate submit).
+since: 0.4.0
+figma:
+  codeConnect: packages/ui-react/src/components/ui/switch/switch.figma.tsx

--- a/packages/ui-spec/components/switch/tokens.yaml
+++ b/packages/ui-spec/components/switch/tokens.yaml
@@ -1,0 +1,53 @@
+spec_version: '1.0'
+component: Switch
+
+# References only — values live in @acronis-platform/tokens-pd.
+#
+# KNOWN GAP: these are the design-intended `--ui-switch-*` tokens. The current
+# React implementation is not yet wired to them — it uses the shared semantic
+# bridge (bg-primary / bg-input / bg-background / ring) and `opacity-50` for
+# disabled. Wiring Switch to these tokens (as Button now is) is tracked
+# follow-up work; this spec is the target contract.
+source: '@acronis-platform/tokens-pd'
+
+tokens:
+  - {
+      name: --ui-switch-background-active,
+      affects: root,
+      description: Track fill when on,
+    }
+  - {
+      name: --ui-switch-background-inactive,
+      affects: root,
+      description: Track fill when off,
+    }
+  - { name: --ui-switch-background-disabled, affects: root }
+  - { name: --ui-switch-border-disabled, affects: root }
+  - {
+      name: --ui-switch-circle-on,
+      affects: thumb,
+      description: Thumb fill when on,
+    }
+  - {
+      name: --ui-switch-circle-off,
+      affects: thumb,
+      description: Thumb fill when off,
+    }
+  - { name: --ui-switch-circle-disabled, affects: thumb }
+  - { name: --ui-switch-units-width, affects: root }
+  - { name: --ui-switch-units-height, affects: root }
+  - { name: --ui-switch-units-radius, affects: root }
+  - { name: --ui-switch-units-border, affects: root }
+  - { name: --ui-switch-units-padding-x, affects: root }
+  - { name: --ui-switch-units-padding-y, affects: root }
+  - { name: --ui-switch-units-gap, affects: root }
+  - {
+      name: --ui-switch-units-circle,
+      affects: thumb,
+      description: Thumb diameter,
+    }
+  - {
+      name: --ui-focus-brand,
+      affects: root,
+      description: Focus-visible ring color,
+    }

--- a/packages/ui-spec/index.ts
+++ b/packages/ui-spec/index.ts
@@ -1,0 +1,27 @@
+import { listComponentNames, readYaml, specFilePath } from './lib/load';
+import type { IndexSpec } from './types';
+
+export type * from './types';
+export { loadSpec, listComponentNames } from './lib/load';
+
+export interface ComponentRegistryEntry {
+  name: string;
+  component: string;
+  status: IndexSpec['status'];
+  category: string;
+  description: string;
+}
+
+/** Registry of every component that has a spec, read from each `index.yaml`. */
+export const components: ComponentRegistryEntry[] = listComponentNames().map(
+  (name) => {
+    const index = readYaml<IndexSpec>(specFilePath(name, 'index'));
+    return {
+      name: index.name,
+      component: index.component,
+      status: index.status,
+      category: index.category,
+      description: index.description,
+    };
+  }
+);

--- a/packages/ui-spec/lib/cva.ts
+++ b/packages/ui-spec/lib/cva.ts
@@ -1,0 +1,85 @@
+import ts from 'typescript';
+
+/**
+ * Extract the variant groups of a `cva(base, { variants: {...} })` call from a
+ * TypeScript source string, returning a map of group name → declared keys.
+ * Example: `{ variant: ['default', 'secondary', ...], size: ['default', 'sm', 'lg'] }`.
+ *
+ * Used by the conformance test to assert a component's real `cva` variants match
+ * the enums declared in its `api.yaml`. Returns `{}` if no `cva` call is found.
+ */
+export function extractCvaGroups(source: string): Record<string, string[]> {
+  const sourceFile = ts.createSourceFile(
+    'component.tsx',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  let result: Record<string, string[]> = {};
+
+  const visit = (node: ts.Node): void => {
+    if (
+      Object.keys(result).length === 0 &&
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'cva' &&
+      node.arguments.length >= 2 &&
+      ts.isObjectLiteralExpression(node.arguments[1])
+    ) {
+      const variants = findProperty(node.arguments[1], 'variants');
+      if (variants && ts.isObjectLiteralExpression(variants)) {
+        result = collectGroups(variants);
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+
+  return result;
+}
+
+/** Find a property's initializer object within an object literal. */
+function findProperty(
+  obj: ts.ObjectLiteralExpression,
+  name: string
+): ts.Expression | undefined {
+  for (const prop of obj.properties) {
+    if (
+      ts.isPropertyAssignment(prop) &&
+      propertyName(prop) === name
+    ) {
+      return prop.initializer;
+    }
+  }
+  return undefined;
+}
+
+/** Map each group (variant, size, …) to the keys of its object literal. */
+function collectGroups(
+  variants: ts.ObjectLiteralExpression
+): Record<string, string[]> {
+  const groups: Record<string, string[]> = {};
+  for (const prop of variants.properties) {
+    if (
+      ts.isPropertyAssignment(prop) &&
+      ts.isObjectLiteralExpression(prop.initializer)
+    ) {
+      const group = propertyName(prop);
+      if (group) {
+        groups[group] = prop.initializer.properties
+          .map((p) => (ts.isPropertyAssignment(p) ? propertyName(p) : undefined))
+          .filter((k): k is string => Boolean(k));
+      }
+    }
+  }
+  return groups;
+}
+
+function propertyName(prop: ts.PropertyAssignment): string | undefined {
+  const { name } = prop;
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) return name.text;
+  return undefined;
+}

--- a/packages/ui-spec/lib/load.ts
+++ b/packages/ui-spec/lib/load.ts
@@ -1,0 +1,51 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { load as parseYaml } from 'js-yaml';
+
+import type {
+  AnatomySpec,
+  ApiSpec,
+  ComponentSpec,
+  IndexSpec,
+  TokensSpec,
+} from '../types';
+
+const PKG_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+export const COMPONENTS_DIR = join(PKG_ROOT, 'components');
+export const SCHEMA_DIR = join(PKG_ROOT, 'schema');
+
+/** The four YAML files of every spec, keyed by the schema that validates them. */
+export const YAML_FILES = ['index', 'anatomy', 'api', 'tokens'] as const;
+export type YamlFile = (typeof YAML_FILES)[number];
+
+/** Component directory names under `components/`. */
+export function listComponentNames(): string[] {
+  return readdirSync(COMPONENTS_DIR)
+    .filter((entry) => statSync(join(COMPONENTS_DIR, entry)).isDirectory())
+    .sort();
+}
+
+export function specFilePath(name: string, file: YamlFile): string {
+  return join(COMPONENTS_DIR, name, `${file}.yaml`);
+}
+
+export function readYaml<T>(absPath: string): T {
+  return parseYaml(readFileSync(absPath, 'utf8')) as T;
+}
+
+export function readSchema(file: YamlFile): object {
+  return JSON.parse(
+    readFileSync(join(SCHEMA_DIR, `${file}.schema.json`), 'utf8')
+  ) as object;
+}
+
+/** Load the full four-file spec for a component. */
+export function loadSpec(name: string): ComponentSpec {
+  return {
+    index: readYaml<IndexSpec>(specFilePath(name, 'index')),
+    anatomy: readYaml<AnatomySpec>(specFilePath(name, 'anatomy')),
+    api: readYaml<ApiSpec>(specFilePath(name, 'api')),
+    tokens: readYaml<TokensSpec>(specFilePath(name, 'tokens')),
+  };
+}

--- a/packages/ui-spec/package.json
+++ b/packages/ui-spec/package.json
@@ -34,9 +34,10 @@
     "@types/js-yaml": "4.0.9",
     "@types/node": "catalog:",
     "ajv": "catalog:",
-    "js-yaml": "4.1.0",
+    "js-yaml": "4.1.1",
     "tsx": "4.22.3",
     "typescript": "catalog:",
+    "vite": "catalog:",
     "vitest": "catalog:"
   }
 }

--- a/packages/ui-spec/package.json
+++ b/packages/ui-spec/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@acronis-platform/ui-spec",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Framework-agnostic component specifications for the Acronis UI Kit (Phase 0 spike).",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./index.ts",
+    "./components/*": "./components/*",
+    "./schema/*": "./schema/*"
+  },
+  "main": "./index.ts",
+  "scripts": {
+    "build": "echo \"no build (spec data package)\" && exit 0",
+    "clean": "echo \"nothing to clean (spec data package)\" && exit 0",
+    "dev": "echo \"no dev server (spec data package)\" && exit 0",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "validate": "vitest run"
+  },
+  "keywords": [
+    "ui-kit",
+    "specs",
+    "design-system",
+    "acronis"
+  ],
+  "devDependencies": {
+    "@types/js-yaml": "4.0.9",
+    "@types/node": "catalog:",
+    "ajv": "catalog:",
+    "js-yaml": "4.1.0",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/ui-spec/package.json
+++ b/packages/ui-spec/package.json
@@ -21,7 +21,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "validate": "vitest run"
+    "validate": "vitest run",
+    "generate:stories": "tsx scripts/generate-stories.ts"
   },
   "keywords": [
     "ui-kit",
@@ -34,6 +35,7 @@
     "@types/node": "catalog:",
     "ajv": "catalog:",
     "js-yaml": "4.1.0",
+    "tsx": "4.22.3",
     "typescript": "catalog:",
     "vitest": "catalog:"
   }

--- a/packages/ui-spec/schema/anatomy.schema.json
+++ b/packages/ui-spec/schema/anatomy.schema.json
@@ -84,16 +84,70 @@
           "id": { "type": "string" },
           "type": { "type": "string" },
           "initial": {},
+          "values": {
+            "type": "array",
+            "description": "Allowed values for enumerated state (omit for free/boolean)."
+          },
           "controllable_via": {
             "type": "array",
             "items": { "type": "string" },
             "description": "api.yaml props that read/override this internal state."
+          },
+          "controlled_default": {
+            "type": "string",
+            "description": "api.yaml prop that seeds the value in uncontrolled mode (e.g. 'default-checked')."
+          },
+          "emits": {
+            "type": "string",
+            "description": "api.yaml event fired when the value changes (e.g. 'checked-change')."
           },
           "changed_by": {
             "type": "string",
             "description": "The interaction that mutates it (e.g. 'click / Space toggles')."
           },
           "description": { "type": "string" }
+        }
+      }
+    },
+    "transitions": {
+      "type": "array",
+      "description": "State machine: how interactions move internal state between values (and what that affects).",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "state", "on", "to"],
+        "properties": {
+          "id": { "type": "string" },
+          "state": {
+            "type": "string",
+            "description": "internal_state id this transition mutates."
+          },
+          "from": {
+            "description": "Source value, or omit for any."
+          },
+          "on": {
+            "type": "string",
+            "description": "The event/interaction that triggers it (e.g. 'click / Space / Enter')."
+          },
+          "to": {
+            "description": "Resulting value, or an expression like 'toggle'."
+          },
+          "guard": {
+            "type": "string",
+            "description": "Condition that must hold (e.g. 'not disabled')."
+          },
+          "effect": {
+            "type": "string",
+            "description": "Side effect (e.g. 'emits checked-change(next)')."
+          },
+          "when_controlled": {
+            "type": "string",
+            "description": "How behaviour differs when the value is controlled by a prop."
+          },
+          "interactive": {
+            "type": "boolean",
+            "description": "Whether this transition is reachable by a user gesture (drives play-story generation)."
+          }
         }
       }
     }

--- a/packages/ui-spec/schema/anatomy.schema.json
+++ b/packages/ui-spec/schema/anatomy.schema.json
@@ -52,12 +52,48 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["id", "trigger"],
+        "required": ["id", "trigger", "kind"],
         "properties": {
           "id": { "type": "string" },
           "trigger": { "type": "string" },
+          "kind": {
+            "enum": ["prop", "pseudo", "internal"],
+            "description": "How the state is reached: a prop value, a CSS pseudo-class, or component-owned (internal) state changed by interaction."
+          },
+          "pseudo": {
+            "type": "string",
+            "description": "CSS pseudo-class for kind=pseudo (e.g. ':hover')."
+          },
+          "prop": {
+            "type": "string",
+            "description": "For kind=prop: the api.yaml property that drives this state."
+          },
           "affects": { "type": "array", "items": { "type": "string" } },
           "exclusive_with": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "internal_state": {
+      "type": "array",
+      "description": "Component-owned state that changes via interaction and affects visual state (empty/absent for components that are a pure function of their props).",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "type", "description"],
+        "properties": {
+          "id": { "type": "string" },
+          "type": { "type": "string" },
+          "initial": {},
+          "controllable_via": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "api.yaml props that read/override this internal state."
+          },
+          "changed_by": {
+            "type": "string",
+            "description": "The interaction that mutates it (e.g. 'click / Space toggles')."
+          },
+          "description": { "type": "string" }
         }
       }
     }

--- a/packages/ui-spec/schema/anatomy.schema.json
+++ b/packages/ui-spec/schema/anatomy.schema.json
@@ -8,6 +8,10 @@
   "properties": {
     "spec_version": { "type": "string" },
     "component": { "type": "string" },
+    "schematic": {
+      "type": "string",
+      "description": "ASCII schematic of the layout, labelling the parts."
+    },
     "root": {
       "type": "object",
       "additionalProperties": false,

--- a/packages/ui-spec/schema/anatomy.schema.json
+++ b/packages/ui-spec/schema/anatomy.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://acronis.com/ui-spec/anatomy.schema.json",
+  "title": "Component spec — anatomy.yaml",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["spec_version", "component", "root", "parts"],
+  "properties": {
+    "spec_version": { "type": "string" },
+    "component": { "type": "string" },
+    "root": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["element"],
+      "properties": {
+        "element": { "type": "string" },
+        "role": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+    "parts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "description"],
+        "properties": {
+          "id": { "type": "string" },
+          "description": { "type": "string" },
+          "element": { "type": "string" },
+          "optional": { "type": "boolean" },
+          "visible_when": { "type": "string" }
+        }
+      }
+    },
+    "layout": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string" },
+        "direction": { "type": "string" },
+        "align": { "type": "string" },
+        "order": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "states": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "trigger"],
+        "properties": {
+          "id": { "type": "string" },
+          "trigger": { "type": "string" },
+          "affects": { "type": "array", "items": { "type": "string" } },
+          "exclusive_with": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    }
+  }
+}

--- a/packages/ui-spec/schema/api.schema.json
+++ b/packages/ui-spec/schema/api.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://acronis.com/ui-spec/api.schema.json",
+  "title": "Component spec — api.yaml",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["spec_version", "component", "contract", "adapters"],
+  "properties": {
+    "spec_version": { "type": "string" },
+    "component": { "type": "string" },
+    "contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["properties"],
+      "properties": {
+        "properties": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "type", "description"],
+            "properties": {
+              "name": { "type": "string" },
+              "type": { "type": "string" },
+              "required": { "type": "boolean" },
+              "default": {},
+              "description": { "type": "string" }
+            }
+          }
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "description"],
+            "properties": {
+              "name": { "type": "string" },
+              "payload": { "type": "string" },
+              "description": { "type": "string" }
+            }
+          }
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "description"],
+            "properties": {
+              "name": { "type": "string" },
+              "description": { "type": "string" }
+            }
+          }
+        },
+        "methods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "description"],
+            "properties": {
+              "name": { "type": "string" },
+              "signature": { "type": "string" },
+              "description": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "adapters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["react"],
+      "properties": {
+        "react": { "$ref": "#/$defs/adapter" },
+        "vue": { "$ref": "#/$defs/adapter" },
+        "web-components": { "$ref": "#/$defs/adapter" }
+      }
+    }
+  },
+  "$defs": {
+    "adapter": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "component": { "type": "string" },
+        "element": { "type": "string" },
+        "import": { "type": "string" },
+        "example": { "type": "string" },
+        "status": { "enum": ["implemented", "planned"] }
+      }
+    }
+  }
+}

--- a/packages/ui-spec/schema/index.schema.json
+++ b/packages/ui-spec/schema/index.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://acronis.com/ui-spec/index.schema.json",
+  "title": "Component spec — index.yaml",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "spec_version",
+    "component",
+    "name",
+    "status",
+    "category",
+    "description"
+  ],
+  "properties": {
+    "spec_version": { "type": "string" },
+    "component": { "type": "string", "pattern": "^[A-Z][A-Za-z0-9]*$" },
+    "name": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+    "status": { "enum": ["draft", "ready", "stable", "deprecated"] },
+    "category": { "type": "string" },
+    "description": { "type": "string" },
+    "since": { "type": "string" },
+    "dependencies": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "components": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "figma": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "node": { "type": "string" },
+        "codeConnect": { "type": "string" }
+      }
+    }
+  }
+}

--- a/packages/ui-spec/schema/tokens.schema.json
+++ b/packages/ui-spec/schema/tokens.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://acronis.com/ui-spec/tokens.schema.json",
+  "title": "Component spec — tokens.yaml (references only, no values)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["spec_version", "component", "source", "tokens"],
+  "properties": {
+    "spec_version": { "type": "string" },
+    "component": { "type": "string" },
+    "source": { "type": "string" },
+    "tokens": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string", "pattern": "^--ui-[a-z0-9-]+$" },
+          "affects": { "type": "string" },
+          "description": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/packages/ui-spec/scripts/generate-stories.ts
+++ b/packages/ui-spec/scripts/generate-stories.ts
@@ -171,6 +171,7 @@ export const Disabled: Story = {
 
   // ── transitions: drive each interactive transition, land in the new state ──
   const role = anatomy.root.role ?? 'button';
+  const rootSelector = `[role="${role}"], ${anatomy.root.element}`;
   for (const t of (anatomy.transitions ?? []).filter((x) => x.interactive)) {
     needsPlay = true;
     const guard = t.guard ? ` [guard: ${t.guard}]` : '';
@@ -178,7 +179,7 @@ export const Disabled: Story = {
 export const ${cap(t.id)}: Story = {
   render: () => ${base},
   play: async ({ canvasElement }) => {
-    const el = canvasElement.querySelector('[role="${role}"]');
+    const el = canvasElement.querySelector('${rootSelector}');
     if (el) await userEvent.click(el as HTMLElement);
   },
 };`);

--- a/packages/ui-spec/scripts/generate-stories.ts
+++ b/packages/ui-spec/scripts/generate-stories.ts
@@ -169,14 +169,13 @@ export const Disabled: Story = {
     }
   }
 
-  // ── kind=internal: drive the real interaction, land in the changed state ──
-  const internal = anatomy.internal_state ?? [];
-  if (internal.length) {
+  // ── transitions: drive each interactive transition, land in the new state ──
+  const role = anatomy.root.role ?? 'button';
+  for (const t of (anatomy.transitions ?? []).filter((x) => x.interactive)) {
     needsPlay = true;
-    const role = anatomy.root.role ?? 'button';
-    const changedBy = internal[0].changed_by ?? 'interaction';
-    parts.push(`// Internal state "${internal[0].id}" — ${changedBy}.
-export const Interaction: Story = {
+    const guard = t.guard ? ` [guard: ${t.guard}]` : '';
+    parts.push(`// transition "${t.id}": ${t.on} -> ${String(t.to)}${guard}
+export const ${cap(t.id)}: Story = {
   render: () => ${base},
   play: async ({ canvasElement }) => {
     const el = canvasElement.querySelector('[role="${role}"]');

--- a/packages/ui-spec/scripts/generate-stories.ts
+++ b/packages/ui-spec/scripts/generate-stories.ts
@@ -1,35 +1,36 @@
 /**
- * Generate Storybook "All states" stories from component specs.
+ * Generate Storybook stories from component specs.
  *
- * For each spec it reads the variant/size enums and boolean state props from
- * `api.yaml` and emits a story that renders the full prop-driven state matrix —
- * a single comprehensive, snapshot-friendly story per component (a base for
- * visual-regression tests). Output lands next to the React component in
- * `packages/ui-react/src/components/ui/<name>/__stories__/<name>.generated.stories.tsx`.
+ * Drives output from each state's `kind` (see anatomy.yaml):
+ *   - kind=prop     → static matrix / variations (snapshot by passing props)
+ *   - kind=pseudo   → a story per CSS pseudo-state. `:hover`/`:active` emit
+ *                     addon-ready `parameters.pseudo` (needs a pseudo-states
+ *                     addon to paint); `:focus-visible` is driven by a real
+ *                     `play` tab() so it works without one.
+ *   - kind=internal → an Interaction `play` story that performs the real
+ *                     interaction so the component lands in the after-interaction
+ *                     state (e.g. Switch click → checked).
  *
- * Run: `pnpm --filter @acronis-platform/ui-spec generate:stories`
+ * Output: packages/ui-react/src/components/ui/<name>/__stories__/<name>.generated.stories.tsx
+ * Run:    pnpm --filter @acronis-platform/ui-spec generate:stories
  *
- * NOTE (spike limitation): the *axes* (which variants/sizes/states exist) are
- * spec-derived; the small per-component "how to instantiate" hint below
- * (sample content, required aria-label) is not yet in the spec. A future
- * `story` hint in `api.yaml` would remove this map.
+ * NOTE (spike limitation): the state *axes* are spec-derived; the small
+ * per-component "how to instantiate" hint below (sample content, aria-label) is
+ * not yet in the spec — a future `story` hint in api.yaml would remove it.
  */
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { listComponentNames, loadSpec } from '../lib/load';
-import type { ApiSpec } from '../types';
+import type { AnatomySpec, ApiSpec } from '../types';
 
 const PKG_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const UI_REACT_UI = resolve(PKG_ROOT, '../ui-react/src/components/ui');
 
 interface RenderHint {
-  /** Raw JSX or text used as the component's children (empty = self-closing). */
   sample?: string;
-  /** Extra import lines the sample needs. */
   extraImports?: string[];
-  /** aria-label applied to each instance (for controls with no text). */
   ariaLabel?: string;
 }
 
@@ -47,36 +48,48 @@ const RENDER: Record<string, RenderHint> = {
 
 const HEADER =
   '// AUTO-GENERATED from @acronis-platform/ui-spec — DO NOT EDIT.\n' +
-  '// Regenerate: pnpm --filter @acronis-platform/ui-spec generate:stories\n';
+  '// Regenerate: pnpm --filter @acronis-platform/ui-spec generate:stories\n' +
+  '// `:hover` / `:active` stories require a Storybook pseudo-states addon to paint.\n';
 
-/** String-union members of an `api.yaml` property `type`, e.g. ['sm','lg']. */
+const PSEUDO_KEY: Record<string, string> = {
+  ':hover': 'hover',
+  ':active': 'active',
+  ':focus': 'focus',
+};
+
 function enumMembers(api: ApiSpec, prop: string): string[] {
   const p = api.contract.properties.find((x) => x.name === prop);
   if (!p) return [];
   return [...p.type.matchAll(/'([^']+)'/g)].map((m) => m[1]);
 }
 
-function hasProp(api: ApiSpec, name: string): boolean {
-  return api.contract.properties.some((p) => p.name === name);
-}
+const hasProp = (api: ApiSpec, name: string): boolean =>
+  api.contract.properties.some((p) => p.name === name);
 
-function arr(values: string[]): string {
-  return `[${values.map((v) => `'${v}'`).join(', ')}] as const`;
-}
+const arr = (values: string[]): string =>
+  `[${values.map((v) => `'${v}'`).join(', ')}] as const`;
 
-function buildStories(comp: string, api: ApiSpec, hint: RenderHint): string {
+const cap = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1);
+
+function buildStories(
+  comp: string,
+  api: ApiSpec,
+  anatomy: AnatomySpec,
+  hint: RenderHint
+): { body: string; needsPlay: boolean } {
   const variants = enumMembers(api, 'variant');
   const sizes = enumMembers(api, 'size');
   const label = hint.ariaLabel ? ` aria-label="${hint.ariaLabel}"` : '';
-  const children = hint.sample ? `${hint.sample}` : '';
-  const open = (props: string) =>
-    children
-      ? `<${comp}${props}>${children}</${comp}>`
-      : `<${comp}${props} />`;
+  const children = hint.sample ?? '';
+  const inst = (props: string) =>
+    children ? `<${comp}${props}>${children}</${comp}>` : `<${comp}${props} />`;
+  const base = inst(label);
 
-  // Shape 1 — variant × size grid (+ a disabled row).
+  const parts: string[] = [];
+
+  // ── kind=prop: static matrix / variations ──
   if (variants.length && sizes.length) {
-    return `const VARIANTS = ${arr(variants)};
+    parts.push(`const VARIANTS = ${arr(variants)};
 const SIZES = ${arr(sizes)};
 
 export const Matrix: Story = {
@@ -99,9 +112,7 @@ export const Matrix: Story = {
         <span key={\`\${v}-label\`} style={{ fontSize: 12, opacity: 0.6 }}>
           {v}
         </span>,
-        ...SIZES.map((s) => (
-          ${open(' key={`${v}-${s}`} variant={v} size={s}')}
-        )),
+        ...SIZES.map((s) => ${inst(' key={`${v}-${s}`} variant={v} size={s}')}),
       ])}
     </div>
   ),
@@ -110,18 +121,12 @@ export const Matrix: Story = {
 export const Disabled: Story = {
   render: () => (
     <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12 }}>
-      {VARIANTS.map((v) => (
-        ${open(' key={v} variant={v} disabled')}
-      ))}
+      {VARIANTS.map((v) => ${inst(' key={v} variant={v} disabled')})}
     </div>
   ),
-};
-`;
-  }
-
-  // Shape 2 — on/off toggle (checked × disabled).
-  if (hasProp(api, 'checked')) {
-    return `export const States: Story = {
+};`);
+  } else if (hasProp(api, 'checked')) {
+    parts.push(`export const States: Story = {
   render: () => (
     <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, alignItems: 'center' }}>
       <${comp} aria-label="Off" />
@@ -130,34 +135,72 @@ export const Disabled: Story = {
       <${comp} aria-label="Disabled on" disabled defaultChecked />
     </div>
   ),
-};
-`;
-  }
-
-  // Shape 3 — single style, enabled vs disabled.
-  return `export const States: Story = {
+};`);
+  } else {
+    parts.push(`export const States: Story = {
   render: () => (
     <div style={{ display: 'flex', gap: 16, alignItems: 'center' }}>
-      ${open(label)}
-      ${open(`${label} disabled`)}
+      ${inst(label)}
+      ${inst(`${label} disabled`)}
     </div>
   ),
-};
-`;
+};`);
+  }
+
+  // ── kind=pseudo: one story per pseudo-state ──
+  let needsPlay = false;
+  for (const state of anatomy.states ?? []) {
+    if (state.kind !== 'pseudo' || !state.pseudo) continue;
+    if (state.pseudo === ':focus-visible') {
+      needsPlay = true;
+      parts.push(`export const FocusVisible: Story = {
+  render: () => ${base},
+  // Real keyboard focus — paints :focus-visible without a pseudo-states addon.
+  play: async () => {
+    await userEvent.tab();
+  },
+};`);
+    } else if (PSEUDO_KEY[state.pseudo]) {
+      const key = PSEUDO_KEY[state.pseudo];
+      parts.push(`export const ${cap(key)}: Story = {
+  parameters: { pseudo: { ${key}: true } },
+  render: () => ${base},
+};`);
+    }
+  }
+
+  // ── kind=internal: drive the real interaction, land in the changed state ──
+  const internal = anatomy.internal_state ?? [];
+  if (internal.length) {
+    needsPlay = true;
+    const role = anatomy.root.role ?? 'button';
+    const changedBy = internal[0].changed_by ?? 'interaction';
+    parts.push(`// Internal state "${internal[0].id}" — ${changedBy}.
+export const Interaction: Story = {
+  render: () => ${base},
+  play: async ({ canvasElement }) => {
+    const el = canvasElement.querySelector('[role="${role}"]');
+    if (el) await userEvent.click(el as HTMLElement);
+  },
+};`);
+  }
+
+  return { body: parts.join('\n\n'), needsPlay };
 }
 
 function generate(name: string): boolean {
-  const dir = join(UI_REACT_UI, name, '__stories__');
   if (!existsSync(join(UI_REACT_UI, name))) {
     console.warn(`skip ${name}: no @acronis-platform/ui-react component`);
     return false;
   }
-  const { index, api } = loadSpec(name);
+  const { index, api, anatomy } = loadSpec(name);
   const comp = index.component;
   const hint = RENDER[name] ?? {};
+  const { body, needsPlay } = buildStories(comp, api, anatomy, hint);
 
   const imports = [
     "import type { Meta, StoryObj } from '@storybook/react-vite';",
+    ...(needsPlay ? ["import { userEvent } from 'storybook/test';"] : []),
     ...(hint.extraImports ?? []),
     `import { ${comp} } from '../${name}';`,
   ].join('\n');
@@ -173,8 +216,10 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-${buildStories(comp, api, hint)}`;
+${body}
+`;
 
+  const dir = join(UI_REACT_UI, name, '__stories__');
   mkdirSync(dir, { recursive: true });
   writeFileSync(join(dir, `${name}.generated.stories.tsx`), file);
   console.log(`generated ${name}.generated.stories.tsx`);

--- a/packages/ui-spec/scripts/generate-stories.ts
+++ b/packages/ui-spec/scripts/generate-stories.ts
@@ -1,0 +1,186 @@
+/**
+ * Generate Storybook "All states" stories from component specs.
+ *
+ * For each spec it reads the variant/size enums and boolean state props from
+ * `api.yaml` and emits a story that renders the full prop-driven state matrix —
+ * a single comprehensive, snapshot-friendly story per component (a base for
+ * visual-regression tests). Output lands next to the React component in
+ * `packages/ui-react/src/components/ui/<name>/__stories__/<name>.generated.stories.tsx`.
+ *
+ * Run: `pnpm --filter @acronis-platform/ui-spec generate:stories`
+ *
+ * NOTE (spike limitation): the *axes* (which variants/sizes/states exist) are
+ * spec-derived; the small per-component "how to instantiate" hint below
+ * (sample content, required aria-label) is not yet in the spec. A future
+ * `story` hint in `api.yaml` would remove this map.
+ */
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { listComponentNames, loadSpec } from '../lib/load';
+import type { ApiSpec } from '../types';
+
+const PKG_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const UI_REACT_UI = resolve(PKG_ROOT, '../ui-react/src/components/ui');
+
+interface RenderHint {
+  /** Raw JSX or text used as the component's children (empty = self-closing). */
+  sample?: string;
+  /** Extra import lines the sample needs. */
+  extraImports?: string[];
+  /** aria-label applied to each instance (for controls with no text). */
+  ariaLabel?: string;
+}
+
+const RENDER: Record<string, RenderHint> = {
+  button: { sample: 'Label' },
+  'button-icon': {
+    sample: '<PlusIcon />',
+    extraImports: [
+      "import { PlusIcon } from '@acronis-platform/icons-react/stroke-mono';",
+    ],
+    ariaLabel: 'Action',
+  },
+  switch: { ariaLabel: 'Toggle' },
+};
+
+const HEADER =
+  '// AUTO-GENERATED from @acronis-platform/ui-spec — DO NOT EDIT.\n' +
+  '// Regenerate: pnpm --filter @acronis-platform/ui-spec generate:stories\n';
+
+/** String-union members of an `api.yaml` property `type`, e.g. ['sm','lg']. */
+function enumMembers(api: ApiSpec, prop: string): string[] {
+  const p = api.contract.properties.find((x) => x.name === prop);
+  if (!p) return [];
+  return [...p.type.matchAll(/'([^']+)'/g)].map((m) => m[1]);
+}
+
+function hasProp(api: ApiSpec, name: string): boolean {
+  return api.contract.properties.some((p) => p.name === name);
+}
+
+function arr(values: string[]): string {
+  return `[${values.map((v) => `'${v}'`).join(', ')}] as const`;
+}
+
+function buildStories(comp: string, api: ApiSpec, hint: RenderHint): string {
+  const variants = enumMembers(api, 'variant');
+  const sizes = enumMembers(api, 'size');
+  const label = hint.ariaLabel ? ` aria-label="${hint.ariaLabel}"` : '';
+  const children = hint.sample ? `${hint.sample}` : '';
+  const open = (props: string) =>
+    children
+      ? `<${comp}${props}>${children}</${comp}>`
+      : `<${comp}${props} />`;
+
+  // Shape 1 — variant × size grid (+ a disabled row).
+  if (variants.length && sizes.length) {
+    return `const VARIANTS = ${arr(variants)};
+const SIZES = ${arr(sizes)};
+
+export const Matrix: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: \`repeat(\${SIZES.length + 1}, max-content)\`,
+        gap: 12,
+        alignItems: 'center',
+      }}
+    >
+      <span />
+      {SIZES.map((s) => (
+        <span key={s} style={{ fontSize: 12, opacity: 0.6 }}>
+          {s}
+        </span>
+      ))}
+      {VARIANTS.flatMap((v) => [
+        <span key={\`\${v}-label\`} style={{ fontSize: 12, opacity: 0.6 }}>
+          {v}
+        </span>,
+        ...SIZES.map((s) => (
+          ${open(' key={`${v}-${s}`} variant={v} size={s}')}
+        )),
+      ])}
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12 }}>
+      {VARIANTS.map((v) => (
+        ${open(' key={v} variant={v} disabled')}
+      ))}
+    </div>
+  ),
+};
+`;
+  }
+
+  // Shape 2 — on/off toggle (checked × disabled).
+  if (hasProp(api, 'checked')) {
+    return `export const States: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, alignItems: 'center' }}>
+      <${comp} aria-label="Off" />
+      <${comp} aria-label="On" defaultChecked />
+      <${comp} aria-label="Disabled off" disabled />
+      <${comp} aria-label="Disabled on" disabled defaultChecked />
+    </div>
+  ),
+};
+`;
+  }
+
+  // Shape 3 — single style, enabled vs disabled.
+  return `export const States: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 16, alignItems: 'center' }}>
+      ${open(label)}
+      ${open(`${label} disabled`)}
+    </div>
+  ),
+};
+`;
+}
+
+function generate(name: string): boolean {
+  const dir = join(UI_REACT_UI, name, '__stories__');
+  if (!existsSync(join(UI_REACT_UI, name))) {
+    console.warn(`skip ${name}: no @acronis-platform/ui-react component`);
+    return false;
+  }
+  const { index, api } = loadSpec(name);
+  const comp = index.component;
+  const hint = RENDER[name] ?? {};
+
+  const imports = [
+    "import type { Meta, StoryObj } from '@storybook/react-vite';",
+    ...(hint.extraImports ?? []),
+    `import { ${comp} } from '../${name}';`,
+  ].join('\n');
+
+  const file = `${HEADER}
+${imports}
+
+const meta = {
+  title: 'UI/${comp}/All States (generated)',
+  component: ${comp},
+} satisfies Meta<typeof ${comp}>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+${buildStories(comp, api, hint)}`;
+
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${name}.generated.stories.tsx`), file);
+  console.log(`generated ${name}.generated.stories.tsx`);
+  return true;
+}
+
+let count = 0;
+for (const name of listComponentNames()) if (generate(name)) count += 1;
+console.log(`\n${count} story file(s) generated.`);

--- a/packages/ui-spec/tsconfig.json
+++ b/packages/ui-spec/tsconfig.json
@@ -10,5 +10,5 @@
     "noEmit": true,
     "moduleDetection": "force"
   },
-  "include": ["*.ts", "lib/**/*.ts", "__tests__/**/*.ts"]
+  "include": ["*.ts", "lib/**/*.ts", "scripts/**/*.ts", "__tests__/**/*.ts"]
 }

--- a/packages/ui-spec/tsconfig.json
+++ b/packages/ui-spec/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "target": "ES2022",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noEmit": true,
+    "moduleDetection": "force"
+  },
+  "include": ["*.ts", "lib/**/*.ts", "__tests__/**/*.ts"]
+}

--- a/packages/ui-spec/types.ts
+++ b/packages/ui-spec/types.ts
@@ -42,9 +42,31 @@ export interface InternalState {
   id: string;
   type: string;
   initial?: unknown;
+  /** Allowed values for enumerated state (omit for free/boolean). */
+  values?: unknown[];
+  /** api.yaml props that read/override this state. */
   controllable_via?: string[];
+  /** api.yaml prop that seeds the value when uncontrolled. */
+  controlled_default?: string;
+  /** api.yaml event fired when the value changes. */
+  emits?: string;
   changed_by?: string;
   description: string;
+}
+
+/** A state-machine edge: an interaction moving internal state between values. */
+export interface Transition {
+  id: string;
+  /** internal_state id this transition mutates. */
+  state: string;
+  from?: unknown;
+  on: string;
+  to: unknown;
+  guard?: string;
+  effect?: string;
+  when_controlled?: string;
+  /** Reachable by a user gesture (drives play-story generation). */
+  interactive?: boolean;
 }
 
 export interface AnatomySpec {
@@ -54,6 +76,7 @@ export interface AnatomySpec {
   root: { element: string; role?: string; description?: string };
   parts: AnatomyPart[];
   internal_state?: InternalState[];
+  transitions?: Transition[];
   layout?: {
     type?: string;
     direction?: string;

--- a/packages/ui-spec/types.ts
+++ b/packages/ui-spec/types.ts
@@ -22,11 +22,29 @@ export interface AnatomyPart {
   visible_when?: string;
 }
 
+export type StateKind = 'prop' | 'pseudo' | 'internal';
+
 export interface AnatomyState {
   id: string;
   trigger: string;
+  /** How the state is reached. */
+  kind: StateKind;
+  /** CSS pseudo-class, for kind=pseudo (e.g. ':hover'). */
+  pseudo?: string;
+  /** For kind=prop: the api.yaml property that drives this state. */
+  prop?: string;
   affects?: string[];
   exclusive_with?: string[];
+}
+
+/** Component-owned state that changes via interaction and affects visuals. */
+export interface InternalState {
+  id: string;
+  type: string;
+  initial?: unknown;
+  controllable_via?: string[];
+  changed_by?: string;
+  description: string;
 }
 
 export interface AnatomySpec {
@@ -35,6 +53,7 @@ export interface AnatomySpec {
   schematic?: string;
   root: { element: string; role?: string; description?: string };
   parts: AnatomyPart[];
+  internal_state?: InternalState[];
   layout?: {
     type?: string;
     direction?: string;

--- a/packages/ui-spec/types.ts
+++ b/packages/ui-spec/types.ts
@@ -1,0 +1,90 @@
+/** TypeScript shapes for the four YAML files of a component spec. */
+
+export type ComponentStatus = 'draft' | 'ready' | 'stable' | 'deprecated';
+
+export interface IndexSpec {
+  spec_version: string;
+  component: string;
+  name: string;
+  status: ComponentStatus;
+  category: string;
+  description: string;
+  since?: string;
+  dependencies?: { components?: string[] };
+  figma?: { node?: string; codeConnect?: string };
+}
+
+export interface AnatomyPart {
+  id: string;
+  description: string;
+  element?: string;
+  optional?: boolean;
+  visible_when?: string;
+}
+
+export interface AnatomyState {
+  id: string;
+  trigger: string;
+  affects?: string[];
+  exclusive_with?: string[];
+}
+
+export interface AnatomySpec {
+  spec_version: string;
+  component: string;
+  root: { element: string; role?: string; description?: string };
+  parts: AnatomyPart[];
+  layout?: {
+    type?: string;
+    direction?: string;
+    align?: string;
+    order?: string[];
+  };
+  states?: AnatomyState[];
+}
+
+export interface ApiProperty {
+  name: string;
+  type: string;
+  required?: boolean;
+  default?: unknown;
+  description: string;
+}
+
+export interface ApiAdapter {
+  component?: string;
+  element?: string;
+  import?: string;
+  example?: string;
+  status?: 'implemented' | 'planned';
+}
+
+export interface ApiSpec {
+  spec_version: string;
+  component: string;
+  contract: {
+    properties: ApiProperty[];
+    events?: { name: string; payload?: string; description: string }[];
+    content?: { name: string; description: string }[];
+    methods?: { name: string; signature?: string; description: string }[];
+  };
+  adapters: {
+    react: ApiAdapter;
+    vue?: ApiAdapter;
+    'web-components'?: ApiAdapter;
+  };
+}
+
+export interface TokensSpec {
+  spec_version: string;
+  component: string;
+  source: string;
+  tokens: { name: string; affects?: string; description?: string }[];
+}
+
+export interface ComponentSpec {
+  index: IndexSpec;
+  anatomy: AnatomySpec;
+  api: ApiSpec;
+  tokens: TokensSpec;
+}

--- a/packages/ui-spec/types.ts
+++ b/packages/ui-spec/types.ts
@@ -32,6 +32,7 @@ export interface AnatomyState {
 export interface AnatomySpec {
   spec_version: string;
   component: string;
+  schematic?: string;
   root: { element: string; role?: string; description?: string };
   parts: AnatomyPart[];
   layout?: {

--- a/packages/ui-spec/vitest.config.ts
+++ b/packages/ui-spec/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['__tests__/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -791,17 +791,20 @@ importers:
         specifier: 'catalog:'
         version: 8.17.1
       js-yaml:
-        specifier: 4.1.0
-        version: 4.1.0
+        specifier: 4.1.1
+        version: 4.1.1
       tsx:
         specifier: 4.22.3
         version: 4.22.3
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(happy-dom@20.9.0)(jsdom@24.1.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(happy-dom@20.9.0)(jsdom@24.1.3)(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
 
   tools/style-dictionary:
     devDependencies:
@@ -6480,10 +6483,6 @@ packages:
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
-
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
   js-yaml@4.1.1:
@@ -12924,7 +12923,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -12934,7 +12933,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -15065,10 +15064,6 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
-
-  js-yaml@4.1.0:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.1.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -793,6 +793,9 @@ importers:
       js-yaml:
         specifier: 4.1.0
         version: 4.1.0
+      tsx:
+        specifier: 4.22.3
+        version: 4.22.3
       typescript:
         specifier: 'catalog:'
         version: 6.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -779,6 +779,27 @@ importers:
         specifier: 'catalog:'
         version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(happy-dom@20.9.0)(jsdom@24.1.3)(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
 
+  packages/ui-spec:
+    devDependencies:
+      '@types/js-yaml':
+        specifier: 4.0.9
+        version: 4.0.9
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      ajv:
+        specifier: 'catalog:'
+        version: 8.17.1
+      js-yaml:
+        specifier: 4.1.0
+        version: 4.1.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(happy-dom@20.9.0)(jsdom@24.1.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
+
   tools/style-dictionary:
     devDependencies:
       '@acronis-platform/design-assets':
@@ -3901,6 +3922,9 @@ packages:
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -6453,6 +6477,10 @@ packages:
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
   js-yaml@4.1.1:
@@ -11925,6 +11953,8 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/mdast@4.0.4':
@@ -12891,7 +12921,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -12901,7 +12931,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -15032,6 +15062,10 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
+
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
 
   js-yaml@4.1.1:
     dependencies:


### PR DESCRIPTION
### Type of change

- [x] New feature (a non-breaking change that adds functionality)
- [x] Documentation (proposal / ADR)

### Description

Introduces a **framework-agnostic component specification** layer, in two commits:

1. **Proposal (ADR)** — `context/component-specs-proposal.md` (status: **Proposed**).
   Evaluates adopting an adapted version of the Acronis Vue ui-kit's `grammar` +
   `specs` model here: a machine-readable, framework-neutral contract for each
   component, to support the roadmap's future non-React implementations and the
   agent-driven workflow. Indexed in the root `AGENTS.md`.
2. **Phase 0 spike** — `packages/ui-spec` (private), proving the format and its
   conformance check on three existing components.

### `packages/ui-spec`

**7-file spec format** per component (`index`/`anatomy`/`api`/`tokens` YAML +
`behavior`/`accessibility`/`README` MD), with:

- **4 JSON Schemas** validating the YAML.
- A TS registry (`index.ts`), shapes (`types.ts`), a YAML loader, and a
  TypeScript-AST `cva` key extractor (`lib/`).
- **A vitest suite that makes specs more than docs:**
  - schema-validates every spec, and
  - **cva ↔ contract conformance** — parses the real `cva` `variant`/`size`
    keys out of `ui-react`'s `button.tsx` and asserts they equal
    `button/api.yaml`'s enums. Drift fails the build.

**Specs authored** for `button`, `button-icon`, `switch`:

- **Tokens by reference** — `tokens.yaml` lists only `--ui-*` names + the part
  affected; the token schema **forbids a `value`/`default` key**, so values are
  never duplicated from `tokens-pd`. This structurally prevents the Figma↔token
  drift class.
- `api.yaml` `adapters`: React = `implemented`; Vue / Web Components = `planned`.

**A gap the spec already surfaced:** `Switch` is not yet wired to its dedicated
`--ui-switch-*` tokens (it uses the semantic bridge + `opacity-50`). The switch
spec records the intended tokens and flags this as a known gap — exactly the
kind of drift this layer is meant to expose.

### Scope / what this is not

- **Private package, spike scope** (3 components). Not published; no changeset.
- Open questions (package placement, Open UI naming, how much generation tooling
  to port) are intentionally left for the proposal discussion.

### Verification

- `pnpm --filter @acronis-platform/ui-spec test` → 13/13 (12 schema + 1 conformance).
- `pnpm -r typecheck`, ui-spec `lint` — clean. Pre-commit hook green.

### Checklist

- [x] Tests added (schema validation + conformance).
- [x] Self-review performed.
- [x] Follows project guidelines.
- [x] No new warnings.
