### PR TITLE
feat(tokens): introduce semantic context grouping for tokens and upda…

### DIFF
--- a/.changeset/kitchen-sink-color-grouping.md
+++ b/.changeset/kitchen-sink-color-grouping.md
@@ -1,10 +1,11 @@
 ---
+'@acronis-platform/kitchen-sink': patch
 ---
 
-Kitchen-sink demo only: regroup the **Colors & tokens** section by semantic
-**context → role**, order tokens by state progression, and render the `status`
-family as an intent × role/state matrix.
+Regroup the **Colors & tokens** section: semantic colors by **context → role**,
+component tokens the same way (sub-group → state-ordered rows), with the regular
+families rendered as a matrix — status by intent, button by variant. Tokens are
+also ordered by state progression (idle → hover → active → pressed → disabled).
 
-`apps/kitchen-sink` is a private, unpublished app, so this change has **no
-release impact** — this is an intentionally empty changeset (no published
-package is bumped).
+`@acronis-platform/kitchen-sink` is a private, unpublished app, so this bump has
+no publish impact.

--- a/.changeset/kitchen-sink-color-grouping.md
+++ b/.changeset/kitchen-sink-color-grouping.md
@@ -1,0 +1,10 @@
+---
+---
+
+Kitchen-sink demo only: regroup the **Colors & tokens** section by semantic
+**context → role**, order tokens by state progression, and render the `status`
+family as an intent × role/state matrix.
+
+`apps/kitchen-sink` is a private, unpublished app, so this change has **no
+release impact** — this is an intentionally empty changeset (no published
+package is bumped).

--- a/apps/kitchen-sink/src/lib/tokens.ts
+++ b/apps/kitchen-sink/src/lib/tokens.ts
@@ -54,6 +54,24 @@ export interface TokenGroup {
   tokens: { name: string }[];
 }
 
+/** A row of tokens that share a role (paints `bg` / `text` / `border` / …). */
+export interface RoleGroup {
+  /** Normalized role: `bg` | `text` | `border` | `glyph` | `focus`. */
+  role: string;
+  /** `name` is the full custom property; `leaf` is the part after the
+   *  role+context prefix (e.g. `primary-hover`) for a compact card label. */
+  tokens: { name: string; leaf: string }[];
+}
+
+/** Semantic tokens for one context (`surface`, `brand`, `status`, …),
+ *  split into role rows. */
+export interface ContextGroup {
+  context: string;
+  /** Total tokens across all role rows (for the heading count). */
+  count: number;
+  roles: RoleGroup[];
+}
+
 /** Per-component token CSS (not bundled by ui-react/styles). */
 const COMPONENT_SOURCES: { tier: string; css: string }[] = [
   { tier: 'breadcrumb', css: breadcrumbAcronis },
@@ -91,19 +109,115 @@ function tokenNames(css: string): string[] {
   return [...set].sort();
 }
 
-/** Semantic groups (`--ui-background-*`, `--ui-text-*`, …), grouped by tier. */
-export const semanticGroups: TokenGroup[] = (() => {
-  const byTier = new Map<string, string[]>();
-  for (const name of tokenNames(semanticAcronis)) {
-    const tier = name.slice('--ui-'.length).split('-')[0];
-    const list = byTier.get(tier) ?? [];
-    list.push(name);
-    byTier.set(tier, list);
+/**
+ * Semantic token taxonomy. Every name is `--ui-<role>-<context>-…`:
+ *   - background tokens read context directly  (`background-<context>-…`)
+ *   - text/border/glyph read it after `on-`     (`text-on-<context>-…`)
+ *   - focus has no context and is its own group (`focus-…`)
+ * We group by **context** first (how designers reason — "colors that live on a
+ * surface"), then by **role** within, so a surface's bg/text/border/glyph sit
+ * together instead of in four separate mega-buckets.
+ */
+const ROLE_LABEL: Record<string, string> = {
+  background: 'bg',
+  text: 'text',
+  border: 'border',
+  glyph: 'glyph',
+  focus: 'focus',
+};
+const CONTEXT_ORDER = [
+  'surface',
+  'brand',
+  'status',
+  'inverted',
+  'overlay',
+  'ai',
+  'focus',
+];
+const ROLE_ORDER = ['bg', 'text', 'border', 'glyph', 'focus'];
+
+/** Order states as a progression instead of alphabetically. */
+const STATE_RANK: Record<string, number> = {
+  idle: 1,
+  default: 1,
+  hover: 2,
+  active: 3,
+  pressed: 4,
+  disabled: 5,
+};
+
+function parseToken(name: string): {
+  context: string;
+  role: string;
+  leaf: string;
+} {
+  const segs = name.slice('--ui-'.length).split('-');
+  const role0 = segs[0];
+  if (role0 === 'focus') {
+    return { context: 'focus', role: 'focus', leaf: segs.slice(1).join('-') };
   }
-  return [...byTier.entries()].map(([tier, names]) => ({
-    tier,
-    tokens: names.map((name) => ({ name })),
-  }));
+  if (role0 === 'background') {
+    return { context: segs[1], role: 'bg', leaf: segs.slice(2).join('-') };
+  }
+  // text | border | glyph — context follows the `on-` marker.
+  const hasOn = segs[1] === 'on';
+  const context = hasOn ? segs[2] : segs[1];
+  const leaf = segs.slice(hasOn ? 3 : 2).join('-');
+  return { context, role: ROLE_LABEL[role0] ?? role0, leaf };
+}
+
+/** Sort by variant base, then state progression (idle → … → disabled). */
+function byState(a: string, b: string): number {
+  const key = (n: string): [string, number] => {
+    const segs = n.split('-');
+    const last = segs[segs.length - 1];
+    return last in STATE_RANK
+      ? [segs.slice(0, -1).join('-'), STATE_RANK[last]]
+      : [n, 0];
+  };
+  const [ba, ra] = key(a);
+  const [bb, rb] = key(b);
+  return ba === bb ? ra - rb : ba < bb ? -1 : 1;
+}
+
+/** Position in a fixed order array; unknowns sort last, then alphabetically. */
+function ordered<T extends string>(order: T[]) {
+  return (a: T, b: T): number => {
+    const ia = order.indexOf(a);
+    const ib = order.indexOf(b);
+    if (ia !== ib) return (ia < 0 ? order.length : ia) - (ib < 0 ? order.length : ib);
+    return a < b ? -1 : a > b ? 1 : 0;
+  };
+}
+
+/** Semantic colors grouped by context → role. */
+export const semanticContextGroups: ContextGroup[] = (() => {
+  const byContext = new Map<string, Map<string, string[]>>();
+  for (const name of tokenNames(semanticAcronis)) {
+    const { context, role } = parseToken(name);
+    const roles = byContext.get(context) ?? new Map<string, string[]>();
+    (roles.get(role) ?? roles.set(role, []).get(role)!).push(name);
+    byContext.set(context, roles);
+  }
+  const ctxSort = ordered(CONTEXT_ORDER);
+  const roleSort = ordered(ROLE_ORDER);
+  return [...byContext.entries()]
+    .sort(([a], [b]) => ctxSort(a, b))
+    .map(([context, roles]) => {
+      const roleGroups = [...roles.entries()]
+        .sort(([a], [b]) => roleSort(a, b))
+        .map(([role, names]) => ({
+          role,
+          tokens: names
+            .sort(byState)
+            .map((name) => ({ name, leaf: parseToken(name).leaf || name })),
+        }));
+      return {
+        context,
+        count: roleGroups.reduce((n, r) => n + r.tokens.length, 0),
+        roles: roleGroups,
+      };
+    });
 })();
 
 /** Per-component groups (`--ui-button-*`, `--ui-switch-*`, …). */

--- a/apps/kitchen-sink/src/lib/tokens.ts
+++ b/apps/kitchen-sink/src/lib/tokens.ts
@@ -48,12 +48,6 @@ export type ColorMode = 'light' | 'dark';
 export const BRANDS: Brand[] = ['acronis', 'brand-b'];
 export const DEFAULT_BRAND: Brand = 'acronis';
 
-export interface TokenGroup {
-  /** First path segment after `--ui-` (e.g. `button`, `background`). */
-  tier: string;
-  tokens: { name: string }[];
-}
-
 /** A row of tokens that share a role (paints `bg` / `text` / `border` / …). */
 export interface RoleGroup {
   /** Normalized role: `bg` | `text` | `border` | `glyph` | `focus`. */
@@ -166,14 +160,24 @@ function parseToken(name: string): {
   return { context, role: ROLE_LABEL[role0] ?? role0, leaf };
 }
 
-/** Sort by variant base, then state progression (idle → … → disabled). */
-function byState(a: string, b: string): number {
-  const key = (n: string): [string, number] => {
-    const segs = n.split('-');
+/**
+ * Sort tokens within a group by their `leaf` (the part after the role/context
+ * prefix): named variants first (idle → … → disabled within each), then any
+ * bare context-root state. Operating on the leaf — and ranking a state with no
+ * variant *after* named variants — keeps `primary` ahead of a root-level
+ * `hover`/`active` (whose stripped "base" is the context itself, which would
+ * otherwise sort first as a prefix).
+ */
+function compareLeaf(a: string, b: string): number {
+  const key = (leaf: string): [string, number] => {
+    const segs = leaf.split('-');
     const last = segs[segs.length - 1];
-    return last in STATE_RANK
-      ? [segs.slice(0, -1).join('-'), STATE_RANK[last]]
-      : [n, 0];
+    if (last in STATE_RANK) {
+      const variant = segs.slice(0, -1).join('-');
+      // `￿` sorts after any real variant name → root-level states last.
+      return [variant === '' ? '￿' : variant, STATE_RANK[last]];
+    }
+    return [leaf, 0];
   };
   const [ba, ra] = key(a);
   const [bb, rb] = key(b);
@@ -209,8 +213,8 @@ export const semanticContextGroups: ContextGroup[] = (() => {
         .map(([role, names]) => ({
           role,
           tokens: names
-            .sort(byState)
-            .map((name) => ({ name, leaf: parseToken(name).leaf || name })),
+            .map((name) => ({ name, leaf: parseToken(name).leaf || name }))
+            .sort((x, y) => compareLeaf(x.leaf, y.leaf)),
         }));
       return {
         context,
@@ -220,11 +224,63 @@ export const semanticContextGroups: ContextGroup[] = (() => {
     });
 })();
 
+// ---- Token matrix ---------------------------------------------------------
+// Some token families follow a regular row × (role/state) grid — status by
+// intent, button by variant — and read far better as a matrix than as flat
+// swatch rows. The model below is shared by both.
+
+/** What a column paints, so the cell can render an apt preview. */
+export type MatrixCellKind = 'fill' | 'border' | 'text' | 'glyph';
+
+export interface MatrixColumnGroup {
+  label: string;
+  kind: MatrixCellKind;
+  /** Column headers within the group (e.g. `idle` / `hover` / `pressed`). */
+  columns: string[];
+  /** row key → token name per column (`null` when that cell has no token). */
+  cells: Record<string, (string | null)[]>;
+}
+
+export interface TokenMatrix {
+  /** Row keys (status intents, button variants, …). */
+  rows: string[];
+  groups: MatrixColumnGroup[];
+}
+
+interface MatrixSpec {
+  label: string;
+  kind: MatrixCellKind;
+  columns: string[];
+  name: (row: string, column: string) => string | null;
+}
+
+function buildMatrix(rows: string[], specs: MatrixSpec[]): TokenMatrix {
+  return {
+    rows,
+    groups: specs.map((spec) => ({
+      label: spec.label,
+      kind: spec.kind,
+      columns: spec.columns,
+      cells: Object.fromEntries(
+        rows.map((row) => [row, spec.columns.map((c) => spec.name(row, c))])
+      ),
+    })),
+  };
+}
+
+/** Collect every non-null token name a matrix references. */
+function matrixNames(matrix: TokenMatrix): Set<string> {
+  const names = new Set<string>();
+  for (const g of matrix.groups)
+    for (const row of Object.values(g.cells))
+      for (const n of row) if (n) names.add(n);
+  return names;
+}
+
 // ---- Status matrix --------------------------------------------------------
-// Status is the largest context and follows a regular intent × (role/state)
-// grid (every intent exists for every role), so it reads far better as a
-// matrix than as flat swatch rows. Non-intent status tokens (on/off, link,
-// primary, …) don't fit the grid and are surfaced separately as `statusExtras`.
+// Status is the largest semantic context and every intent exists for every
+// role. Non-intent status tokens (on/off, link, primary, …) don't fit the grid
+// and are surfaced separately as `statusExtras`.
 
 const STATUS_INTENTS = [
   'critical',
@@ -235,35 +291,15 @@ const STATUS_INTENTS = [
   'neutral',
 ];
 
-/** What a column paints, so the cell can render an apt preview. */
-export type StatusCellKind = 'fill' | 'border' | 'text' | 'glyph';
-
-export interface StatusColumnGroup {
-  label: string;
-  kind: StatusCellKind;
-  /** Column headers within the group (e.g. `idle` / `hover` / `pressed`). */
-  columns: string[];
-  /** intent → token name per column (`null` when that cell has no token). */
-  cells: Record<string, (string | null)[]>;
-}
-
-export interface StatusMatrix {
-  intents: string[];
-  groups: StatusColumnGroup[];
-}
-
 const statusNameSet = new Set(
-  tokenNames(semanticAcronis).filter((n) => parseToken(n).context === 'status')
+  (semanticContextGroups.find((g) => g.context === 'status')?.roles ?? [])
+    .flatMap((r) => r.tokens)
+    .map((t) => t.name)
 );
 const pickStatus = (name: string): string | null =>
   statusNameSet.has(name) ? name : null;
 
-const STATUS_COLUMN_SPECS: {
-  label: string;
-  kind: StatusCellKind;
-  columns: string[];
-  name: (intent: string, column: string) => string | null;
-}[] = [
+export const statusMatrix: TokenMatrix = buildMatrix(STATUS_INTENTS, [
   {
     label: 'Background',
     kind: 'fill',
@@ -287,57 +323,129 @@ const STATUS_COLUMN_SPECS: {
     name: (i, c) =>
       pickStatus(`--ui-border-on-status-${i}${c === 'base' ? '' : `-${c}`}`),
   },
-  {
-    label: 'Text',
-    kind: 'text',
-    columns: ['base'],
-    name: (i) => pickStatus(`--ui-text-on-status-${i}`),
-  },
-  {
-    label: 'Glyph',
-    kind: 'glyph',
-    columns: ['base'],
-    name: (i) => pickStatus(`--ui-glyph-on-status-${i}`),
-  },
-];
+  { label: 'Text', kind: 'text', columns: ['base'], name: (i) => pickStatus(`--ui-text-on-status-${i}`) },
+  { label: 'Glyph', kind: 'glyph', columns: ['base'], name: (i) => pickStatus(`--ui-glyph-on-status-${i}`) },
+]);
 
-export const statusMatrix: StatusMatrix = {
-  intents: STATUS_INTENTS,
-  groups: STATUS_COLUMN_SPECS.map((spec) => ({
-    label: spec.label,
-    kind: spec.kind,
-    columns: spec.columns,
-    cells: Object.fromEntries(
-      STATUS_INTENTS.map((intent) => [
-        intent,
-        spec.columns.map((c) => spec.name(intent, c)),
-      ])
-    ),
-  })),
-};
-
-/** Status tokens not represented in the matrix (on/off, link, primary, …),
- *  grouped by role for a normal swatch listing below the matrix. */
-export const statusExtras: RoleGroup[] = (() => {
-  const covered = new Set<string>();
-  for (const g of statusMatrix.groups)
-    for (const names of Object.values(g.cells))
-      for (const n of names) if (n) covered.add(n);
-  const status = semanticContextGroups.find((g) => g.context === 'status');
-  if (!status) return [];
-  return status.roles
+/** Subset a set of role groups to the tokens not covered by a matrix. */
+function extrasFrom(roles: RoleGroup[], matrix: TokenMatrix): RoleGroup[] {
+  const covered = matrixNames(matrix);
+  return roles
     .map((r) => ({
       role: r.role,
       tokens: r.tokens.filter((t) => !covered.has(t.name)),
     }))
     .filter((r) => r.tokens.length > 0);
-})();
+}
+
+/** Status tokens not represented in the matrix (on/off, link, primary, …),
+ *  grouped by role for a normal swatch listing below the matrix. */
+export const statusExtras: RoleGroup[] = extrasFrom(
+  semanticContextGroups.find((g) => g.context === 'status')?.roles ?? [],
+  statusMatrix
+);
+
+// ---- Component tokens -----------------------------------------------------
+// Same idea as the semantic context → role grouping: each component is split
+// into sub-groups (the segment after the component name — a variant like
+// `primary`, a part like `circle`, or a dimension bucket like `global`), each
+// rendered as a state-ordered row. Dimension buckets sort last.
+
+const DIMENSION_SUBGROUPS = ['global', 'units', 'nesting'];
+
+/** Sub-group + leaf for a component token (`--ui-<component>-<sub>-<leaf…>`). */
+function parseComponentToken(
+  tier: string,
+  name: string
+): { subgroup: string; leaf: string } {
+  const rest = name.slice(`--ui-${tier}-`.length).split('-');
+  const subgroup = rest[0] ?? name;
+  const leaf = rest.slice(1).join('-') || rest[0] || name;
+  return { subgroup, leaf };
+}
+
+/** Color/variant sub-groups first (alphabetical), dimension buckets last. */
+function compareSubgroup(a: string, b: string): number {
+  const ia = DIMENSION_SUBGROUPS.indexOf(a);
+  const ib = DIMENSION_SUBGROUPS.indexOf(b);
+  if ((ia < 0) !== (ib < 0)) return ia < 0 ? -1 : 1;
+  if (ia < 0) return a < b ? -1 : a > b ? 1 : 0;
+  return ia - ib;
+}
+
+export interface ComponentTokenGroup {
+  /** Component name / tier, e.g. `button`. */
+  component: string;
+  count: number;
+  subgroups: RoleGroup[];
+}
 
 /** Per-component groups (`--ui-button-*`, `--ui-switch-*`, …). */
-export const componentGroups: TokenGroup[] = COMPONENT_SOURCES.map((s) => ({
-  tier: s.tier,
-  tokens: tokenNames(s.css).map((name) => ({ name })),
-}));
+export const componentGroups: ComponentTokenGroup[] = COMPONENT_SOURCES.map(
+  (s) => {
+    const bySub = new Map<string, { name: string; leaf: string }[]>();
+    for (const name of tokenNames(s.css)) {
+      const { subgroup, leaf } = parseComponentToken(s.tier, name);
+      const list = bySub.get(subgroup) ?? [];
+      list.push({ name, leaf });
+      bySub.set(subgroup, list);
+    }
+    const subgroups = [...bySub.entries()]
+      .sort(([a], [b]) => compareSubgroup(a, b))
+      .map(([role, tokens]) => ({
+        role,
+        tokens: tokens.sort((x, y) => compareLeaf(x.leaf, y.leaf)),
+      }));
+    return {
+      component: s.tier,
+      count: subgroups.reduce((n, r) => n + r.tokens.length, 0),
+      subgroups,
+    };
+  }
+);
+
+// ---- Button matrix --------------------------------------------------------
+// Button is the one component with a fully regular variant × role × state grid
+// (`--ui-button-<variant>-<role>-<state>`), so it gets the matrix treatment.
+// Its non-variant `global-*` dimension tokens fall out as `buttonExtras`.
+
+const BUTTON_VARIANTS = [
+  'primary',
+  'secondary',
+  'ghost',
+  'destructive',
+  'inverted',
+  'icon',
+  'ai',
+];
+const BUTTON_STATES = ['idle', 'hover', 'active', 'disabled'];
+
+const buttonNameSet = new Set(tokenNames(buttonAcronis));
+const pickButton = (name: string): string | null =>
+  buttonNameSet.has(name) ? name : null;
+
+export const buttonMatrix: TokenMatrix = buildMatrix(
+  BUTTON_VARIANTS,
+  (
+    [
+      ['Background', 'fill', 'background'],
+      ['Border', 'border', 'border'],
+      ['Icon', 'glyph', 'icon'],
+      ['Label', 'text', 'label'],
+    ] as const
+  ).map(([label, kind, role]) => ({
+    label,
+    kind,
+    columns: BUTTON_STATES,
+    name: (variant, state) => pickButton(`--ui-button-${variant}-${role}-${state}`),
+  }))
+);
+
+/** Button tokens not in the matrix (`global-*` dimensions). */
+export const buttonExtras: RoleGroup[] = extrasFrom(
+  componentGroups.find((g) => g.component === 'button')?.subgroups ?? [],
+  buttonMatrix
+);
 
 export interface TypographyStyle {
   /** e.g. `ui-typography-body-default`. */

--- a/apps/kitchen-sink/src/lib/tokens.ts
+++ b/apps/kitchen-sink/src/lib/tokens.ts
@@ -220,6 +220,119 @@ export const semanticContextGroups: ContextGroup[] = (() => {
     });
 })();
 
+// ---- Status matrix --------------------------------------------------------
+// Status is the largest context and follows a regular intent × (role/state)
+// grid (every intent exists for every role), so it reads far better as a
+// matrix than as flat swatch rows. Non-intent status tokens (on/off, link,
+// primary, …) don't fit the grid and are surfaced separately as `statusExtras`.
+
+const STATUS_INTENTS = [
+  'critical',
+  'danger',
+  'info',
+  'success',
+  'warning',
+  'neutral',
+];
+
+/** What a column paints, so the cell can render an apt preview. */
+export type StatusCellKind = 'fill' | 'border' | 'text' | 'glyph';
+
+export interface StatusColumnGroup {
+  label: string;
+  kind: StatusCellKind;
+  /** Column headers within the group (e.g. `idle` / `hover` / `pressed`). */
+  columns: string[];
+  /** intent → token name per column (`null` when that cell has no token). */
+  cells: Record<string, (string | null)[]>;
+}
+
+export interface StatusMatrix {
+  intents: string[];
+  groups: StatusColumnGroup[];
+}
+
+const statusNameSet = new Set(
+  tokenNames(semanticAcronis).filter((n) => parseToken(n).context === 'status')
+);
+const pickStatus = (name: string): string | null =>
+  statusNameSet.has(name) ? name : null;
+
+const STATUS_COLUMN_SPECS: {
+  label: string;
+  kind: StatusCellKind;
+  columns: string[];
+  name: (intent: string, column: string) => string | null;
+}[] = [
+  {
+    label: 'Background',
+    kind: 'fill',
+    columns: ['idle', 'hover', 'pressed'],
+    name: (i, c) =>
+      pickStatus(`--ui-background-status-${i}${c === 'idle' ? '' : `-${c}`}`),
+  },
+  {
+    label: 'Background · inverted',
+    kind: 'fill',
+    columns: ['idle', 'hover', 'pressed'],
+    name: (i, c) =>
+      pickStatus(
+        `--ui-background-status-inverted-${i}${c === 'idle' ? '' : `-${c}`}`
+      ),
+  },
+  {
+    label: 'Border',
+    kind: 'border',
+    columns: ['base', 'dark'],
+    name: (i, c) =>
+      pickStatus(`--ui-border-on-status-${i}${c === 'base' ? '' : `-${c}`}`),
+  },
+  {
+    label: 'Text',
+    kind: 'text',
+    columns: ['base'],
+    name: (i) => pickStatus(`--ui-text-on-status-${i}`),
+  },
+  {
+    label: 'Glyph',
+    kind: 'glyph',
+    columns: ['base'],
+    name: (i) => pickStatus(`--ui-glyph-on-status-${i}`),
+  },
+];
+
+export const statusMatrix: StatusMatrix = {
+  intents: STATUS_INTENTS,
+  groups: STATUS_COLUMN_SPECS.map((spec) => ({
+    label: spec.label,
+    kind: spec.kind,
+    columns: spec.columns,
+    cells: Object.fromEntries(
+      STATUS_INTENTS.map((intent) => [
+        intent,
+        spec.columns.map((c) => spec.name(intent, c)),
+      ])
+    ),
+  })),
+};
+
+/** Status tokens not represented in the matrix (on/off, link, primary, …),
+ *  grouped by role for a normal swatch listing below the matrix. */
+export const statusExtras: RoleGroup[] = (() => {
+  const covered = new Set<string>();
+  for (const g of statusMatrix.groups)
+    for (const names of Object.values(g.cells))
+      for (const n of names) if (n) covered.add(n);
+  const status = semanticContextGroups.find((g) => g.context === 'status');
+  if (!status) return [];
+  return status.roles
+    .map((r) => ({
+      role: r.role,
+      tokens: r.tokens.filter((t) => !covered.has(t.name)),
+    }))
+    .filter((r) => r.tokens.length > 0);
+})();
+
 /** Per-component groups (`--ui-button-*`, `--ui-switch-*`, …). */
 export const componentGroups: TokenGroup[] = COMPONENT_SOURCES.map((s) => ({
   tier: s.tier,

--- a/apps/kitchen-sink/src/sections/colors.tsx
+++ b/apps/kitchen-sink/src/sections/colors.tsx
@@ -1,7 +1,9 @@
 import {
   componentGroups,
   resolveToken,
-  semanticGroups,
+  semanticContextGroups,
+  type ContextGroup,
+  type RoleGroup,
   type TokenGroup,
 } from '@/lib/tokens';
 
@@ -14,25 +16,17 @@ function isColorValue(value: string): boolean {
   );
 }
 
-function GroupHeading({ label, count }: { label: string; count: number }) {
-  return (
-    <h3
-      style={{
-        fontSize: 12,
-        textTransform: 'uppercase',
-        letterSpacing: 0.5,
-        opacity: 0.6,
-        marginBottom: 10,
-      }}
-    >
-      {label} <span style={{ fontWeight: 400 }}>({count})</span>
-    </h3>
-  );
-}
+const ROLE_LABELS: Record<string, string> = {
+  bg: 'Background',
+  text: 'Text',
+  border: 'Border',
+  glyph: 'Glyph',
+  focus: 'Focus',
+};
 
 /** One token: a swatch (colors/gradients) or a value chip (dimensions/etc.),
- *  plus the full `--ui-*` custom-property name. */
-function TokenCard({ name }: { name: string }) {
+ *  with a compact `label` up top and the full `--ui-*` name below. */
+function TokenCard({ name, label }: { name: string; label?: string }) {
   const value = resolveToken(name);
   const isColor = isColorValue(value);
   return (
@@ -66,13 +60,25 @@ function TokenCard({ name }: { name: string }) {
           {value || '—'}
         </div>
       )}
+      {label && (
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            marginTop: 4,
+            color: 'var(--ui-text-on-surface-primary)',
+          }}
+        >
+          {label}
+        </div>
+      )}
       <div
         style={{
           fontSize: 10,
           fontFamily: 'monospace',
-          marginTop: 4,
+          marginTop: label ? 1 : 4,
           wordBreak: 'break-all',
-          color: 'var(--ui-text-on-surface-primary)',
+          color: 'var(--ui-text-on-surface-secondary)',
         }}
       >
         {name}
@@ -94,17 +100,86 @@ function TokenCard({ name }: { name: string }) {
   );
 }
 
-function Group({ group }: { group: TokenGroup }) {
+const cardGrid = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
+  gap: 12,
+} as const;
+
+/** A role row within a context — small role label, then its swatches. */
+function RoleRow({ group }: { group: RoleGroup }) {
   return (
-    <div>
-      <GroupHeading label={group.tier} count={group.tokens.length} />
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
       <div
         style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
-          gap: 12,
+          fontSize: 11,
+          fontWeight: 600,
+          color: 'var(--ui-text-on-surface-secondary)',
         }}
       >
+        {ROLE_LABELS[group.role] ?? group.role}{' '}
+        <span style={{ fontWeight: 400, opacity: 0.7 }}>
+          ({group.tokens.length})
+        </span>
+      </div>
+      <div style={cardGrid}>
+        {group.tokens.map((token) => (
+          <TokenCard key={token.name} name={token.name} label={token.leaf} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** A context section (Surface, Brand, Status, …) holding its role rows. */
+function ContextSection({ group }: { group: ContextGroup }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 16,
+        padding: 16,
+        borderRadius: 8,
+        border: SWATCH_BORDER,
+        background: 'var(--ui-background-surface-primary)',
+      }}
+    >
+      <h4
+        style={{
+          fontSize: 13,
+          fontWeight: 700,
+          textTransform: 'uppercase',
+          letterSpacing: 0.5,
+          margin: 0,
+        }}
+      >
+        {group.context}{' '}
+        <span style={{ fontWeight: 400, opacity: 0.6 }}>({group.count})</span>
+      </h4>
+      {group.roles.map((role) => (
+        <RoleRow key={role.role} group={role} />
+      ))}
+    </div>
+  );
+}
+
+/** Per-component token group (`--ui-button-*`, …) — flat grid, grouped by name. */
+function ComponentGroup({ group }: { group: TokenGroup }) {
+  return (
+    <div>
+      <h3
+        style={{
+          fontSize: 12,
+          textTransform: 'uppercase',
+          letterSpacing: 0.5,
+          opacity: 0.6,
+          marginBottom: 10,
+        }}
+      >
+        {group.tier} <span style={{ fontWeight: 400 }}>({group.tokens.length})</span>
+      </h3>
+      <div style={cardGrid}>
         {group.tokens.map((token) => (
           <TokenCard key={token.name} name={token.name} />
         ))}
@@ -119,20 +194,22 @@ export function ColorsSection() {
       <p style={{ fontSize: 13, color: 'var(--ui-text-on-surface-secondary)' }}>
         Generated <code>--ui-*</code> tokens from{' '}
         <code>@acronis-platform/tokens-pd</code>. Values reflect the active brand
-        and light/dark scheme.
+        and light/dark scheme. Semantic colors are grouped by{' '}
+        <strong>context</strong> (the surface/intent a color lives on), then by{' '}
+        <strong>role</strong> (background, text, border, glyph) within.
       </p>
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
-        <h3 style={{ fontSize: 14, fontWeight: 600 }}>Semantic tokens</h3>
-        {semanticGroups.map((group) => (
-          <Group key={group.tier} group={group} />
+        <h3 style={{ fontSize: 14, fontWeight: 600 }}>Semantic colors</h3>
+        {semanticContextGroups.map((group) => (
+          <ContextSection key={group.context} group={group} />
         ))}
       </div>
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
         <h3 style={{ fontSize: 14, fontWeight: 600 }}>Component tokens</h3>
         {componentGroups.map((group) => (
-          <Group key={group.tier} group={group} />
+          <ComponentGroup key={group.tier} group={group} />
         ))}
       </div>
     </div>

--- a/apps/kitchen-sink/src/sections/colors.tsx
+++ b/apps/kitchen-sink/src/sections/colors.tsx
@@ -1,13 +1,16 @@
 import {
+  buttonExtras,
+  buttonMatrix,
   componentGroups,
   resolveToken,
   semanticContextGroups,
   statusExtras,
   statusMatrix,
+  type ComponentTokenGroup,
   type ContextGroup,
+  type MatrixCellKind,
   type RoleGroup,
-  type StatusCellKind,
-  type TokenGroup,
+  type TokenMatrix,
 } from '@/lib/tokens';
 
 const SWATCH_BORDER = '1px solid var(--ui-border-on-surface-border)';
@@ -109,6 +112,24 @@ const cardGrid = {
   gap: 12,
 } as const;
 
+const groupCard = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+  padding: 16,
+  borderRadius: 8,
+  border: SWATCH_BORDER,
+  background: 'var(--ui-background-surface-primary)',
+} as const;
+
+const groupHeading = {
+  fontSize: 13,
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: 0.5,
+  margin: 0,
+} as const;
+
 /** A role row within a context — small role label, then its swatches. */
 function RoleRow({ group }: { group: RoleGroup }) {
   return (
@@ -117,6 +138,7 @@ function RoleRow({ group }: { group: RoleGroup }) {
         style={{
           fontSize: 11,
           fontWeight: 600,
+          textTransform: 'capitalize',
           color: 'var(--ui-text-on-surface-secondary)',
         }}
       >
@@ -139,7 +161,7 @@ function MatrixCell({
   kind,
   name,
 }: {
-  kind: StatusCellKind;
+  kind: MatrixCellKind;
   name: string | null;
 }) {
   if (!name) {
@@ -191,9 +213,17 @@ const matrixTh = {
   whiteSpace: 'nowrap',
 } as const;
 
-/** Status rendered as an intent × (role/state) matrix. Hover a cell for its
- *  full `--ui-*` name. */
-function StatusMatrix() {
+/** A row × (role/state) matrix (status intents, button variants, …). Hover a
+ *  cell for its full `--ui-*` name. `extras` lists tokens off the grid. */
+function TokenMatrixView({
+  matrix,
+  extras,
+  extrasLabel,
+}: {
+  matrix: TokenMatrix;
+  extras: RoleGroup[];
+  extrasLabel: string;
+}) {
   // Left border between column groups makes the grouping legible.
   const divider = '1px solid var(--ui-border-on-surface-divider)';
   return (
@@ -203,7 +233,7 @@ function StatusMatrix() {
           <thead>
             <tr>
               <th style={{ ...matrixTh, textAlign: 'left' }} rowSpan={2} />
-              {statusMatrix.groups.map((g) => (
+              {matrix.groups.map((g) => (
                 <th
                   key={g.label}
                   colSpan={g.columns.length}
@@ -219,7 +249,7 @@ function StatusMatrix() {
               ))}
             </tr>
             <tr>
-              {statusMatrix.groups.flatMap((g) =>
+              {matrix.groups.flatMap((g) =>
                 g.columns.map((c, ci) => (
                   <th
                     key={`${g.label}-${c}`}
@@ -236,8 +266,8 @@ function StatusMatrix() {
             </tr>
           </thead>
           <tbody>
-            {statusMatrix.intents.map((intent) => (
-              <tr key={intent}>
+            {matrix.rows.map((row) => (
+              <tr key={row}>
                 <th
                   style={{
                     ...matrixTh,
@@ -245,12 +275,12 @@ function StatusMatrix() {
                     color: 'var(--ui-text-on-surface-primary)',
                   }}
                 >
-                  {intent}
+                  {row}
                 </th>
-                {statusMatrix.groups.flatMap((g, gi) =>
-                  g.cells[intent].map((name, ci) => (
+                {matrix.groups.flatMap((g, gi) =>
+                  g.cells[row].map((name, ci) => (
                     <td
-                      key={`${g.label}-${intent}-${ci}`}
+                      key={`${g.label}-${row}-${ci}`}
                       style={{
                         padding: 6,
                         borderLeft: gi > 0 && ci === 0 ? divider : undefined,
@@ -265,7 +295,7 @@ function StatusMatrix() {
           </tbody>
         </table>
       </div>
-      {statusExtras.length > 0 && (
+      {extras.length > 0 && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
           <div
             style={{
@@ -276,9 +306,9 @@ function StatusMatrix() {
               color: 'var(--ui-text-on-surface-secondary)',
             }}
           >
-            Other status tokens
+            {extrasLabel}
           </div>
-          {statusExtras.map((role) => (
+          {extras.map((role) => (
             <RoleRow key={role.role} group={role} />
           ))}
         </div>
@@ -290,31 +320,17 @@ function StatusMatrix() {
 /** A context section (Surface, Brand, Status, …) holding its role rows. */
 function ContextSection({ group }: { group: ContextGroup }) {
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 16,
-        padding: 16,
-        borderRadius: 8,
-        border: SWATCH_BORDER,
-        background: 'var(--ui-background-surface-primary)',
-      }}
-    >
-      <h4
-        style={{
-          fontSize: 13,
-          fontWeight: 700,
-          textTransform: 'uppercase',
-          letterSpacing: 0.5,
-          margin: 0,
-        }}
-      >
+    <div style={groupCard}>
+      <h4 style={groupHeading}>
         {group.context}{' '}
         <span style={{ fontWeight: 400, opacity: 0.6 }}>({group.count})</span>
       </h4>
       {group.context === 'status' ? (
-        <StatusMatrix />
+        <TokenMatrixView
+          matrix={statusMatrix}
+          extras={statusExtras}
+          extrasLabel="Other status tokens"
+        />
       ) : (
         group.roles.map((role) => <RoleRow key={role.role} group={role} />)
       )}
@@ -322,26 +338,24 @@ function ContextSection({ group }: { group: ContextGroup }) {
   );
 }
 
-/** Per-component token group (`--ui-button-*`, …) — flat grid, grouped by name. */
-function ComponentGroup({ group }: { group: TokenGroup }) {
+/** A component token group, mirroring the semantic context cards: each
+ *  component is a card of sub-group rows. `button` gets the matrix treatment. */
+function ComponentSection({ group }: { group: ComponentTokenGroup }) {
   return (
-    <div>
-      <h3
-        style={{
-          fontSize: 12,
-          textTransform: 'uppercase',
-          letterSpacing: 0.5,
-          opacity: 0.6,
-          marginBottom: 10,
-        }}
-      >
-        {group.tier} <span style={{ fontWeight: 400 }}>({group.tokens.length})</span>
-      </h3>
-      <div style={cardGrid}>
-        {group.tokens.map((token) => (
-          <TokenCard key={token.name} name={token.name} />
-        ))}
-      </div>
+    <div style={groupCard}>
+      <h4 style={groupHeading}>
+        {group.component}{' '}
+        <span style={{ fontWeight: 400, opacity: 0.6 }}>({group.count})</span>
+      </h4>
+      {group.component === 'button' ? (
+        <TokenMatrixView
+          matrix={buttonMatrix}
+          extras={buttonExtras}
+          extrasLabel="Other button tokens"
+        />
+      ) : (
+        group.subgroups.map((sub) => <RoleRow key={sub.role} group={sub} />)
+      )}
     </div>
   );
 }
@@ -352,9 +366,11 @@ export function ColorsSection() {
       <p style={{ fontSize: 13, color: 'var(--ui-text-on-surface-secondary)' }}>
         Generated <code>--ui-*</code> tokens from{' '}
         <code>@acronis-platform/tokens-pd</code>. Values reflect the active brand
-        and light/dark scheme. Semantic colors are grouped by{' '}
-        <strong>context</strong> (the surface/intent a color lives on), then by{' '}
-        <strong>role</strong> (background, text, border, glyph) within.
+        and light/dark scheme. Tokens are grouped by{' '}
+        <strong>context</strong> (the surface/intent a color lives on, or the
+        component), then by <strong>role</strong> (background, text, border,
+        glyph) within. Regular families — status by intent, button by variant —
+        are shown as a matrix.
       </p>
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
@@ -367,7 +383,7 @@ export function ColorsSection() {
       <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
         <h3 style={{ fontSize: 14, fontWeight: 600 }}>Component tokens</h3>
         {componentGroups.map((group) => (
-          <ComponentGroup key={group.tier} group={group} />
+          <ComponentSection key={group.component} group={group} />
         ))}
       </div>
     </div>

--- a/apps/kitchen-sink/src/sections/colors.tsx
+++ b/apps/kitchen-sink/src/sections/colors.tsx
@@ -2,8 +2,11 @@ import {
   componentGroups,
   resolveToken,
   semanticContextGroups,
+  statusExtras,
+  statusMatrix,
   type ContextGroup,
   type RoleGroup,
+  type StatusCellKind,
   type TokenGroup,
 } from '@/lib/tokens';
 
@@ -131,6 +134,159 @@ function RoleRow({ group }: { group: RoleGroup }) {
   );
 }
 
+/** A single matrix cell, previewed per what its column paints. */
+function MatrixCell({
+  kind,
+  name,
+}: {
+  kind: StatusCellKind;
+  name: string | null;
+}) {
+  if (!name) {
+    return (
+      <span style={{ opacity: 0.3, color: 'var(--ui-text-on-surface-secondary)' }}>
+        –
+      </span>
+    );
+  }
+  const box = {
+    width: 30,
+    height: 30,
+    borderRadius: 6,
+    border: SWATCH_BORDER,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    margin: '0 auto',
+  } as const;
+  if (kind === 'fill') {
+    return <div title={name} style={{ ...box, background: `var(${name})` }} />;
+  }
+  if (kind === 'border') {
+    return <div title={name} style={{ ...box, border: `2px solid var(${name})` }} />;
+  }
+  const fg = {
+    ...box,
+    color: `var(${name})`,
+    background: 'var(--ui-background-surface-secondary)',
+  } as const;
+  return kind === 'text' ? (
+    <div title={name} style={{ ...fg, fontSize: 12, fontWeight: 700 }}>
+      Aa
+    </div>
+  ) : (
+    <div title={name} style={{ ...fg, fontSize: 15 }}>
+      ●
+    </div>
+  );
+}
+
+const matrixTh = {
+  fontSize: 10,
+  fontWeight: 600,
+  textTransform: 'uppercase',
+  letterSpacing: 0.4,
+  color: 'var(--ui-text-on-surface-secondary)',
+  padding: '4px 8px',
+  whiteSpace: 'nowrap',
+} as const;
+
+/** Status rendered as an intent × (role/state) matrix. Hover a cell for its
+ *  full `--ui-*` name. */
+function StatusMatrix() {
+  // Left border between column groups makes the grouping legible.
+  const divider = '1px solid var(--ui-border-on-surface-divider)';
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ borderCollapse: 'collapse', fontSize: 12 }}>
+          <thead>
+            <tr>
+              <th style={{ ...matrixTh, textAlign: 'left' }} rowSpan={2} />
+              {statusMatrix.groups.map((g) => (
+                <th
+                  key={g.label}
+                  colSpan={g.columns.length}
+                  style={{
+                    ...matrixTh,
+                    textAlign: 'center',
+                    borderLeft: divider,
+                    borderBottom: divider,
+                  }}
+                >
+                  {g.label}
+                </th>
+              ))}
+            </tr>
+            <tr>
+              {statusMatrix.groups.flatMap((g) =>
+                g.columns.map((c, ci) => (
+                  <th
+                    key={`${g.label}-${c}`}
+                    style={{
+                      ...matrixTh,
+                      textAlign: 'center',
+                      borderLeft: ci === 0 ? divider : undefined,
+                    }}
+                  >
+                    {c}
+                  </th>
+                ))
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {statusMatrix.intents.map((intent) => (
+              <tr key={intent}>
+                <th
+                  style={{
+                    ...matrixTh,
+                    textAlign: 'left',
+                    color: 'var(--ui-text-on-surface-primary)',
+                  }}
+                >
+                  {intent}
+                </th>
+                {statusMatrix.groups.flatMap((g, gi) =>
+                  g.cells[intent].map((name, ci) => (
+                    <td
+                      key={`${g.label}-${intent}-${ci}`}
+                      style={{
+                        padding: 6,
+                        borderLeft: gi > 0 && ci === 0 ? divider : undefined,
+                      }}
+                    >
+                      <MatrixCell kind={g.kind} name={name} />
+                    </td>
+                  ))
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {statusExtras.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <div
+            style={{
+              fontSize: 11,
+              fontWeight: 600,
+              textTransform: 'uppercase',
+              letterSpacing: 0.4,
+              color: 'var(--ui-text-on-surface-secondary)',
+            }}
+          >
+            Other status tokens
+          </div>
+          {statusExtras.map((role) => (
+            <RoleRow key={role.role} group={role} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 /** A context section (Surface, Brand, Status, …) holding its role rows. */
 function ContextSection({ group }: { group: ContextGroup }) {
   return (
@@ -157,9 +313,11 @@ function ContextSection({ group }: { group: ContextGroup }) {
         {group.context}{' '}
         <span style={{ fontWeight: 400, opacity: 0.6 }}>({group.count})</span>
       </h4>
-      {group.roles.map((role) => (
-        <RoleRow key={role.role} group={role} />
-      ))}
+      {group.context === 'status' ? (
+        <StatusMatrix />
+      ) : (
+        group.roles.map((role) => <RoleRow key={role.role} group={role} />)
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### Type of change

- [x] Enhancement (improving an existing functionality like performance)
- [x] Refactoring (old API is revised and supported)

### Description

Reworks how the **Colors & tokens** section of the `kitchen-sink` demo groups the
generated `--ui-*` tokens, so the page is scannable instead of a few giant flat
grids. Applies one consistent model to **both** semantic and component tokens.

**Before:** tokens were grouped on a single axis (first path segment), producing
a few lopsided buckets — the worst being ~60 `background` swatches in one flat
grid. Component tokens were a flat alphabetical list per component. Sorting was
alphabetical, which scrambled state order.

**After:**

- **Context → Role grouping (semantic).** Group by **context** first (`surface`,
  `brand`, `status`, `inverted`, `overlay`, `ai`, `focus`), then by **role**
  (background / text / border / glyph). A surface's bg/text/border/glyph now sit
  together, each context in its own card with counts.
- **Same grouping for component tokens.** Each component is a card of sub-group
  rows (the segment after the component name — a variant like `primary`, a part
  like `circle`, or a dimension bucket like `global`), state-ordered. Dimension
  buckets (`global` / `units` / `nesting`) sort last.
- **State-aware ordering.** Within a row, tokens follow a real progression
  (`idle → hover → active → pressed → disabled`); named variants precede
  root-level states (so `surface-primary` comes before `surface-hover`).
- **Matrices for the regular families.** `status` (rows = intent) and `button`
  (rows = variant) follow a clean row × role/state grid, so they render as a
  matrix — columns grouped by role with per-state sub-columns, each cell a
  preview (fill / outline / `Aa` / dot) with the full token name on hover.
  Off-grid tokens are listed below as "Other … tokens". Both matrices share one
  generic builder/renderer.

Scope is entirely `apps/kitchen-sink` (a **private**, unpublished app). No
published package surface changes; the included changeset bumps only the private
package (no publish impact).

### Related issue

n/a — demo/QA-surface improvement.

### Checklist

- [x] I have performed a **self-review** of my code;
- [x] My code follows the style **guidelines** of this project;
- [x] My changes generate no new **warnings**.
