### PR TITLE
fix(button): align Code Connect with current Figma Button schema

### DIFF
--- a/packages/ui-react/src/components/ui/button/button.figma.tsx
+++ b/packages/ui-react/src/components/ui/button/button.figma.tsx
@@ -24,9 +24,18 @@ figma.connect(
       disabled: figma.enum('State', {
         Disabled: true,
       }),
+      // The Figma button has two same-named "Icon" properties — a boolean
+      // visibility toggle and an instance-swap slot — so they're referenced by
+      // their full `Name#id` to disambiguate. When the toggle is on, the
+      // swapped icon instance is rendered as the button's leading child.
+      icon: figma.boolean('Icon#1173:2', {
+        true: figma.instance('Icon#1173:0'),
+        false: undefined,
+      }),
     },
-    example: ({ variant, disabled }) => (
+    example: ({ variant, disabled, icon }) => (
       <Button variant={variant} disabled={disabled}>
+        {icon}
         Label
       </Button>
     ),

--- a/packages/ui-react/src/components/ui/button/button.figma.tsx
+++ b/packages/ui-react/src/components/ui/button/button.figma.tsx
@@ -9,29 +9,25 @@ figma.connect(
   'https://www.figma.com/design/lrU3ydIyvPYQNE6ixdsKtJ/shadcn-uikit?node-id=1173-2789',
   {
     props: {
-      variant: figma.enum('Style', {
+      // Figma's `Variant` property labels its text-only style "Link"; the code
+      // variant (and its `--ui-button-ghost-*` tokens) is named `ghost`.
+      variant: figma.enum('Variant', {
         Primary: 'default',
         Secondary: 'secondary',
-        Ghost: 'ghost',
+        Link: 'ghost',
         Destructive: 'destructive',
         Ai: 'ai',
         Inverted: 'inverted',
       }),
       // The Figma button encodes interaction state as a variant; only the
-      // Disabled state maps to a code prop (Idle/Hover/Active are visual).
+      // Disabled state maps to a code prop (Idle/Hover/Active/Focus are visual).
       disabled: figma.enum('State', {
         Disabled: true,
       }),
-      icon: figma.boolean('👀 Icon', {
-        true: figma.instance('⭐️ Icon'),
-        false: undefined,
-      }),
-      label: figma.string('✏️ Label'),
     },
-    example: ({ variant, disabled, icon, label }) => (
+    example: ({ variant, disabled }) => (
       <Button variant={variant} disabled={disabled}>
-        {icon}
-        {label}
+        Label
       </Button>
     ),
   }

--- a/packages/ui-react/src/components/ui/button/button.tsx
+++ b/packages/ui-react/src/components/ui/button/button.tsx
@@ -5,8 +5,8 @@ import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
 
-// Variants mirror the Figma "Button" component's `Style` property (Primary,
-// Secondary, Ghost, Destructive, Ai, Inverted). Each interaction state
+// Variants mirror the Figma "Button" component's `Variant` property (Primary,
+// Secondary, Link→ghost, Destructive, Ai, Inverted). Each interaction state
 // (idle / hover / active / disabled) wires background, label, and border to its
 // own dedicated `--ui-button-*` token from @acronis-platform/tokens-pd. Every
 // state is wired explicitly — even where acronis's value is unchanged — because


### PR DESCRIPTION
## Problem

The `Figma Code Connect` workflow ([failed run](https://github.com/acronis/uikit/actions/runs/27196376382/job/80288960337)) errored on **Publish Code Connect to Figma**:

```
Validation failed for Button: The property "Style" does not exist on the Figma component
Validation failed for Button: The property "👀 Icon" does not exist on the Figma component
Validation failed for Button: The property "✏️ Label" does not exist on the Figma component
```

The Figma **Button** component set was restructured and `button.figma.tsx` still mapped the old property schema. Verified the live `componentPropertyDefinitions` via the Figma Plugin API (node `1173-2789`):

| Live property | Type | Was |
| --- | --- | --- |
| `Variant` (Primary, Secondary, **Link**, Destructive, Inverted, Ai) | VARIANT | `Style` (had **Ghost** instead of Link) |
| `State` (Idle, Hover, Active, Disabled, Focus) | VARIANT | unchanged |
| `Icon#1173:2` | BOOLEAN | `👀 Icon` |
| `Icon#1173:0` | INSTANCE_SWAP | `⭐️ Icon` |
| — | — | `✏️ Label` (TEXT) — **removed** |

## Fix

- **`Style` → `Variant`**, mapping Figma's `Link` → code `ghost` (the code variant and its `--ui-button-ghost-*` tokens keep their name — only the Figma label changed; renaming the code variant would cascade through design-tokens/tokens-pd and is out of scope).
- **Icon retained.** The two icon properties now share the base name "Icon", so they're referenced by their full `Name#id` to disambiguate the boolean toggle (`Icon#1173:2`) from the instance-swap slot (`Icon#1173:0`); the swapped icon renders as the button's leading child.
- **`State` → `disabled`** mapping kept (`State` still exists).
- Dropped only the `label` mapping — the `✏️ Label` TEXT property no longer exists.
- Updated the stale `Style` reference in `button.tsx`'s comment.

## Verification

- `figma connect parse` succeeds; the generated template wires `Variant`, `State`, and both `Icon#…` props, rendering the icon as a leading child.
- `pnpm --filter @acronis-platform/ui-react typecheck` passes.
- Property names verified against the live component via Figma Plugin API `componentPropertyDefinitions`.

> Live publish validation needs `FIGMA_ACCESS_TOKEN` (not available locally), so the definitive check runs in CI on this PR.

ButtonIcon and Switch Code Connect files were unaffected. No changeset: `*.figma.tsx` files are excluded from the published build.