### PR TITLE
feat(tokens): data-driven brand discovery + brand matrix doc

### DIFF
--- a/packages/design-tokens/AGENTS.md
+++ b/packages/design-tokens/AGENTS.md
@@ -44,12 +44,13 @@ When a new file lands under `context/`, add a row here in the same change. An un
 
 ### Context — hand-authored
 
-| When the task involves…                                                                                                                                          | Load                                             |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| Grounding vocabulary (Tier, Group, Mode, Theme, Brand, Collection, token)                                                                                        | [`context/glossary.md`](context/glossary.md)     |
-| Writing/reading a `.tokens.json` — the files, token shape (`$value`/`$type`/`values`/`platforms`/`$extensions`), modes & themes, the alias chain, platform scope | [`context/manifest.md`](context/manifest.md)     |
-| DTCG conformance & divergence, the `$schema`/Figma discriminator, `$extensions` namespaces (`com.acronis.*`/`com.figma.*`), naming / `$`-prefix / `$type` rules  | [`context/spec.md`](context/spec.md)             |
-| Pulling from Figma — the mapping, the pull/post-process workflow, the generators under `.tmp/scripts/`                                                           | [`context/figma-sync.md`](context/figma-sync.md) |
+| When the task involves…                                                                                                                                          | Load                                                 |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| Grounding vocabulary (Tier, Group, Mode, Theme, Brand, Collection, token)                                                                                        | [`context/glossary.md`](context/glossary.md)         |
+| Writing/reading a `.tokens.json` — the files, token shape (`$value`/`$type`/`values`/`platforms`/`$extensions`), modes & themes, the alias chain, platform scope | [`context/manifest.md`](context/manifest.md)         |
+| DTCG conformance & divergence, the `$schema`/Figma discriminator, `$extensions` namespaces (`com.acronis.*`/`com.figma.*`), naming / `$`-prefix / `$type` rules  | [`context/spec.md`](context/spec.md)                 |
+| Pulling from Figma — the mapping, the pull/post-process workflow, the generators under `.tmp/scripts/`                                                           | [`context/figma-sync.md`](context/figma-sync.md)     |
+| The brand set — which brands exist, what each overrides, light/dark per brand, and how the data-driven brand discovery works                                     | [`context/brand-matrix.md`](context/brand-matrix.md) |
 
 ### DTCG 2025.10 spec — vendored snapshot
 

--- a/packages/design-tokens/context/brand-matrix.md
+++ b/packages/design-tokens/context/brand-matrix.md
@@ -1,0 +1,145 @@
+# Brand matrix
+
+The set of **brands** the token pipeline supports, what each overrides, and how
+light/dark is handled. This is the source of truth for issue #174 (E1). The brand
+list is **data-driven** — see [Adding a brand](#adding-a-brand).
+
+## Two independent axes
+
+A brand and a color mode are **separate axes**, and the pipeline treats them
+differently:
+
+- **Brand** (Acronis, Virtuozzo, …) — the `values` dict on each token in
+  `tiers/semantic.json` and `tiers/components.json` is **keyed by brand**. Each
+  brand becomes a generated stylesheet (`tokens-pd/css/<brand>.css`).
+- **Color mode** (light / dark) — **not** a brand. `tiers/primitives.json` is
+  keyed by `light` / `dark`, and the build zips a token's two theme resolutions
+  into one `light-dark(<light>, <dark>)` declaration. So **every brand is
+  automatically light + dark** in a single stylesheet — there is no separate
+  "dark" brand (unlike the legacy Vue themes, which shipped `dark` as its own
+  theme).
+
+> Migrating from `ui-legacy`: the legacy `@uikit/ui-kit-themes` shipped ~24
+> `[data-theme=…]` SCSS themes (`--av-*`, oklch), most of them **light-only
+> accent overrides** layered on a shared `default`, with `dark` as a separate
+> theme. Here the same brands become **brand modes** in Figma → `values.<brand>`
+> keys → generated `--ui-*` CSS, with light/dark folded into every token.
+
+## Delivery model
+
+`acronis` is the **default brand**: it emits **full** stylesheets (`acronis.css`
+
+- `css/<component>/acronis.css`). Every other brand emits **override-only**
+  files — just the tokens whose value differs from `acronis`. Consumers load the
+  acronis base, then layer a brand override and flip `color-scheme` / `[data-theme]`:
+
+```
+acronis.css            (full base, light + dark)
+  + <brand>.css        (override-only: the brand's diff vs acronis)
+```
+
+Because non-default brands are a diff, a brand that only restyles its accent
+colors produces a tiny file; brands inherit everything they don't override from
+the acronis base.
+
+## Brand override surface
+
+Which token groups a brand is expected to override (everything else is inherited
+from the acronis base — keep brands small and maintainable):
+
+| Group (semantic)                       | Tokens                                                   | Brand overrides?               |
+| -------------------------------------- | -------------------------------------------------------- | ------------------------------ |
+| Brand color                            | `--ui-background-brand-*`                                | **yes** (the point of a brand) |
+| On-brand foreground                    | `--ui-text-on-*`, `--ui-glyph-on-*`                      | usually                        |
+| Focus ring                             | `--ui-focus-*`                                           | usually                        |
+| AI gradient                            | `--ui-background-ai-*`                                   | optional                       |
+| Per-component brand tiers              | `css/<component>/<brand>.css` (button, chip, switch, …)  | as needed                      |
+| Neutral surfaces / status / text scale | `--ui-background-surface-*`, `--ui-*-status-*`, neutrals | rarely (white-label exception) |
+| Primitives (palette, scales)           | `tiers/primitives.json`                                  | **never** (brand-agnostic)     |
+| Typography, spacing, radii, units      | —                                                        | **never**                      |
+
+Today `brand-b` (the proof-of-pipeline second brand) overrides exactly the first
+three groups plus per-component tiers for 11 components — the canonical "accent
+brand" surface.
+
+## The matrix
+
+Target brand set = the **legacy Acronis brand set** carried over from
+`ui-legacy`, plus **any new brand Figma introduces** (data-driven). Each row is a
+Figma **brand mode** → a `values.<brand>` key → a generated `<brand>.css`.
+
+`brand id` is the kebab key used in `values.<brand>` and the CSS filename
+(`<brand>.css`).
+
+| Brand id                | Legacy `[data-theme]` | Partner / use     | Role                                                  | Light     | Dark                 |
+| ----------------------- | --------------------- | ----------------- | ----------------------------------------------------- | --------- | -------------------- |
+| `acronis`               | `acronis` / `default` | Acronis           | **default (full base)**                               | ✓         | ✓                    |
+| `blue-yellow`           | `blue-yellow`         | USS Signal        | accent                                                | ✓         | ?                    |
+| `brown`                 | `brown`               | —                 | accent                                                | ✓         | ?                    |
+| `dark-gray`             | `dark-gray`           | —                 | accent                                                | ✓         | ?                    |
+| `deep-purple`           | `deep-purple`         | —                 | accent                                                | ✓         | ?                    |
+| `deep-sky`              | `deep-sky`            | ITKontoret        | accent                                                | ✓         | ?                    |
+| `green`                 | `green`               | ALSO / Choise     | accent                                                | ✓         | ?                    |
+| `ingram`                | `ingram`              | Ingram Micro      | accent                                                | ✓         | ?                    |
+| `light-blue`            | `light-blue`          | HP                | accent                                                | ✓         | ?                    |
+| `light-gray`            | `light-gray`          | —                 | accent                                                | ✓         | ?                    |
+| `orange`                | `orange`              | Tsukaeru / Helpox | accent                                                | ✓         | ?                    |
+| `pinky`                 | `pinky`               | —                 | accent                                                | ✓         | ?                    |
+| `purple`                | `purple`              | —                 | accent                                                | ✓         | ?                    |
+| `purple-fusion`         | `purple-fusion`       | Media             | accent                                                | ✓         | ?                    |
+| `red`                   | `red`                 | Home.pl           | accent                                                | ✓         | ?                    |
+| `red-brick`             | `red-brick`           | Fire Brick        | accent                                                | ✓         | ?                    |
+| `sand`                  | `sand`                | —                 | accent                                                | ✓         | ?                    |
+| `telstra`               | `telstra`             | Telstra           | accent                                                | ✓         | ?                    |
+| `virtual-one`           | `virtual-one`         | Virtual One       | accent                                                | ✓         | ?                    |
+| `virtuozzo`             | `virtuozzo`           | Virtuozzo         | accent / full                                         | ✓         | ✓ (legacy `__new__`) |
+| `web`                   | `web`                 | Website           | accent                                                | ✓         | ?                    |
+| `yellow`                | `yellow`              | 1C                | accent                                                | ✓         | ?                    |
+| —                       | `dark`                | —                 | **color mode, not a brand** (every brand's dark half) | —         | —                    |
+| `brand-b`               | —                     | pipeline proof    | accent (placeholder)                                  | ✓         | ✓                    |
+| _(any new Figma brand)_ | —                     | —                 | data-driven                                           | per Figma | per Figma            |
+
+That is the **24 legacy themes** (the `ui-legacy` set): 22 brand rows + the
+`acronis`/`default` base + the `dark` **mode** (folded into every brand, not its
+own brand). `brand-b` is an extra placeholder proving the override pipeline.
+
+### Light / dark per brand
+
+Every brand is light **and** dark via `light-dark()` — **provided its Figma mode
+defines dark values**. In `ui-legacy`, only `default`/`acronis` (and the
+half-migrated `virtuozzo` under `__new__/`) had a real dark variant; the accent
+partner themes were light-only. So the **`Dark` column is `?` pending Figma**:
+each brand mode must supply dark values, or it inherits the acronis dark base for
+anything it doesn't override (acceptable, but confirm per brand).
+
+## Adding a brand
+
+Fully **data-driven** — no code change in `tools/style-dictionary`:
+
+1. Add the brand as a **mode** in the Figma variable collection and define its
+   token values (at minimum the [override surface](#brand-override-surface)).
+2. Sync into `@acronis-platform/design-tokens` — the synced `tiers/*.json` gain a
+   `values.<brand>` key on the tokens the brand sets.
+3. Rebuild `tokens-pd`. `tools/style-dictionary` discovers the brand from the
+   union of `values` keys (`discoverBrands()` in `tokens.ts`) and emits
+   `css/<brand>.css` (+ per-component overrides) and the Tailwind preset.
+
+A brand mode in Figma is **exhaustive** (every variable has a value per mode), so
+each brand resolves as a complete view; the build emits only its diff vs acronis.
+
+## Current state vs target
+
+- **Shipped now:** `acronis` (full) + `brand-b` (override-only placeholder).
+- **Target:** the legacy set above, sourced from Figma brand modes.
+- **Gap (data, not code):** the 21 legacy accent brands' token values are **not
+  yet in Figma / design-tokens**. The pipeline is ready; populating them is a
+  Figma-authoring + sync task (do not hand-author token values here — see the
+  package `AGENTS.md`).
+
+## Open confirmations (#174)
+
+- Final brand set + exact Figma mode names (the roadmap also names a forward set
+  `acronis-default` / `acronis-ocean` / `cyber-chat` / `acronis-white-label` —
+  reconcile that with the legacy 22 above).
+- Which brands ship a **dark** variant (vs inheriting acronis dark).
+- Is `brand-b` kept as a fixture or removed once real brands land?

--- a/tools/style-dictionary/src/__tests__/discover-brands.test.ts
+++ b/tools/style-dictionary/src/__tests__/discover-brands.test.ts
@@ -1,0 +1,33 @@
+// Pins the data-driven brand matrix: `discoverBrands()` derives the brand set
+// from the union of `values` keys in the brand-bearing token tiers (semantic +
+// components), with the default brand first and the rest alphabetical. Adding a
+// brand mode upstream must surface here with no code change — see
+// `packages/design-tokens/context/brand-matrix.md`.
+
+import { describe, expect, it } from 'vitest';
+
+import { BRAND_NAMES, BRANDS, DEFAULT_BRAND, discoverBrands } from '../tokens';
+
+describe('discoverBrands', () => {
+  it('lists the default brand first', () => {
+    expect(discoverBrands()[0]).toBe(DEFAULT_BRAND);
+  });
+
+  it('returns a deduplicated set with the non-default brands sorted', () => {
+    const brands = discoverBrands();
+    const rest = brands.slice(1);
+    expect(new Set(brands).size).toBe(brands.length);
+    expect(rest).toContain('brand-b');
+    expect([...rest].sort()).toEqual(rest);
+    expect(rest).not.toContain(DEFAULT_BRAND);
+  });
+
+  it('drives the exported BRAND_NAMES and BRANDS view list', () => {
+    expect([...BRAND_NAMES]).toEqual(discoverBrands());
+    expect(BRANDS.map((b) => b.name)).toEqual([...BRAND_NAMES]);
+    for (const brand of BRANDS) {
+      expect(brand.semantic).toBe(`semantic-${brand.name}`);
+      expect(brand.components).toBe(`components-${brand.name}`);
+    }
+  });
+});

--- a/tools/style-dictionary/src/tokens.ts
+++ b/tools/style-dictionary/src/tokens.ts
@@ -75,18 +75,62 @@ interface DtcgView {
   mode: string;
 }
 
+/**
+ * Tiers whose tokens carry the Brand axis — their `values` dicts are keyed by
+ * brand. (The primitives tier is keyed by theme: light/dark, not by brand.)
+ */
+const BRAND_TIERS: TokenSourceName[] = ['semantic', 'components'];
+
+/** Collect the key set of every `values` dict in a token tree. */
+function collectValueKeys(node: unknown, into: Set<string>): void {
+  if (!node || typeof node !== 'object') return;
+  const obj = node as Record<string, unknown>;
+  const values = obj['values'];
+  if (values && typeof values === 'object' && !Array.isArray(values)) {
+    for (const key of Object.keys(values)) into.add(key);
+    return; // token leaf — do not descend into the resolved values
+  }
+  for (const [k, v] of Object.entries(obj)) {
+    if (k.startsWith('$')) continue;
+    collectValueKeys(v, into);
+  }
+}
+
+/**
+ * Discover the brand set from the token data — the union of `values` keys across
+ * the brand-bearing tiers (semantic + components). `DEFAULT_BRAND` is emitted in
+ * full and listed first; the rest are alphabetical. This is the data-driven
+ * brand matrix: adding a brand mode in `@acronis-platform/design-tokens` adds a
+ * brand here (and a generated `<brand>.css`) with **no code change**. See
+ * `packages/design-tokens/context/brand-matrix.md`.
+ */
+export function discoverBrands(): string[] {
+  const keys = new Set<string>();
+  for (const tier of BRAND_TIERS) collectValueKeys(readTokenSource(tier), keys);
+  if (!keys.has(DEFAULT_BRAND)) {
+    throw new Error(
+      `Default brand "${DEFAULT_BRAND}" has no token values in ${BRAND_TIERS.join(' / ')}`
+    );
+  }
+  return [DEFAULT_BRAND, ...[...keys].filter((b) => b !== DEFAULT_BRAND).sort()];
+}
+
+/** The discovered brand set (data-driven). */
+export const BRAND_NAMES: readonly string[] = discoverBrands();
+
 const VIEWS: DtcgView[] = [
   { out: 'primitives-light', source: 'primitives', mode: 'light' },
   { out: 'primitives-dark', source: 'primitives', mode: 'dark' },
-  { out: 'semantic-acronis', source: 'semantic', mode: 'acronis' },
-  { out: 'semantic-brand-b', source: 'semantic', mode: 'brand-b' },
-  { out: 'components-acronis', source: 'components', mode: 'acronis' },
-  { out: 'components-brand-b', source: 'components', mode: 'brand-b' },
+  ...BRAND_NAMES.flatMap((brand): DtcgView[] => [
+    { out: `semantic-${brand}`, source: 'semantic', mode: brand },
+    { out: `components-${brand}`, source: 'components', mode: brand },
+  ]),
 ];
 
 /**
  * Stage-2 brands. Each brand resolves its semantic + component view against both
- * theme views of the primitives, zipping colors into `light-dark()`.
+ * theme views of the primitives, zipping colors into `light-dark()`. Derived
+ * from the discovered brand set, so the list is data-driven.
  */
 export interface Brand {
   name: string;
@@ -94,10 +138,11 @@ export interface Brand {
   components: string;
 }
 
-export const BRANDS: Brand[] = [
-  { name: 'acronis', semantic: 'semantic-acronis', components: 'components-acronis' },
-  { name: 'brand-b', semantic: 'semantic-brand-b', components: 'components-brand-b' },
-];
+export const BRANDS: Brand[] = BRAND_NAMES.map((name) => ({
+  name,
+  semantic: `semantic-${name}`,
+  components: `components-${name}`,
+}));
 
 export type Theme = 'light' | 'dark';
 


### PR DESCRIPTION
## What

Two parts, addressing #174 (E1 — brand matrix):

### 1. Data-driven brand discovery (`tools/style-dictionary`)
Replaces the hardcoded `VIEWS` / `BRANDS` (acronis + brand-b) in `src/tokens.ts` with `discoverBrands()`, which derives the brand set from the **union of `values` keys** across the brand-bearing token tiers (`semantic` + `components`). The default brand (`acronis`) is listed first and emitted in full; the rest are alphabetical, override-only.

**A new Figma brand mode → a `values.<brand>` key → a generated `<brand>.css`, with no code change.**

### 2. Brand matrix doc (`packages/design-tokens`)
`context/brand-matrix.md` documents:
- the **brand axis vs. the light/dark mode axis** (dark is folded into every brand via `light-dark()`, not a separate brand — unlike legacy Vue);
- the target brand set: the **legacy 24-theme** Acronis set as Figma brand modes, with partner mapping;
- each brand's **override surface** (what a brand is expected to override vs. inherit);
- the **add-a-brand contract**;
- current state vs. target and open confirmations.

Indexed in `design-tokens/AGENTS.md`'s context table.

## Verification
- `style-dictionary` typecheck clean; **73 tests pass** (+3 new `discover-brands.test.ts` pinning the discovery contract).
- `tokens-pd` rebuild produces **byte-identical output** (0 changed files) — the refactor is a pure no-op for the current acronis + brand-b data.

## Not in this PR (data, not code)
The 21 legacy accent brands' actual token values are **not** fabricated here — they must come from Figma brand modes + a design-tokens sync (per the package `AGENTS.md` rule against hand-authoring snapshots). The pipeline is now ready to emit them once they land.

Refs #174