### PR TITLE
test(style-dictionary): harden normalization/light-dark/gradient/brand coverage (#177)

### DIFF
--- a/tools/style-dictionary/src/__tests__/brand-scoping.test.ts
+++ b/tools/style-dictionary/src/__tests__/brand-scoping.test.ts
@@ -1,0 +1,91 @@
+// Pins the two pure pieces of the brand model: data-driven discovery
+// (`collectValueKeys` surfaces any `values.<brand>` key, so a new Figma brand
+// needs no code change) and override-only emission (`diffDecls` keeps only what a
+// brand changes vs. the default base). Together these guard the contract that
+// adding a brand = adding data, and that non-default brands ship diffs, not full
+// copies (#177). No Style Dictionary or disk I/O — synthetic fixtures only.
+
+import { describe, expect, it } from 'vitest';
+
+import type { Decls } from '../hooks/formats/css-light-dark';
+import { collectValueKeys, diffDecls } from '../tokens';
+
+describe('collectValueKeys (data-driven brand discovery)', () => {
+  it('collects the union of `values` keys across a token tree', () => {
+    const tree = {
+      background: {
+        brand: {
+          $type: 'color',
+          values: { acronis: { ref: 'a' }, 'brand-b': { ref: 'b' } },
+        },
+      },
+      text: {
+        primary: { $type: 'color', values: { acronis: { ref: 'c' } } },
+      },
+    };
+    const keys = new Set<string>();
+    collectValueKeys(tree, keys);
+    expect([...keys].sort()).toEqual(['acronis', 'brand-b']);
+  });
+
+  it('surfaces a newly added brand mode with no code change', () => {
+    const tree = {
+      background: {
+        brand: {
+          $type: 'color',
+          values: { acronis: 1, 'brand-b': 2, telstra: 3 },
+        },
+      },
+    };
+    const keys = new Set<string>();
+    collectValueKeys(tree, keys);
+    expect(keys.has('telstra')).toBe(true);
+  });
+
+  it('does not descend into the resolved values, and ignores $-prefixed metadata', () => {
+    const tree = {
+      token: {
+        $type: 'color',
+        $extensions: { 'com.figma.variableId': 'X' },
+        // a brand value object whose own keys must NOT be mistaken for brands
+        values: { acronis: { colorSpace: 'hsl', components: [0, 0, 0] } },
+      },
+    };
+    const keys = new Set<string>();
+    collectValueKeys(tree, keys);
+    expect([...keys]).toEqual(['acronis']);
+  });
+});
+
+describe('diffDecls (override-only emission)', () => {
+  const decls = (vars: Record<string, string>, classes: Record<string, string> = {}): Decls => ({
+    vars: new Map(Object.entries(vars)),
+    classes: new Map(Object.entries(classes)),
+    skipped: [],
+  });
+
+  it('emits nothing when the brand equals the base', () => {
+    const base = decls({ '--ui-a': '1', '--ui-b': '2' });
+    const out = diffDecls(base, decls({ '--ui-a': '1', '--ui-b': '2' }));
+    expect(out.vars.size).toBe(0);
+    expect(out.classes.size).toBe(0);
+  });
+
+  it('keeps only the vars whose value differs from the base', () => {
+    const base = decls({ '--ui-a': '1', '--ui-b': '2' });
+    const out = diffDecls(base, decls({ '--ui-a': '1', '--ui-b': '9' }));
+    expect([...out.vars]).toEqual([['--ui-b', '9']]);
+  });
+
+  it('keeps a var the brand introduces that the base lacks', () => {
+    const base = decls({ '--ui-a': '1' });
+    const out = diffDecls(base, decls({ '--ui-a': '1', '--ui-c': '3' }));
+    expect([...out.vars]).toEqual([['--ui-c', '3']]);
+  });
+
+  it('diffs typography class blocks the same way', () => {
+    const base = decls({}, { '.ui-typography-body': 'font-size: 14px;' });
+    const out = diffDecls(base, decls({}, { '.ui-typography-body': 'font-size: 16px;' }));
+    expect([...out.classes]).toEqual([['.ui-typography-body', 'font-size: 16px;']]);
+  });
+});

--- a/tools/style-dictionary/src/hooks/transforms/__tests__/transforms.test.ts
+++ b/tools/style-dictionary/src/hooks/transforms/__tests__/transforms.test.ts
@@ -1,0 +1,144 @@
+// Unit tests for the pure value/name transforms the CSS build applies, plus the
+// semantic-only emit filter. These run without Style Dictionary or disk I/O —
+// they pin the HSL→rgb math, the Figma-matrix→angle gradient math, the `ui`
+// naming convention, dimension formatting, and which tiers get emitted, so the
+// generated tokens-pd output can't drift silently as brands/data grow (#177).
+
+import type { TransformedToken } from 'style-dictionary/types';
+import { describe, expect, it } from 'vitest';
+
+import { type DtcgColor, hslColorToRgb, colorHslToRgb } from '../color-hsl-rgb';
+import { gradientCss } from '../gradient-css';
+import { uiName } from '../name-ui';
+import { formatDimension } from '../dimension-px';
+import { isEmittableToken } from '../../filters/semantic-only';
+
+const hsl = (h: number, s: number, l: number, alpha?: number): DtcgColor => ({
+  colorSpace: 'hsl',
+  components: [h, s, l],
+  ...(alpha === undefined ? {} : { alpha }),
+});
+
+describe('hslColorToRgb', () => {
+  it('converts the achromatic extremes', () => {
+    expect(hslColorToRgb(hsl(0, 0, 0))).toBe('rgb(0 0 0)');
+    expect(hslColorToRgb(hsl(0, 0, 100))).toBe('rgb(255 255 255)');
+    expect(hslColorToRgb(hsl(0, 0, 50))).toBe('rgb(128 128 128)');
+  });
+
+  it('converts saturated primaries at each hue third', () => {
+    expect(hslColorToRgb(hsl(0, 100, 50))).toBe('rgb(255 0 0)');
+    expect(hslColorToRgb(hsl(120, 100, 50))).toBe('rgb(0 255 0)');
+    expect(hslColorToRgb(hsl(240, 100, 50))).toBe('rgb(0 0 255)');
+  });
+
+  it('renders the modern rgb() space-separated form with no commas', () => {
+    expect(hslColorToRgb(hsl(210, 100, 30))).toMatch(/^rgb\(\d+ \d+ \d+\)$/);
+  });
+
+  it('appends the alpha channel only when it is below 1', () => {
+    expect(hslColorToRgb(hsl(0, 0, 0, 0.4))).toBe('rgb(0 0 0 / 0.4)');
+    expect(hslColorToRgb(hsl(0, 0, 0, 1))).toBe('rgb(0 0 0)');
+    expect(hslColorToRgb(hsl(0, 0, 0, 0))).toBe('rgb(0 0 0 / 0)');
+  });
+
+  it('clamps channels into the 0–255 byte range', () => {
+    // every channel stays a valid byte regardless of input
+    const out = hslColorToRgb(hsl(59, 100, 50));
+    const channels = out.match(/\d+/g)!.map(Number);
+    for (const c of channels) expect(c).toBeGreaterThanOrEqual(0);
+    for (const c of channels) expect(c).toBeLessThanOrEqual(255);
+  });
+
+  it('throws on a non-hsl colorSpace instead of emitting garbage', () => {
+    expect(() => hslColorToRgb({ colorSpace: 'srgb', components: [1, 0, 0] } as unknown as DtcgColor)).toThrow(
+      /colorSpace/
+    );
+  });
+
+  it('the transform filters to color tokens', () => {
+    expect(colorHslToRgb.filter?.({ $type: 'color' } as TransformedToken, {} as never)).toBe(true);
+    expect(colorHslToRgb.filter?.({ $type: 'dimension' } as TransformedToken, {} as never)).toBe(false);
+  });
+});
+
+describe('gradientCss', () => {
+  const stop = (color: DtcgColor, position: number) => ({ color, position });
+  const run = (value: unknown, ext?: Record<string, unknown>) =>
+    (gradientCss.transform as (t: TransformedToken) => string)({
+      $type: 'gradient',
+      $value: value,
+      $extensions: ext,
+    } as unknown as TransformedToken);
+
+  it('renders stops as `rgb pos%` joined, using the same color conversion', () => {
+    const out = run([stop(hsl(0, 100, 50), 0), stop(hsl(240, 100, 50), 1)], {
+      'com.figma.gradientTransform': [
+        [1, 0, 0],
+        [0, 1, 0],
+      ],
+    });
+    expect(out).toBe('linear-gradient(90deg, rgb(255 0 0) 0%, rgb(0 0 255) 100%)');
+  });
+
+  it('maps the identity Figma transform matrix to 90deg (to right)', () => {
+    const out = run([stop(hsl(0, 0, 0), 0), stop(hsl(0, 0, 100), 1)], {
+      'com.figma.gradientTransform': [
+        [1, 0, 0],
+        [0, 1, 0],
+      ],
+    });
+    expect(out).toContain('linear-gradient(90deg,');
+  });
+
+  it('defaults to 180deg (to bottom) when no transform matrix is present', () => {
+    expect(run([stop(hsl(0, 0, 0), 0)])).toContain('linear-gradient(180deg,');
+  });
+
+  it('rounds fractional stop positions', () => {
+    expect(run([stop(hsl(0, 0, 0), 0.2), stop(hsl(0, 0, 100), 1)])).toContain('rgb(0 0 0) 20%');
+  });
+
+  it('filters to gradient tokens', () => {
+    expect(gradientCss.filter?.({ $type: 'gradient' } as TransformedToken, {} as never)).toBe(true);
+    expect(gradientCss.filter?.({ $type: 'color' } as TransformedToken, {} as never)).toBe(false);
+  });
+});
+
+describe('uiName', () => {
+  it('drops a leading `colors` tier segment and prefixes `ui`', () => {
+    expect(uiName(['colors', 'background', 'surface', 'primary'])).toBe('ui-background-surface-primary');
+  });
+
+  it('keeps a non-colors tier root (component tokens)', () => {
+    expect(uiName(['button', 'primary', 'background', 'idle'])).toBe('ui-button-primary-background-idle');
+  });
+
+  it('strips underscores so `_global` becomes `global`', () => {
+    expect(uiName(['button', '_global', 'radius'])).toBe('ui-button-global-radius');
+  });
+
+  it('kebab-cases camelCase segments', () => {
+    expect(uiName(['colors', 'backgroundColor'])).toBe('ui-background-color');
+  });
+});
+
+describe('formatDimension', () => {
+  it('joins value and unit', () => {
+    expect(formatDimension({ value: 4, unit: 'px' })).toBe('4px');
+    expect(formatDimension({ value: 0.25, unit: 'rem' })).toBe('0.25rem');
+  });
+});
+
+describe('isEmittableToken (semantic-only filter)', () => {
+  it('drops primitive resolution roots', () => {
+    expect(isEmittableToken({ path: ['palette', 'blue', '7'] })).toBe(false);
+    expect(isEmittableToken({ path: ['units', 'gap', 'sm'] })).toBe(false);
+    expect(isEmittableToken({ path: ['font', 'family', 'sans'] })).toBe(false);
+  });
+
+  it('keeps emitted tiers (semantic + component)', () => {
+    expect(isEmittableToken({ path: ['colors', 'background', 'brand', 'primary'] })).toBe(true);
+    expect(isEmittableToken({ path: ['button', 'primary', 'background', 'idle'] })).toBe(true);
+  });
+});

--- a/tools/style-dictionary/src/tokens.ts
+++ b/tools/style-dictionary/src/tokens.ts
@@ -82,7 +82,7 @@ interface DtcgView {
 const BRAND_TIERS: TokenSourceName[] = ['semantic', 'components'];
 
 /** Collect the key set of every `values` dict in a token tree. */
-function collectValueKeys(node: unknown, into: Set<string>): void {
+export function collectValueKeys(node: unknown, into: Set<string>): void {
   if (!node || typeof node !== 'object') return;
   const obj = node as Record<string, unknown>;
   const values = obj['values'];
@@ -238,7 +238,7 @@ const sliceFile = (slice: string, brand: string): string =>
 const emptyDecls = (): Decls => ({ vars: new Map(), classes: new Map(), skipped: [] });
 
 /** Override-only maps: entries that differ from (or are absent in) the base. */
-function diffDecls(base: Decls, brand: Decls): Pick<Decls, 'vars' | 'classes'> {
+export function diffDecls(base: Decls, brand: Decls): Pick<Decls, 'vars' | 'classes'> {
   const vars = new Map<string, string>();
   for (const [name, value] of brand.vars) {
     if (base.vars.get(name) !== value) vars.set(name, value);


### PR DESCRIPTION
Closes #177.

Adds unit coverage for the pieces of the build pipeline that were previously only exercised by a full `tokens-pd` build, so brand/data growth can't silently regress the generated output.

## New tests (+26: 73 → 99)

**`hooks/transforms/__tests__/transforms.test.ts`** — the pure value/name transforms:
- `hslColorToRgb` — achromatic extremes, saturated primaries at each hue third, modern comma-less `rgb()` form, alpha appended only when `< 1`, byte clamping, and the `colorSpace` guard.
- `gradientCss` — stop rendering (`rgb pos%`), the Figma matrix→angle math (identity → 90deg, no-matrix default → 180deg), position rounding, and the `$type` filter.
- `uiName`, `formatDimension`, `isEmittableToken` (the semantic-only emit filter — primitive roots dropped, semantic/component kept).

**`__tests__/brand-scoping.test.ts`** — the two brand guarantees, via two functions now exported from `tokens.ts`:
- `collectValueKeys` (data-driven discovery): the union of `values.<brand>` keys is collected; **a newly added brand mode surfaces with no code change**; it doesn't descend into resolved values or `$`-metadata.
- `diffDecls` (override-only emission): equal-to-base emits nothing; only changed/new vars are kept; typography class blocks diff the same way.

## Verification
- `style-dictionary` test ✅ 99 pass · typecheck ✅ · lint ✅
- `tokens-pd` rebuild is **byte-identical** (0 changed files) — exporting the two helpers changed no generation behavior.

## Notes
- `style-dictionary` is private — no changeset.
- The **drift guard** ("rebuild byte-stable for unchanged input") is enforced by the CI drift gate on the committed `tokens-pd` output rather than a slow in-process build test; confirmed manually here (0 drift).