### PR TITLE
feat(figma-token-exporter): self-hosted Figma plugin + receiver for token pulls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,23 +33,24 @@ distinct role:
 
 ## Workspaces
 
-| Path                         | Package                                 | Published? | Stack                                                                       | Workspace docs                                   |
-| ---------------------------- | --------------------------------------- | ---------- | --------------------------------------------------------------------------- | ------------------------------------------------ |
-| `packages/ui-legacy/`        | `@acronis-platform/shadcn-uikit`        | **yes**    | Vite library, Storybook 10, Vitest + RTL                                    | [AGENTS.md](packages/ui-legacy/AGENTS.md)        |
-| `packages/ui-react/`         | `@acronis-platform/ui-react`            | **yes**    | Base UI library, Vite, Storybook 10, Vitest + RTL, Tailwind v4              | [AGENTS.md](packages/ui-react/AGENTS.md)         |
-| `packages/icons-react/`      | `@acronis-platform/icons-react`         | **yes**    | React icons generated from `design-assets`, Vite, Storybook, Vitest         | [AGENTS.md](packages/icons-react/AGENTS.md)      |
-| `packages/icons-svg/`        | `@acronis-platform/icons-svg`           | no         | Raw SVG icon sources (mono/multicolor) fetched from Figma + manifests       | [AGENTS.md](packages/icons-svg/AGENTS.md)        |
-| `packages/icons-svg-next/`   | `@acronis-platform/icons-svg-next`      | no         | Raw SVG sources for the **next-gen** icon set (Figma `new-frames` strategy) | [AGENTS.md](packages/icons-svg-next/AGENTS.md)   |
-| `packages/icons-sprite/`     | `@acronis-platform/icons-sprite`        | **yes**    | Generated (committed) SVG sprites built from `icons-svg` (tsx + SVGO)       | [AGENTS.md](packages/icons-sprite/AGENTS.md)     |
-| `apps/demo/`                 | `@acronis-platform/shadcn-uikit-demo`   | no         | Vite SPA, React Router v7, Zustand                                          | [AGENTS.md](apps/demo/AGENTS.md)                 |
-| `apps/docs/`                 | `@acronis-platform/shadcn-uikit-docs`   | no         | Next.js 15 + Fumadocs                                                       | [AGENTS.md](apps/docs/AGENTS.md)                 |
-| `apps/demos/`                | `@acronis-platform/shadcn-uikit-demos`  | no         | source-only (no build, no dev server)                                       | [AGENTS.md](apps/demos/AGENTS.md)                |
-| `apps/kitchen-sink/`         | `@acronis-platform/kitchen-sink`        | no         | Vite SPA — one-page showcase of tokens, elements, components, icons         | [AGENTS.md](apps/kitchen-sink/AGENTS.md)         |
-| `packages/design-tokens/`    | `@acronis-platform/design-tokens`       | **yes**    | JSON data only (DTCG-2025.10 design tokens), ajv-validated                  | [AGENTS.md](packages/design-tokens/AGENTS.md)    |
-| `packages/design-assets/`    | `@acronis-platform/design-assets`       | **yes**    | JSON data only (icon/illustration manifests + binaries), ajv-validated      | [AGENTS.md](packages/design-assets/AGENTS.md)    |
-| `packages/tokens-pd/`        | `@acronis-platform/tokens-pd`           | **yes**    | Generated (committed) CSS + Tailwind presets + DTCG, built by the tool      | [AGENTS.md](packages/tokens-pd/AGENTS.md)        |
-| `tools/style-dictionary/`    | `@acronis-platform/style-dictionary`    | no         | Style Dictionary v5 build: design-tokens → tokens-pd CSS/presets            | [AGENTS.md](tools/style-dictionary/AGENTS.md)    |
-| `tools/figma-icons-fetcher/` | `@acronis-platform/figma-icons-fetcher` | no         | Fetches + SVGO-optimizes icons from Figma into `icons-svg` (tsx, Vitest)    | [AGENTS.md](tools/figma-icons-fetcher/AGENTS.md) |
+| Path                          | Package                                  | Published? | Stack                                                                                                            | Workspace docs                                    |
+| ----------------------------- | ---------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `packages/ui-legacy/`         | `@acronis-platform/shadcn-uikit`         | **yes**    | Vite library, Storybook 10, Vitest + RTL                                                                         | [AGENTS.md](packages/ui-legacy/AGENTS.md)         |
+| `packages/ui-react/`          | `@acronis-platform/ui-react`             | **yes**    | Base UI library, Vite, Storybook 10, Vitest + RTL, Tailwind v4                                                   | [AGENTS.md](packages/ui-react/AGENTS.md)          |
+| `packages/icons-react/`       | `@acronis-platform/icons-react`          | **yes**    | React icons generated from `design-assets`, Vite, Storybook, Vitest                                              | [AGENTS.md](packages/icons-react/AGENTS.md)       |
+| `packages/icons-svg/`         | `@acronis-platform/icons-svg`            | no         | Raw SVG icon sources (mono/multicolor) fetched from Figma + manifests                                            | [AGENTS.md](packages/icons-svg/AGENTS.md)         |
+| `packages/icons-svg-next/`    | `@acronis-platform/icons-svg-next`       | no         | Raw SVG sources for the **next-gen** icon set (Figma `new-frames` strategy)                                      | [AGENTS.md](packages/icons-svg-next/AGENTS.md)    |
+| `packages/icons-sprite/`      | `@acronis-platform/icons-sprite`         | **yes**    | Generated (committed) SVG sprites built from `icons-svg` (tsx + SVGO)                                            | [AGENTS.md](packages/icons-sprite/AGENTS.md)      |
+| `apps/demo/`                  | `@acronis-platform/shadcn-uikit-demo`    | no         | Vite SPA, React Router v7, Zustand                                                                               | [AGENTS.md](apps/demo/AGENTS.md)                  |
+| `apps/docs/`                  | `@acronis-platform/shadcn-uikit-docs`    | no         | Next.js 15 + Fumadocs                                                                                            | [AGENTS.md](apps/docs/AGENTS.md)                  |
+| `apps/demos/`                 | `@acronis-platform/shadcn-uikit-demos`   | no         | source-only (no build, no dev server)                                                                            | [AGENTS.md](apps/demos/AGENTS.md)                 |
+| `apps/kitchen-sink/`          | `@acronis-platform/kitchen-sink`         | no         | Vite SPA — one-page showcase of tokens, elements, components, icons                                              | [AGENTS.md](apps/kitchen-sink/AGENTS.md)          |
+| `packages/design-tokens/`     | `@acronis-platform/design-tokens`        | **yes**    | JSON data only (DTCG-2025.10 design tokens), ajv-validated                                                       | [AGENTS.md](packages/design-tokens/AGENTS.md)     |
+| `packages/design-assets/`     | `@acronis-platform/design-assets`        | **yes**    | JSON data only (icon/illustration manifests + binaries), ajv-validated                                           | [AGENTS.md](packages/design-assets/AGENTS.md)     |
+| `packages/tokens-pd/`         | `@acronis-platform/tokens-pd`            | **yes**    | Generated (committed) CSS + Tailwind presets + DTCG, built by the tool                                           | [AGENTS.md](packages/tokens-pd/AGENTS.md)         |
+| `tools/style-dictionary/`     | `@acronis-platform/style-dictionary`     | no         | Style Dictionary v5 build: design-tokens → tokens-pd CSS/presets                                                 | [AGENTS.md](tools/style-dictionary/AGENTS.md)     |
+| `tools/figma-icons-fetcher/`  | `@acronis-platform/figma-icons-fetcher`  | no         | Fetches + SVGO-optimizes icons from Figma into `icons-svg` (tsx, Vitest)                                         | [AGENTS.md](tools/figma-icons-fetcher/AGENTS.md)  |
+| `tools/figma-token-exporter/` | `@acronis-platform/figma-token-exporter` | no         | Self-hosted Figma plugin + local receiver: exports variables/styles → the `design-tokens` snapshot (tsx, Vitest) | [AGENTS.md](tools/figma-token-exporter/AGENTS.md) |
 
 `packages/` holds the published workspaces:
 
@@ -94,6 +95,14 @@ distinct role:
   selection is pluggable (`frames-by-name` / `new-frames`). Run via `tsx` (no
   build step); drives the `Fetch Figma Icons` workflows and each package's
   `pull-icons` script.
+- `tools/figma-token-exporter/` — a **self-hosted Figma plugin + local
+  receiver** that exports design-token variables/styles into
+  `packages/design-tokens/.tmp/figma-tokens/` (the snapshot the sync emitters
+  consume). It replaces the third-party figma-console Desktop Bridge for the
+  bulk token pull; its `src/convert.ts` faithfully ports figma-console's
+  variable→DTCG serialization so the snapshot stays a drop-in. Run the receiver
+  via `tsx`; the plugin is imported into Figma Desktop from its `manifest.json`.
+  Used by the `/sync-tokens` flow.
 
 ## Scripts vocabulary
 

--- a/packages/design-tokens/context/figma-sync.md
+++ b/packages/design-tokens/context/figma-sync.md
@@ -87,7 +87,19 @@ The translation logic for palette names lives in `../.tmp/scripts/lib/palette-ma
 
 ## Pull workflow
 
-Use the Figma Console MCP tools, then run the post-process gate:
+> **Preferred backend: `tools/figma-token-exporter`.** The repo now ships its
+> own Figma plugin + local receiver that writes the same snapshot files this
+> doc describes — replacing the third-party figma-console Desktop Bridge for the
+> bulk pull. Its `src/convert.ts` is a faithful port of figma-console's
+> variable→DTCG serialization, so the output is a drop-in for the emitters
+> below. To use it: run `pnpm --filter @acronis-platform/figma-token-exporter
+receive`, then run the **Acronis Token Exporter** plugin in Figma Desktop and
+> click _Send snapshot to repo_. It also folds resolved orphan IDs into
+> `variables-meta.json`, so the post-process gate (step 4) passes on the first
+> run. See [`tools/figma-token-exporter/README.md`](../../../tools/figma-token-exporter/README.md).
+> The figma-console MCP steps below remain valid as a fallback.
+
+Using the Figma Console MCP tools directly (fallback), then run the post-process gate:
 
 1. **DTCG variables export** — `figma_export_tokens` with `format: dtcg`, `scope: file`, `modes: all`, and `outputPath: '.tmp/figma-tokens/'` (must be a **directory** — the tool ignores explicit filenames and always writes `<format>.tokens.json` inside it; the post-process step renames it).
 2. **Variable meta sidecar** — `figma_execute` running `figma.variables.getLocalVariablesAsync()` and returning `{ [id]: { name, scopes, hidden } }`. Save as `.tmp/figma-tokens/variables-meta.json`.

--- a/packages/design-tokens/context/figma-sync.md
+++ b/packages/design-tokens/context/figma-sync.md
@@ -92,9 +92,10 @@ The translation logic for palette names lives in `../.tmp/scripts/lib/palette-ma
 > doc describes — replacing the third-party figma-console Desktop Bridge for the
 > bulk pull. Its `src/convert.ts` is a faithful port of figma-console's
 > variable→DTCG serialization, so the output is a drop-in for the emitters
-> below. To use it: run `pnpm --filter @acronis-platform/figma-token-exporter
-receive`, then run the **Acronis Token Exporter** plugin in Figma Desktop and
-> click _Send snapshot to repo_. It also folds resolved orphan IDs into
+> below. To use it: run the receiver
+> (`pnpm --filter @acronis-platform/figma-token-exporter receive`), then run the
+> **Acronis Token Exporter** plugin in Figma Desktop and click
+> _Send snapshot to repo_. It also folds resolved orphan IDs into
 > `variables-meta.json`, so the post-process gate (step 4) passes on the first
 > run. See [`tools/figma-token-exporter/README.md`](../../../tools/figma-token-exporter/README.md).
 > The figma-console MCP steps below remain valid as a fallback.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -891,6 +891,21 @@ importers:
         specifier: 'catalog:'
         version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(happy-dom@20.9.0)(jsdom@24.1.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
 
+  tools/figma-token-exporter:
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      tsx:
+        specifier: ^4.20.0
+        version: 4.22.3
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(happy-dom@20.9.0)(jsdom@24.1.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
+
   tools/style-dictionary:
     devDependencies:
       '@acronis-platform/design-assets':

--- a/tools/figma-token-exporter/.gitignore
+++ b/tools/figma-token-exporter/.gitignore
@@ -1,0 +1,3 @@
+# nothing generated here is committed except sources
+node_modules/
+*.local

--- a/tools/figma-token-exporter/AGENTS.md
+++ b/tools/figma-token-exporter/AGENTS.md
@@ -1,0 +1,85 @@
+# AGENTS.md — `tools/figma-token-exporter`
+
+`@acronis-platform/figma-token-exporter` — a **private** (unpublished) build
+tool: a small, self-hosted Figma plugin plus a local Node receiver that exports
+the design system's variables and styles into
+`packages/design-tokens/.tmp/figma-tokens/` — the snapshot the design-tokens
+sync emitters consume.
+
+It exists to replace the third-party **figma-console** Desktop Bridge for the
+bulk token pull (step 1 of the [`/sync-tokens`](../../packages/design-tokens/context/figma-sync.md)
+runbook). The Figma org is **not** on Enterprise, so the REST Variables API is
+unavailable and reading variables requires the Plugin API — i.e. _something must
+run inside Figma_. This makes that "something" a repo-owned plugin instead of an
+external MCP + its bridge.
+
+Repo-wide rules (TypeScript, kebab-case filenames, Conventional Commits) live in
+the repo root's [`../../context/`](../../context/) and apply on top. This file
+documents only what is specific to this workspace.
+
+## Why the output matches figma-console exactly
+
+`src/convert.ts` is a **faithful, trimmed port** of figma-console-mcp's
+serialization (MIT — `southleft/figma-console-mcp`: `figma-converter.js` +
+`formatters/dtcg.js` + `alias-resolver.js`), restricted to the single-file,
+all-modes export. The committed emitters under
+`packages/design-tokens/.tmp/scripts/` were written against figma-console's
+output, so reproducing its exact transform yields a **drop-in** snapshot:
+
+- top-level key = `slugify(collection.name)` (`Theme` → `theme`, `Brand` → `brand`);
+- token path = `variable.name.split("/")`, case-preserved;
+- each leaf carries `$value` (+ non-primary modes under `$extensions.modes`) **and**
+  `$extensions["figma-console-mcp"].{variableId,lastSyncedValue}`, where
+  `lastSyncedValue` is keyed by **mode name** with `{reference}` | `{literal}`;
+- an alias to a non-local target encodes as `{__library:VariableID:X:Y}`.
+
+**Do not "improve" the shape here** — if the contract needs to change, change the
+emitters in `packages/design-tokens/.tmp/scripts/` (and `figma-sync.md`) instead.
+`src/__specs__/convert.spec.ts` pins this contract.
+
+## How it runs
+
+Two halves, no build step:
+
+1. **The plugin** (`manifest.json`, `plugin/code.js`, `plugin/ui.html`) — plain
+   JS, imported into **Figma Desktop** via _Plugins → Development → Import plugin
+   from manifest…_ (pick `manifest.json`). On run it reads variables,
+   collections, and text/paint/effect styles, resolves any cross-library alias
+   targets (`getVariableByIdAsync`) so the meta sidecar is complete, and POSTs
+   the raw payload to the local receiver.
+2. **The receiver** (`src/receiver.ts`, run via `tsx`) — listens on
+   `http://localhost:3333`, converts the payload (`src/convert.ts`), and writes
+   the snapshot files (`src/write-snapshot.ts`) into
+   `packages/design-tokens/.tmp/figma-tokens/`.
+
+```bash
+pnpm --filter @acronis-platform/figma-token-exporter receive
+# then in Figma: run "Acronis Token Exporter" → "Send snapshot to repo"
+# override the port (must match manifest networkAccess) with:  receive -- --port 4444
+```
+
+The port (`3333`) is declared in the manifest's `networkAccess.allowedDomains`;
+if you change it, update both. See [`README.md`](./README.md) for the full
+operator walkthrough.
+
+## Files written
+
+Into `packages/design-tokens/.tmp/figma-tokens/` (gitignored — never committed):
+
+| File                    | Consumed by                                      |
+| ----------------------- | ------------------------------------------------ |
+| `variables.tokens.json` | all three `figma-to-*` emitters                  |
+| `variables-meta.json`   | all three (scopes/hidden sidecar)                |
+| `styles-text.json`      | `figma-to-semantic` (letter-spacing, typography) |
+| `styles-color.json`     | parity only — not consumed today                 |
+| `styles-effect.json`    | parity only — not consumed today                 |
+
+The orphan-coverage gate (`figma-pull-postprocess.mjs`) passes on the first run
+because the plugin folds resolved orphan IDs into `variables-meta.json`.
+
+## Testing
+
+`pnpm --filter @acronis-platform/figma-token-exporter test` runs the Vitest unit
+specs (pure converter + snapshot writer; no Figma, no network). The end-to-end
+correctness check is the sync itself: after a real export, the three emitters run
+and `git diff tiers/` shows only intended changes.

--- a/tools/figma-token-exporter/CLAUDE.md
+++ b/tools/figma-token-exporter/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/tools/figma-token-exporter/README.md
+++ b/tools/figma-token-exporter/README.md
@@ -1,0 +1,71 @@
+# @acronis-platform/figma-token-exporter
+
+A self-hosted **Figma plugin + local receiver** that exports the design
+system's variables and styles into `packages/design-tokens/.tmp/figma-tokens/`
+— the snapshot the design-tokens sync emitters consume.
+
+It replaces the third-party **figma-console** Desktop Bridge for the bulk token
+pull. Reading Figma variables needs the Plugin API (the org isn't on Figma
+Enterprise, so the REST Variables API is out), so a plugin must run inside
+Figma — this one is ours, with no external MCP server.
+
+## One-time setup
+
+1. **Import the plugin into Figma Desktop** (required — local/dev plugins don't
+   run in the browser): _Plugins → Development → Import plugin from manifest…_ →
+   select `tools/figma-token-exporter/manifest.json`. It now appears under
+   _Plugins → Development → Acronis Token Exporter_.
+
+## Each export
+
+1. **Start the receiver** from the repo:
+
+   ```bash
+   pnpm --filter @acronis-platform/figma-token-exporter receive
+   ```
+
+   It listens on `http://localhost:3333` and writes into
+   `packages/design-tokens/.tmp/figma-tokens/`. Leave it running.
+
+2. **Open the target Figma file** in Figma Desktop and run **Acronis Token
+   Exporter**. It reads variables/collections/styles and shows a summary.
+
+3. Click **“Send snapshot to repo.”** The receiver logs the files it wrote.
+   You can re-export as many times as you like; Ctrl-C to stop the receiver.
+
+4. Continue the sync from `packages/design-tokens/` (see
+   [`context/figma-sync.md`](../../packages/design-tokens/context/figma-sync.md)
+   or run `/sync-tokens`): orphan-coverage gate → re-emit `tiers/*.json` →
+   validate → review the diff → rebuild `tokens-pd`.
+
+### Changing the port
+
+The receiver port (`3333`) is also declared in `manifest.json` under
+`networkAccess.allowedDomains`. To use another port, pass it to the receiver
+**and** update the manifest (then re-import the plugin):
+
+```bash
+pnpm --filter @acronis-platform/figma-token-exporter receive -- --port 4444
+```
+
+## How it works
+
+- `plugin/code.js` (Figma main thread) — extracts variables, collections, and
+  text/paint/effect styles, resolves cross-library alias targets via
+  `getVariableByIdAsync`, and posts a raw payload to the UI iframe.
+- `plugin/ui.html` — POSTs the payload to the receiver (the iframe has `fetch`;
+  the plugin sandbox does not).
+- `src/receiver.ts` — HTTP listener; on POST, converts and writes the snapshot.
+- `src/convert.ts` — a faithful port of figma-console's variable→DTCG
+  serialization, so the output is a drop-in for the existing emitters.
+- `src/write-snapshot.ts` — writes the five snapshot files + the
+  `variables-meta.json` sidecar.
+
+## Troubleshooting
+
+- **Plugin says “Could not reach the receiver.”** Start the receiver first; make
+  sure its port matches `manifest.json`.
+- **`networkAccess` error in Figma.** The manifest must allow the receiver
+  origin (`http://localhost:3333`). Re-import after editing the manifest.
+- **A `figma_execute`/Desktop Bridge prompt appears.** That's the _old_
+  figma-console flow — it isn't needed anymore; use this plugin instead.

--- a/tools/figma-token-exporter/manifest.json
+++ b/tools/figma-token-exporter/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "Acronis Token Exporter",
+  "api": "1.0.0",
+  "main": "plugin/code.js",
+  "ui": "plugin/ui.html",
+  "editorType": ["figma", "dev"],
+  "capabilities": ["inspect"],
+  "documentAccess": "dynamic-page",
+  "networkAccess": {
+    "allowedDomains": ["http://localhost:3333"],
+    "reasoning": "Posts the exported token snapshot to a local receiver (pnpm --filter @acronis-platform/figma-token-exporter receive) that writes it into packages/design-tokens/.tmp/figma-tokens/."
+  }
+}

--- a/tools/figma-token-exporter/package.json
+++ b/tools/figma-token-exporter/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@acronis-platform/figma-token-exporter",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Private build tool: a self-hosted Figma plugin + local receiver that exports design-token variables/styles into packages/design-tokens/.tmp/figma-tokens/ (the snapshot the sync emitters consume). Replaces the third-party figma-console Desktop Bridge for token pulls.",
+  "type": "module",
+  "exports": {
+    "./convert": "./src/convert.ts",
+    "./write-snapshot": "./src/write-snapshot.ts"
+  },
+  "scripts": {
+    "build": "echo \"no build (plugin is plain JS; node side runs via tsx)\" && exit 0",
+    "dev": "echo \"no dev server (run receive)\" && exit 0",
+    "clean": "echo \"nothing to clean\" && exit 0",
+    "receive": "tsx src/receiver.ts",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "figma",
+    "design-tokens",
+    "dtcg",
+    "plugin",
+    "acronis"
+  ],
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "tsx": "^4.20.0",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/tools/figma-token-exporter/plugin/code.js
+++ b/tools/figma-token-exporter/plugin/code.js
@@ -1,0 +1,144 @@
+// Acronis Token Exporter — Figma plugin (main thread).
+//
+// Reads local variables, collections, and text/paint/effect styles via the
+// Plugin API, resolves any cross-library alias targets (so the meta sidecar
+// covers every referenced VariableID), and hands the raw payload to the UI
+// iframe. The UI POSTs it to a local receiver that writes the design-tokens
+// snapshot. This file is intentionally "dumb": all DTCG/format logic lives in
+// the Node side (src/convert.ts) where it is typed and unit-tested.
+//
+// Plain ES (no bundler). Avoid optional chaining for older sandbox safety.
+
+/* global figma, __html__ */
+
+var PLUGIN_VERSION = '0.1.0';
+
+figma.showUI(__html__, { width: 340, height: 240, themeColors: true });
+
+function serializeVariable(v) {
+  return {
+    id: v.id,
+    name: v.name,
+    resolvedType: v.resolvedType,
+    valuesByMode: v.valuesByMode,
+    variableCollectionId: v.variableCollectionId,
+    scopes: v.scopes,
+    description: v.description,
+    hiddenFromPublishing: v.hiddenFromPublishing,
+  };
+}
+
+function serializeCollection(c) {
+  return {
+    id: c.id,
+    name: c.name,
+    modes: c.modes,
+    defaultModeId: c.defaultModeId,
+    variableIds: c.variableIds,
+  };
+}
+
+function serializeTextStyle(s) {
+  return {
+    id: s.id,
+    name: s.name,
+    fontName: s.fontName,
+    fontSize: s.fontSize,
+    lineHeight: s.lineHeight,
+    letterSpacing: s.letterSpacing,
+    textCase: s.textCase,
+    textDecoration: s.textDecoration,
+  };
+}
+
+function serializePaintStyle(s) {
+  return { id: s.id, name: s.name, paints: s.paints };
+}
+
+function serializeEffectStyle(s) {
+  return { id: s.id, name: s.name, effects: s.effects };
+}
+
+// Collect every VariableID referenced as an alias by any variable's value.
+function collectAliasIds(variables) {
+  var ids = {};
+  for (var i = 0; i < variables.length; i++) {
+    var vbm = variables[i].valuesByMode || {};
+    for (var modeId in vbm) {
+      if (!Object.prototype.hasOwnProperty.call(vbm, modeId)) continue;
+      var val = vbm[modeId];
+      if (val && typeof val === 'object' && val.type === 'VARIABLE_ALIAS' && val.id) {
+        ids[val.id] = true;
+      }
+    }
+  }
+  return Object.keys(ids);
+}
+
+async function buildPayload() {
+  var variables = await figma.variables.getLocalVariablesAsync();
+  var collections = await figma.variables.getLocalVariableCollectionsAsync();
+
+  var localIds = {};
+  for (var i = 0; i < variables.length; i++) localIds[variables[i].id] = true;
+
+  // Resolve alias targets that aren't in the local set (cross-library /
+  // "orphan" IDs). getLocalVariablesAsync misses these, but the snapshot's
+  // meta sidecar must still cover them or the sync's orphan-coverage gate
+  // fails. Fetching them here is what lets that gate pass on the first run.
+  var aliasIds = collectAliasIds(variables);
+  var orphanVariables = [];
+  for (var a = 0; a < aliasIds.length; a++) {
+    var id = aliasIds[a];
+    if (localIds[id]) continue;
+    try {
+      var ov = await figma.variables.getVariableByIdAsync(id);
+      if (ov) orphanVariables.push(serializeVariable(ov));
+    } catch {
+      // Unresolvable even by ID — leave it for the gate to report.
+    }
+  }
+
+  var textStyles = await figma.getLocalTextStylesAsync();
+  var paintStyles = await figma.getLocalPaintStylesAsync();
+  var effectStyles = await figma.getLocalEffectStylesAsync();
+
+  return {
+    exporter: 'acronis-figma-token-exporter',
+    pluginVersion: PLUGIN_VERSION,
+    fileKey: figma.fileKey || null,
+    fileName: figma.root.name,
+    exportedAt: Date.now(),
+    variables: variables.map(serializeVariable),
+    collections: collections.map(serializeCollection),
+    orphanVariables: orphanVariables,
+    textStyles: textStyles.map(serializeTextStyle),
+    paintStyles: paintStyles.map(serializePaintStyle),
+    effectStyles: effectStyles.map(serializeEffectStyle),
+  };
+}
+
+(async function () {
+  try {
+    var payload = await buildPayload();
+    figma.ui.postMessage({
+      type: 'PAYLOAD_READY',
+      payload: payload,
+      summary: {
+        variables: payload.variables.length,
+        collections: payload.collections.length,
+        orphans: payload.orphanVariables.length,
+        textStyles: payload.textStyles.length,
+        fileName: payload.fileName,
+      },
+    });
+  } catch (error) {
+    figma.ui.postMessage({ type: 'ERROR', error: (error && error.message) || String(error) });
+  }
+})();
+
+figma.ui.onmessage = function (msg) {
+  if (msg && msg.type === 'CLOSE') {
+    figma.closePlugin(msg.message || undefined);
+  }
+};

--- a/tools/figma-token-exporter/plugin/code.js
+++ b/tools/figma-token-exporter/plugin/code.js
@@ -94,8 +94,13 @@ async function buildPayload() {
     try {
       var ov = await figma.variables.getVariableByIdAsync(id);
       if (ov) orphanVariables.push(serializeVariable(ov));
-    } catch {
-      // Unresolvable even by ID — leave it for the gate to report.
+    } catch (e) {
+      // getVariableByIdAsync can reject for truly unresolvable IDs — skip and
+      // let the orphan-coverage gate report it. Figma's sandbox lacks optional
+      // `catch {}` binding, so we bind `e` and intentionally ignore it.
+      if (e) {
+        /* ignored */
+      }
     }
   }
 

--- a/tools/figma-token-exporter/plugin/ui.html
+++ b/tools/figma-token-exporter/plugin/ui.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      :root { color-scheme: light dark; }
+      body {
+        font: 12px/1.45 Inter, -apple-system, system-ui, sans-serif;
+        margin: 0; padding: 12px; color: var(--figma-color-text);
+        background: var(--figma-color-bg);
+      }
+      h1 { font-size: 12px; font-weight: 600; margin: 0 0 8px; }
+      .summary { color: var(--figma-color-text-secondary); margin-bottom: 10px; white-space: pre-line; min-height: 48px; }
+      button {
+        width: 100%; padding: 8px 12px; border: 0; border-radius: 6px; cursor: pointer;
+        font-weight: 600; font-size: 12px;
+        background: var(--figma-color-bg-brand); color: var(--figma-color-text-onbrand);
+      }
+      button:disabled { opacity: 0.5; cursor: default; }
+      .status { margin-top: 10px; white-space: pre-line; }
+      .ok { color: var(--figma-color-text-success, #1a8a3a); }
+      .err { color: var(--figma-color-text-danger, #d33); }
+      code { font-family: ui-monospace, Menlo, monospace; font-size: 11px; }
+    </style>
+  </head>
+  <body>
+    <h1>Acronis Token Exporter</h1>
+    <div class="summary" id="summary">Reading variables…</div>
+    <button id="send" disabled>Send snapshot to repo</button>
+    <div class="status" id="status"></div>
+
+    <script>
+      var PORT = 3333;
+      var ENDPOINT = 'http://localhost:' + PORT + '/';
+      var payload = null;
+
+      var summaryEl = document.getElementById('summary');
+      var statusEl = document.getElementById('status');
+      var sendBtn = document.getElementById('send');
+
+      function setStatus(text, cls) {
+        statusEl.textContent = text;
+        statusEl.className = 'status' + (cls ? ' ' + cls : '');
+      }
+
+      onmessage = function (event) {
+        var msg = event.data.pluginMessage;
+        if (!msg) return;
+        if (msg.type === 'PAYLOAD_READY') {
+          payload = msg.payload;
+          var s = msg.summary;
+          summaryEl.textContent =
+            (s.fileName ? s.fileName + '\n' : '') +
+            s.variables + ' variables · ' + s.collections + ' collections\n' +
+            s.orphans + ' resolved orphan refs · ' + s.textStyles + ' text styles';
+          sendBtn.disabled = false;
+        } else if (msg.type === 'ERROR') {
+          summaryEl.textContent = '';
+          setStatus('Plugin error: ' + msg.error, 'err');
+        }
+      };
+
+      sendBtn.onclick = async function () {
+        if (!payload) return;
+        sendBtn.disabled = true;
+        setStatus('Sending to ' + ENDPOINT + ' …');
+        try {
+          var res = await fetch(ENDPOINT, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+          var data = await res.json();
+          if (!res.ok || !data.ok) throw new Error(data.error || ('HTTP ' + res.status));
+          setStatus('Wrote snapshot ✓\n' + (data.files || []).join('\n'), 'ok');
+        } catch (e) {
+          setStatus(
+            'Could not reach the receiver.\nStart it first:\n' +
+              'pnpm --filter @acronis-platform/figma-token-exporter receive\n\n' +
+              ((e && e.message) || String(e)),
+            'err'
+          );
+          sendBtn.disabled = false;
+        }
+      };
+    </script>
+  </body>
+</html>

--- a/tools/figma-token-exporter/src/__specs__/convert.spec.ts
+++ b/tools/figma-token-exporter/src/__specs__/convert.spec.ts
@@ -1,0 +1,178 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, it, expect } from 'vitest';
+import { buildDtcgTree, convertPayloadToDocument } from '../convert.js';
+import { writeSnapshot } from '../write-snapshot.js';
+import type { ExportPayload } from '../types.js';
+
+// A minimal payload exercising every shape the design-tokens emitters read:
+// a multi-mode palette literal (theme), a semantic alias (brand), a component
+// alias + component literal, and an alias to a non-local "orphan" target.
+const payload: ExportPayload = {
+  exporter: 'acronis-figma-token-exporter',
+  pluginVersion: '0.1.0',
+  fileKey: 'FILEKEY',
+  fileName: 'Test File',
+  exportedAt: 0,
+  collections: [
+    {
+      id: 'col-theme',
+      name: 'Theme',
+      defaultModeId: 'm-light',
+      modes: [
+        { modeId: 'm-light', name: 'Light' },
+        { modeId: 'm-dark', name: 'Dark' },
+      ],
+      variableIds: ['v-base', 'v-blue3'],
+    },
+    {
+      id: 'col-brand',
+      name: 'Brand',
+      defaultModeId: 'm-acr',
+      modes: [
+        { modeId: 'm-acr', name: 'Acronis' },
+        { modeId: 'm-bb', name: 'Brand B' },
+      ],
+      variableIds: ['v-sem', 'v-chev', 'v-bga', 'v-orphref'],
+    },
+  ],
+  variables: [
+    {
+      id: 'v-base',
+      name: 'Base',
+      resolvedType: 'COLOR',
+      variableCollectionId: 'col-theme',
+      scopes: ['ALL_SCOPES'],
+      hiddenFromPublishing: false,
+      valuesByMode: { 'm-light': { r: 1, g: 1, b: 1, a: 1 }, 'm-dark': { r: 0, g: 0, b: 0, a: 1 } },
+    },
+    {
+      id: 'v-blue3',
+      name: 'Blue/Blue-3',
+      resolvedType: 'COLOR',
+      variableCollectionId: 'col-theme',
+      scopes: ['ALL_SCOPES'],
+      hiddenFromPublishing: false,
+      valuesByMode: { 'm-light': { r: 1, g: 1, b: 1, a: 1 }, 'm-dark': { r: 0, g: 0, b: 0, a: 1 } },
+    },
+    {
+      id: 'v-sem',
+      name: 'semantic/colors/background/surface/primary',
+      resolvedType: 'COLOR',
+      variableCollectionId: 'col-brand',
+      scopes: ['ALL_SCOPES'],
+      valuesByMode: {
+        'm-acr': { type: 'VARIABLE_ALIAS', id: 'v-base' },
+        'm-bb': { type: 'VARIABLE_ALIAS', id: 'v-base' },
+      },
+    },
+    {
+      id: 'v-chev',
+      name: 'component/breadcrumb/chevron',
+      resolvedType: 'COLOR',
+      variableCollectionId: 'col-brand',
+      valuesByMode: { 'm-acr': { type: 'VARIABLE_ALIAS', id: 'v-sem' } },
+    },
+    {
+      id: 'v-bga',
+      name: 'component/button/background-active',
+      resolvedType: 'COLOR',
+      variableCollectionId: 'col-brand',
+      valuesByMode: { 'm-acr': { r: 0.14, g: 0.27, b: 0.4, a: 1 } },
+    },
+    {
+      id: 'v-orphref',
+      name: 'component/x/y',
+      resolvedType: 'COLOR',
+      variableCollectionId: 'col-brand',
+      valuesByMode: { 'm-acr': { type: 'VARIABLE_ALIAS', id: 'VariableID:139:23' } },
+    },
+  ],
+  orphanVariables: [
+    {
+      id: 'VariableID:139:23',
+      name: 'Transparent/Inverted-6',
+      resolvedType: 'COLOR',
+      variableCollectionId: 'lib',
+      scopes: ['ALL_SCOPES'],
+      hiddenFromPublishing: true,
+      valuesByMode: {},
+    },
+  ],
+  textStyles: [],
+  paintStyles: [],
+  effectStyles: [],
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tree = buildDtcgTree(convertPayloadToDocument(payload)) as any;
+const fc = (leaf: typeof tree) => leaf.$extensions['figma-console-mcp'];
+
+describe('convertPayloadToDocument + buildDtcgTree', () => {
+  it('lowercases the collection name into the top-level key', () => {
+    expect(tree.theme).toBeDefined();
+    expect(tree.brand).toBeDefined();
+  });
+
+  it('splits variable names into nested paths, case-preserved', () => {
+    expect(tree.theme.Blue['Blue-3']).toBeDefined();
+    expect(tree.brand.semantic.colors.background.surface.primary).toBeDefined();
+    expect(tree.brand.component.breadcrumb.chevron).toBeDefined();
+  });
+
+  it('primitives: primary mode in $value, other modes under $extensions.modes', () => {
+    const blue3 = tree.theme.Blue['Blue-3'];
+    expect(blue3.$type).toBe('color');
+    expect(blue3.$value).toBe('#FFFFFF');
+    expect(blue3.$extensions.modes.Dark).toBe('#000000');
+    expect(fc(blue3).variableId).toBe('v-blue3');
+  });
+
+  it('semantic colors: aliases recorded as lastSyncedValue references per mode name', () => {
+    const prim = tree.brand.semantic.colors.background.surface.primary;
+    expect(fc(prim).lastSyncedValue.Acronis.reference).toBe('{Base}');
+    expect(fc(prim).lastSyncedValue['Brand B'].reference).toBe('{Base}');
+    expect(fc(prim).variableId).toBe('v-sem');
+  });
+
+  it('component alias reference uses the target variable dotted name', () => {
+    const chev = tree.brand.component.breadcrumb.chevron;
+    expect(fc(chev).lastSyncedValue.Acronis.reference).toBe(
+      '{semantic.colors.background.surface.primary}',
+    );
+  });
+
+  it('component literal color is an uppercase hex string', () => {
+    const bga = tree.brand.component.button['background-active'];
+    expect(fc(bga).lastSyncedValue.Acronis.literal).toMatch(/^#[0-9A-F]{6}$/);
+  });
+
+  it('orphan (non-local) alias target encodes as a {__library:VariableID} reference', () => {
+    const orphRef = tree.brand.component.x.y;
+    expect(fc(orphRef).lastSyncedValue.Acronis.reference).toBe('{__library:VariableID:139:23}');
+  });
+});
+
+describe('writeSnapshot', () => {
+  const outDir = mkdtempSync(join(tmpdir(), 'fte-'));
+  afterAll(() => rmSync(outDir, { recursive: true, force: true }));
+
+  it('covers every referenced VariableID in the meta sidecar (incl. resolved orphans)', () => {
+    const { files } = writeSnapshot(payload, outDir);
+    expect(files.some((f) => f.endsWith('variables.tokens.json'))).toBe(true);
+
+    const exportSrc = readFileSync(join(outDir, 'variables.tokens.json'), 'utf8');
+    const meta = JSON.parse(readFileSync(join(outDir, 'variables-meta.json'), 'utf8'));
+    const referenced = new Set(exportSrc.match(/VariableID:\d+:\d+/g) ?? []);
+
+    // The orphan-coverage gate's invariant: every VariableID in the export is a meta key.
+    for (const id of referenced) expect(meta[id], `meta missing ${id}`).toBeDefined();
+
+    expect(meta['VariableID:139:23']).toEqual({
+      name: 'Transparent/Inverted-6',
+      scopes: ['ALL_SCOPES'],
+      hidden: true,
+    });
+  });
+});

--- a/tools/figma-token-exporter/src/convert.ts
+++ b/tools/figma-token-exporter/src/convert.ts
@@ -15,6 +15,8 @@
 import type {
   ExportPayload,
   RawVariable,
+  RawCollection,
+  RawMode,
   FigmaVariableValue,
   FigmaVariableAlias,
   FigmaRgba,
@@ -43,7 +45,7 @@ export function convertPayloadToDocument(payload: ExportPayload): TokenDocument 
   for (const v of payload.variables) variableById.set(v.id, v);
 
   const sets = payload.collections.map((collection) => {
-    const wantedModes = collection.modes;
+    const wantedModes = modesDefaultFirst(collection);
     const collectionVars = payload.variables.filter(
       (v) => v.variableCollectionId === collection.id,
     );
@@ -68,15 +70,27 @@ export function convertPayloadToDocument(payload: ExportPayload): TokenDocument 
   };
 }
 
+// Put the collection's default mode first. `renderToken` uses the first mode
+// for the token's `$value` and stashes the rest under `$extensions.modes`, and
+// figma-to-primitives expects the default (e.g. Light) in `$value` and Dark
+// under `modes.Dark` — so order by `defaultModeId`, not Figma's array order.
+function modesDefaultFirst(collection: RawCollection): RawMode[] {
+  const def = collection.modes.find((m) => m.modeId === collection.defaultModeId);
+  if (!def) return collection.modes;
+  return [def, ...collection.modes.filter((m) => m.modeId !== collection.defaultModeId)];
+}
+
 function convertVariable(
   variable: RawVariable,
-  wantedModes: { modeId: string; name: string }[],
+  wantedModes: RawMode[],
   variableById: Map<string, RawVariable>,
 ): Token {
   const path = variable.name.split('/').filter(Boolean);
   const type = mapResolvedType(variable.resolvedType, variable.name);
 
-  const values: Record<string, TokenValue> = {};
+  // Null-prototype map: keys are Figma mode names (untrusted input), so a
+  // literal `__proto__`/`constructor` mode can't pollute Object.prototype.
+  const values: Record<string, TokenValue> = Object.create(null);
   for (const mode of wantedModes) {
     const rawValue = variable.valuesByMode[mode.modeId];
     if (rawValue === undefined) continue;
@@ -194,7 +208,10 @@ function byteToHex(byte: number): string {
 type DtcgNode = Record<string, unknown>;
 
 export function buildDtcgTree(doc: TokenDocument): DtcgNode {
-  const tree: DtcgNode = {};
+  // Null-prototype containers throughout the tree build: keys derive from Figma
+  // variable names / mode names (untrusted), so a `__proto__` segment becomes a
+  // plain own property instead of polluting Object.prototype.
+  const tree: DtcgNode = Object.create(null);
 
   const mcpDocMeta: Record<string, unknown> = {};
   if (doc.meta?.figmaFileKey) mcpDocMeta.figmaFileKey = doc.meta.figmaFileKey;
@@ -207,7 +224,7 @@ export function buildDtcgTree(doc: TokenDocument): DtcgNode {
     const setKey = slugify(set.name);
     let setGroup = tree[setKey] as DtcgNode | undefined;
     if (!setGroup) {
-      setGroup = {};
+      setGroup = Object.create(null) as DtcgNode;
       const mcpMeta: Record<string, unknown> = {};
       if (set.meta?.figmaCollectionId) mcpMeta.figmaCollectionId = set.meta.figmaCollectionId;
       if (set.name !== setKey) mcpMeta.originalName = set.name;
@@ -229,7 +246,11 @@ function slugify(s: string): string {
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    // Runs are already collapsed to a single '-' above, so a single anchored
+    // strip per side is sufficient — and avoids the backtracking-prone
+    // `/^-+|-+$/` alternation (ReDoS).
+    .replace(/^-/, '')
+    .replace(/-$/, '');
 }
 
 function writeTokenIntoTree(root: DtcgNode, token: Token, setModes: string[]): void {
@@ -238,7 +259,7 @@ function writeTokenIntoTree(root: DtcgNode, token: Token, setModes: string[]): v
     const segment = token.path[i];
     let next = cursor[segment] as DtcgNode | undefined;
     if (!next || isToken(next)) {
-      next = {};
+      next = Object.create(null) as DtcgNode;
       cursor[segment] = next;
     }
     cursor = next;
@@ -247,8 +268,12 @@ function writeTokenIntoTree(root: DtcgNode, token: Token, setModes: string[]): v
   cursor[leafKey] = renderToken(token, setModes);
 }
 
+function isRecordLike(node: unknown): node is Record<string, unknown> {
+  return Object(node) === node && !Array.isArray(node);
+}
+
 function isToken(node: unknown): boolean {
-  return typeof node === 'object' && node !== null && '$value' in (node as object);
+  return isRecordLike(node) && '$value' in node;
 }
 
 function renderToken(token: Token, setModes: string[]): DtcgNode {
@@ -261,7 +286,7 @@ function renderToken(token: Token, setModes: string[]): DtcgNode {
   } else if (modeKeys.length > 1) {
     const primaryMode = setModes[0] in token.values ? setModes[0] : modeKeys[0];
     result.$value = encodeValue(token.values[primaryMode]);
-    const otherModes: Record<string, unknown> = {};
+    const otherModes: Record<string, unknown> = Object.create(null);
     for (const m of modeKeys) {
       if (m === primaryMode) continue;
       otherModes[m] = encodeValue(token.values[m]);
@@ -287,14 +312,14 @@ function encodeValue(value: TokenValue | undefined): string | number | boolean {
 }
 
 function mergeExtension(node: DtcgNode, key: string, payload: unknown): void {
-  if (!node.$extensions) node.$extensions = {};
+  if (!node.$extensions) node.$extensions = Object.create(null);
   (node.$extensions as Record<string, unknown>)[key] = payload;
 }
 
 function sortKeys(node: unknown): unknown {
   if (node === null || typeof node !== 'object' || Array.isArray(node)) return node;
   const obj = node as Record<string, unknown>;
-  const sorted: Record<string, unknown> = {};
+  const sorted: Record<string, unknown> = Object.create(null);
   const keys = Object.keys(obj).sort((a, b) => {
     const aDollar = a.startsWith('$');
     const bDollar = b.startsWith('$');

--- a/tools/figma-token-exporter/src/convert.ts
+++ b/tools/figma-token-exporter/src/convert.ts
@@ -1,0 +1,307 @@
+// Variable → DTCG serialization.
+//
+// This is a faithful, trimmed port of figma-console-mcp's pipeline
+// (MIT — southleft/figma-console-mcp: dist/core/tokens/figma-converter.js +
+// formatters/dtcg.js + alias-resolver.js), restricted to the single-file,
+// all-modes export shape that this repo's design-tokens emitters consume.
+//
+// Faithfulness is the whole point: the committed `.tmp/scripts/figma-to-*`
+// emitters were written against figma-console's output, so reproducing the
+// exact transform (slugified collection key, slash→path variable names,
+// `lastSyncedValue` keyed by mode name with {reference}|{literal}, primary
+// mode in `$value` and others under `$extensions.modes`) yields a drop-in
+// snapshot. Do not "improve" the shape here — change the emitters instead.
+
+import type {
+  ExportPayload,
+  RawVariable,
+  FigmaVariableValue,
+  FigmaVariableAlias,
+  FigmaRgba,
+  FigmaResolvedType,
+  Token,
+  TokenDocument,
+  TokenSet,
+  TokenType,
+  TokenValue,
+} from './types.js';
+
+export const FIGMA_MCP_EXTENSION_KEY = 'figma-console-mcp';
+
+// ---------------------------------------------------------------------------
+// payload → TokenDocument  (port of figma-converter.js)
+// ---------------------------------------------------------------------------
+
+export function convertPayloadToDocument(payload: ExportPayload): TokenDocument {
+  // Reference resolution uses LOCAL variables only — exactly like
+  // figma-console. An alias to a non-local target is encoded as
+  // `{__library:VariableID:X:Y}` so the semantic emitter's library-alias branch
+  // can resolve it and the orphan-coverage gate can spot the ID. The resolved
+  // orphan metadata (from the plugin's getVariableByIdAsync) feeds the meta
+  // sidecar instead — never the reference path.
+  const variableById = new Map<string, RawVariable>();
+  for (const v of payload.variables) variableById.set(v.id, v);
+
+  const sets = payload.collections.map((collection) => {
+    const wantedModes = collection.modes;
+    const collectionVars = payload.variables.filter(
+      (v) => v.variableCollectionId === collection.id,
+    );
+    const tokens = collectionVars.map((variable) =>
+      convertVariable(variable, wantedModes, variableById),
+    );
+    const set: TokenSet = {
+      name: collection.name,
+      modes: wantedModes.map((m) => m.name),
+      tokens,
+      meta: { figmaCollectionId: collection.id },
+    };
+    return set;
+  });
+
+  return {
+    sets,
+    meta: {
+      figmaFileKey: payload.fileKey,
+      exportedAt: new Date(payload.exportedAt).toISOString(),
+    },
+  };
+}
+
+function convertVariable(
+  variable: RawVariable,
+  wantedModes: { modeId: string; name: string }[],
+  variableById: Map<string, RawVariable>,
+): Token {
+  const path = variable.name.split('/').filter(Boolean);
+  const type = mapResolvedType(variable.resolvedType, variable.name);
+
+  const values: Record<string, TokenValue> = {};
+  for (const mode of wantedModes) {
+    const rawValue = variable.valuesByMode[mode.modeId];
+    if (rawValue === undefined) continue;
+    values[mode.name] = convertValue(rawValue, variable.resolvedType, variableById);
+  }
+
+  return {
+    path,
+    type,
+    description: variable.description || undefined,
+    values,
+    extensions: {
+      [FIGMA_MCP_EXTENSION_KEY]: {
+        variableId: variable.id,
+        collectionId: variable.variableCollectionId,
+        // lastSyncedValue mirrors `values` — this is the field the semantic /
+        // components emitters actually read (reference|literal per mode name).
+        lastSyncedValue: { ...values },
+      },
+    },
+  };
+}
+
+function mapResolvedType(resolvedType: FigmaResolvedType, variableName: string): TokenType {
+  switch (resolvedType) {
+    case 'COLOR':
+      return 'color';
+    case 'FLOAT':
+      return inferFloatType(variableName);
+    case 'STRING':
+      return inferStringType(variableName);
+    case 'BOOLEAN':
+      return 'boolean';
+    default:
+      return 'string';
+  }
+}
+
+function inferFloatType(variableName: string): TokenType {
+  const lower = variableName.toLowerCase();
+  if (lower.includes('opacity') || lower.includes('alpha')) return 'number';
+  if (lower.includes('font-weight') || lower.includes('weight')) return 'fontWeight';
+  if (lower.includes('duration') || lower.includes('delay')) return 'duration';
+  return 'dimension';
+}
+
+function inferStringType(variableName: string): TokenType {
+  const lower = variableName.toLowerCase();
+  if (lower.includes('font-family') || lower.includes('font/family')) return 'fontFamily';
+  return 'string';
+}
+
+function convertValue(
+  rawValue: FigmaVariableValue,
+  resolvedType: FigmaResolvedType,
+  variableById: Map<string, RawVariable>,
+): TokenValue {
+  if (isVariableAlias(rawValue)) {
+    const target = variableById.get(rawValue.id);
+    if (!target) {
+      // Cross-library / unresolved alias — preserve the ID so the orphan gate
+      // and round-trip can recover it; matches figma-console's encoding.
+      return { reference: `{__library:${rawValue.id}}` };
+    }
+    const dotPath = target.name.replace(/\//g, '.');
+    return { reference: `{${dotPath}}` };
+  }
+
+  if (resolvedType === 'COLOR') {
+    if (typeof rawValue === 'object' && rawValue !== null && 'r' in rawValue) {
+      return { literal: rgbaToHex(rawValue as FigmaRgba) };
+    }
+    return { literal: String(rawValue) };
+  }
+  if (resolvedType === 'FLOAT') {
+    return { literal: typeof rawValue === 'number' ? rawValue : Number(rawValue) };
+  }
+  if (resolvedType === 'BOOLEAN') {
+    return { literal: Boolean(rawValue) };
+  }
+  return { literal: typeof rawValue === 'string' ? rawValue : String(rawValue) };
+}
+
+function isVariableAlias(value: FigmaVariableValue): value is FigmaVariableAlias {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'type' in value &&
+    (value as { type?: string }).type === 'VARIABLE_ALIAS'
+  );
+}
+
+function rgbaToHex(rgba: FigmaRgba): string {
+  const r = clampByte(rgba.r);
+  const g = clampByte(rgba.g);
+  const b = clampByte(rgba.b);
+  const a = rgba.a ?? 1;
+  const hex = `#${byteToHex(r)}${byteToHex(g)}${byteToHex(b)}`;
+  if (a >= 1) return hex;
+  return `${hex}${byteToHex(clampByte(a))}`;
+}
+
+function clampByte(f: number): number {
+  return Math.max(0, Math.min(255, Math.round(f * 255)));
+}
+
+function byteToHex(byte: number): string {
+  return byte.toString(16).padStart(2, '0').toUpperCase();
+}
+
+// ---------------------------------------------------------------------------
+// TokenDocument → DTCG tree  (port of formatters/dtcg.js, single-file mode)
+// ---------------------------------------------------------------------------
+
+type DtcgNode = Record<string, unknown>;
+
+export function buildDtcgTree(doc: TokenDocument): DtcgNode {
+  const tree: DtcgNode = {};
+
+  const mcpDocMeta: Record<string, unknown> = {};
+  if (doc.meta?.figmaFileKey) mcpDocMeta.figmaFileKey = doc.meta.figmaFileKey;
+  if (doc.meta?.exportedAt) mcpDocMeta.exportedAt = doc.meta.exportedAt;
+  if (Object.keys(mcpDocMeta).length > 0) {
+    tree.$extensions = { [FIGMA_MCP_EXTENSION_KEY]: mcpDocMeta };
+  }
+
+  for (const set of doc.sets) {
+    const setKey = slugify(set.name);
+    let setGroup = tree[setKey] as DtcgNode | undefined;
+    if (!setGroup) {
+      setGroup = {};
+      const mcpMeta: Record<string, unknown> = {};
+      if (set.meta?.figmaCollectionId) mcpMeta.figmaCollectionId = set.meta.figmaCollectionId;
+      if (set.name !== setKey) mcpMeta.originalName = set.name;
+      if (Object.keys(mcpMeta).length > 0) {
+        setGroup.$extensions = { [FIGMA_MCP_EXTENSION_KEY]: mcpMeta };
+      }
+      tree[setKey] = setGroup;
+    }
+    for (const token of set.tokens) {
+      writeTokenIntoTree(setGroup, token, set.modes);
+    }
+  }
+
+  return sortKeys(tree) as DtcgNode;
+}
+
+function slugify(s: string): string {
+  return s
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function writeTokenIntoTree(root: DtcgNode, token: Token, setModes: string[]): void {
+  let cursor = root;
+  for (let i = 0; i < token.path.length - 1; i++) {
+    const segment = token.path[i];
+    let next = cursor[segment] as DtcgNode | undefined;
+    if (!next || isToken(next)) {
+      next = {};
+      cursor[segment] = next;
+    }
+    cursor = next;
+  }
+  const leafKey = token.path[token.path.length - 1];
+  cursor[leafKey] = renderToken(token, setModes);
+}
+
+function isToken(node: unknown): boolean {
+  return typeof node === 'object' && node !== null && '$value' in (node as object);
+}
+
+function renderToken(token: Token, setModes: string[]): DtcgNode {
+  const result: DtcgNode = { $value: '', $type: token.type };
+  if (token.description) result.$description = token.description;
+
+  const modeKeys = Object.keys(token.values);
+  if (modeKeys.length === 1) {
+    result.$value = encodeValue(token.values[modeKeys[0]]);
+  } else if (modeKeys.length > 1) {
+    const primaryMode = setModes[0] in token.values ? setModes[0] : modeKeys[0];
+    result.$value = encodeValue(token.values[primaryMode]);
+    const otherModes: Record<string, unknown> = {};
+    for (const m of modeKeys) {
+      if (m === primaryMode) continue;
+      otherModes[m] = encodeValue(token.values[m]);
+    }
+    if (Object.keys(otherModes).length > 0) mergeExtension(result, 'modes', otherModes);
+  }
+
+  if (token.extensions) {
+    for (const [vendor, payload] of Object.entries(token.extensions)) {
+      mergeExtension(result, vendor, payload);
+    }
+  }
+  return result;
+}
+
+function encodeValue(value: TokenValue | undefined): string | number | boolean {
+  if (value?.reference) {
+    // Normalize to DTCG brace form, idempotent if already wrapped.
+    return `{${value.reference.replace(/^\{|\}$/g, '')}}`;
+  }
+  if (value?.literal === undefined) return '';
+  return value.literal;
+}
+
+function mergeExtension(node: DtcgNode, key: string, payload: unknown): void {
+  if (!node.$extensions) node.$extensions = {};
+  (node.$extensions as Record<string, unknown>)[key] = payload;
+}
+
+function sortKeys(node: unknown): unknown {
+  if (node === null || typeof node !== 'object' || Array.isArray(node)) return node;
+  const obj = node as Record<string, unknown>;
+  const sorted: Record<string, unknown> = {};
+  const keys = Object.keys(obj).sort((a, b) => {
+    const aDollar = a.startsWith('$');
+    const bDollar = b.startsWith('$');
+    if (aDollar && !bDollar) return -1;
+    if (!aDollar && bDollar) return 1;
+    return a.localeCompare(b);
+  });
+  for (const k of keys) sorted[k] = sortKeys(obj[k]);
+  return sorted;
+}

--- a/tools/figma-token-exporter/src/receiver.ts
+++ b/tools/figma-token-exporter/src/receiver.ts
@@ -72,14 +72,35 @@ const server = createServer(async (req, res) => {
     return;
   }
 
+  // Read the body — client faults (too large / unreadable) are 413 / 400.
+  let raw: string;
   try {
-    const raw = await readBody(req);
-    const payload = JSON.parse(raw) as ExportPayload;
-    if (payload?.exporter !== 'acronis-figma-token-exporter') {
-      sendJson(res, 400, { ok: false, error: 'Unrecognized payload (missing exporter marker).' });
-      return;
-    }
+    raw = await readBody(req);
+  } catch (err) {
+    const tooLarge = err instanceof Error && err.message === 'Payload too large';
+    sendJson(res, tooLarge ? 413 : 400, {
+      ok: false,
+      error: tooLarge ? 'Payload too large.' : 'Could not read request body.',
+    });
+    return;
+  }
 
+  // Parse + validate — malformed input is the client's fault (400).
+  let payload: ExportPayload;
+  try {
+    payload = JSON.parse(raw) as ExportPayload;
+  } catch {
+    sendJson(res, 400, { ok: false, error: 'Invalid JSON payload.' });
+    return;
+  }
+  if (payload?.exporter !== 'acronis-figma-token-exporter') {
+    sendJson(res, 400, { ok: false, error: 'Unrecognized payload (missing exporter marker).' });
+    return;
+  }
+
+  // Write — a failure here is a server fault (500). Log details locally; return
+  // a generic message so internal/stack details aren't exposed to the client.
+  try {
     const { files } = writeSnapshot(payload);
 
     console.log(
@@ -92,9 +113,8 @@ const server = createServer(async (req, res) => {
 
     sendJson(res, 200, { ok: true, files });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error('✗ Failed to write snapshot:', message);
-    sendJson(res, 500, { ok: false, error: message });
+    console.error('✗ Failed to write snapshot:', error instanceof Error ? (error.stack ?? error.message) : String(error));
+    sendJson(res, 500, { ok: false, error: 'Internal error writing the snapshot — see the receiver logs.' });
   }
 });
 

--- a/tools/figma-token-exporter/src/receiver.ts
+++ b/tools/figma-token-exporter/src/receiver.ts
@@ -1,0 +1,106 @@
+// Local receiver for the Acronis Token Exporter Figma plugin.
+//
+// Listens on http://localhost:3333 and accepts a POSTed ExportPayload from the
+// plugin's UI iframe, then writes the design-tokens snapshot into
+// packages/design-tokens/.tmp/figma-tokens/. Keeps running so you can re-export
+// without restarting; stop with Ctrl-C.
+//
+//   pnpm --filter @acronis-platform/figma-token-exporter receive
+//   pnpm --filter @acronis-platform/figma-token-exporter receive -- --port 4444
+
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { writeSnapshot, DEFAULT_OUT_DIR } from './write-snapshot.js';
+import type { ExportPayload } from './types.js';
+
+const PORT = parsePort(process.argv) ?? 3333;
+// Cap the body at 64 MB — the full ~600-variable model is well under 1 MB.
+const MAX_BODY_BYTES = 64 * 1024 * 1024;
+
+function parsePort(argv: string[]): number | undefined {
+  const i = argv.indexOf('--port');
+  if (i !== -1 && argv[i + 1]) {
+    const n = Number(argv[i + 1]);
+    if (Number.isInteger(n) && n > 0 && n < 65536) return n;
+  }
+  if (process.env.PORT) {
+    const n = Number(process.env.PORT);
+    if (Number.isInteger(n) && n > 0 && n < 65536) return n;
+  }
+  return undefined;
+}
+
+function cors(res: ServerResponse): void {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  cors(res);
+  res.setHeader('Content-Type', 'application/json');
+  res.statusCode = status;
+  res.end(JSON.stringify(body));
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    req.on('data', (c: Buffer) => {
+      size += c.length;
+      if (size > MAX_BODY_BYTES) {
+        reject(new Error('Payload too large'));
+        req.destroy();
+        return;
+      }
+      chunks.push(c);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+const server = createServer(async (req, res) => {
+  if (req.method === 'OPTIONS') {
+    cors(res);
+    res.statusCode = 204;
+    res.end();
+    return;
+  }
+  if (req.method !== 'POST') {
+    sendJson(res, 405, { ok: false, error: 'Use POST.' });
+    return;
+  }
+
+  try {
+    const raw = await readBody(req);
+    const payload = JSON.parse(raw) as ExportPayload;
+    if (payload?.exporter !== 'acronis-figma-token-exporter') {
+      sendJson(res, 400, { ok: false, error: 'Unrecognized payload (missing exporter marker).' });
+      return;
+    }
+
+    const { files } = writeSnapshot(payload);
+
+    console.log(
+      `\n✓ Wrote snapshot from "${payload.fileName}" ` +
+        `(${payload.variables.length} variables, ${payload.collections.length} collections, ` +
+        `${payload.orphanVariables.length} resolved orphans, ${payload.textStyles.length} text styles):`,
+    );
+    for (const f of files) console.log(`  ${f}`);
+    console.log('\nReady for the next export, or Ctrl-C to stop.');
+
+    sendJson(res, 200, { ok: true, files });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('✗ Failed to write snapshot:', message);
+    sendJson(res, 500, { ok: false, error: message });
+  }
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`Acronis Token Exporter receiver listening on http://localhost:${PORT}`);
+  console.log(`Writes into: ${DEFAULT_OUT_DIR}`);
+  console.log('In Figma: run the "Acronis Token Exporter" plugin, then click "Send snapshot to repo".');
+  console.log('Leave this running; Ctrl-C to stop.\n');
+});

--- a/tools/figma-token-exporter/src/types.ts
+++ b/tools/figma-token-exporter/src/types.ts
@@ -1,0 +1,118 @@
+// Shapes exchanged between the Figma plugin (plugin/code.js) and the Node
+// converter/receiver. The plugin emits the raw payload; the converter turns it
+// into the DTCG snapshot the design-tokens emitters consume.
+
+export interface FigmaRgba {
+  r: number;
+  g: number;
+  b: number;
+  a?: number;
+}
+
+export interface FigmaVariableAlias {
+  type: 'VARIABLE_ALIAS';
+  id: string;
+}
+
+export type FigmaVariableValue = number | string | boolean | FigmaRgba | FigmaVariableAlias;
+
+export type FigmaResolvedType = 'COLOR' | 'FLOAT' | 'STRING' | 'BOOLEAN';
+
+export interface RawVariable {
+  id: string;
+  name: string;
+  resolvedType: FigmaResolvedType;
+  valuesByMode: Record<string, FigmaVariableValue>;
+  variableCollectionId: string;
+  scopes?: string[];
+  description?: string;
+  hiddenFromPublishing?: boolean;
+}
+
+export interface RawMode {
+  modeId: string;
+  name: string;
+}
+
+export interface RawCollection {
+  id: string;
+  name: string;
+  modes: RawMode[];
+  defaultModeId: string;
+  variableIds: string[];
+}
+
+export interface RawTextStyle {
+  id: string;
+  name: string;
+  fontName?: { family: string; style: string };
+  fontSize?: number;
+  lineHeight?: { value?: number; unit: string };
+  letterSpacing?: { value: number; unit: string };
+  textCase?: string;
+  textDecoration?: string;
+}
+
+export interface RawStyle {
+  id: string;
+  name: string;
+  paints?: unknown[];
+  effects?: unknown[];
+}
+
+export interface ExportPayload {
+  exporter: 'acronis-figma-token-exporter';
+  pluginVersion: string;
+  fileKey: string | null;
+  fileName: string;
+  exportedAt: number;
+  variables: RawVariable[];
+  collections: RawCollection[];
+  orphanVariables: RawVariable[];
+  textStyles: RawTextStyle[];
+  paintStyles: RawStyle[];
+  effectStyles: RawStyle[];
+}
+
+// Internal token model (mirrors figma-console-mcp's TokenDocument, trimmed).
+export type TokenType =
+  | 'color'
+  | 'dimension'
+  | 'number'
+  | 'fontWeight'
+  | 'fontFamily'
+  | 'duration'
+  | 'string'
+  | 'boolean';
+
+export interface TokenValue {
+  reference?: string;
+  literal?: string | number | boolean;
+}
+
+export interface Token {
+  path: string[];
+  type: TokenType;
+  description?: string;
+  values: Record<string, TokenValue>;
+  extensions?: Record<string, unknown>;
+}
+
+export interface TokenSet {
+  name: string;
+  modes: string[];
+  tokens: Token[];
+  meta?: { figmaCollectionId?: string };
+}
+
+export interface TokenDocument {
+  sets: TokenSet[];
+  meta?: { figmaFileKey?: string | null; exportedAt?: string };
+}
+
+// The meta sidecar the emitters read: { [variableId]: { name, scopes, hidden } }.
+export interface VariableMetaEntry {
+  name: string;
+  scopes: string[];
+  hidden: boolean;
+}

--- a/tools/figma-token-exporter/src/write-snapshot.ts
+++ b/tools/figma-token-exporter/src/write-snapshot.ts
@@ -1,0 +1,67 @@
+// Turn an ExportPayload into the `.tmp/figma-tokens/` snapshot files the
+// design-tokens sync emitters consume, and write them to disk.
+//
+// Files written (matching context/figma-sync.md):
+//   variables.tokens.json — DTCG export (consumed by all three emitters)
+//   variables-meta.json    — { [variableId]: { name, scopes, hidden } }
+//   styles-text.json       — { styles: [...] } (consumed by figma-to-semantic)
+//   styles-color.json      — { styles: [...] } (parity; not consumed today)
+//   styles-effect.json     — { styles: [...] } (parity; not consumed today)
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildDtcgTree, convertPayloadToDocument } from './convert.js';
+import type { ExportPayload, RawVariable, VariableMetaEntry } from './types.js';
+
+// tools/figma-token-exporter/src/ → repo root is three levels up.
+export const DEFAULT_OUT_DIR = fileURLToPath(
+  new URL('../../../packages/design-tokens/.tmp/figma-tokens/', import.meta.url),
+);
+
+function buildMeta(payload: ExportPayload): Record<string, VariableMetaEntry> {
+  const meta: Record<string, VariableMetaEntry> = {};
+  const add = (v: RawVariable) => {
+    meta[v.id] = {
+      name: v.name,
+      scopes: v.scopes ?? [],
+      hidden: !!v.hiddenFromPublishing,
+    };
+  };
+  for (const v of payload.variables) add(v);
+  for (const v of payload.orphanVariables) if (!meta[v.id]) add(v);
+  return meta;
+}
+
+function json(value: unknown): string {
+  return JSON.stringify(value, null, 2) + '\n';
+}
+
+export interface WriteResult {
+  outDir: string;
+  files: string[];
+}
+
+export function writeSnapshot(payload: ExportPayload, outDir: string = DEFAULT_OUT_DIR): WriteResult {
+  mkdirSync(outDir, { recursive: true });
+
+  const variablesTokens = buildDtcgTree(convertPayloadToDocument(payload));
+  const meta = buildMeta(payload);
+
+  const outputs: Record<string, unknown> = {
+    'variables.tokens.json': variablesTokens,
+    'variables-meta.json': meta,
+    'styles-text.json': { styles: payload.textStyles },
+    'styles-color.json': { styles: payload.paintStyles },
+    'styles-effect.json': { styles: payload.effectStyles },
+  };
+
+  const files: string[] = [];
+  for (const [name, value] of Object.entries(outputs)) {
+    const target = join(outDir, name);
+    writeFileSync(target, json(value), 'utf8');
+    files.push(target);
+  }
+
+  return { outDir, files };
+}

--- a/tools/figma-token-exporter/tsconfig.json
+++ b/tools/figma-token-exporter/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## What

A repo-owned replacement for the third-party **figma-console Desktop Bridge** for the bulk token pull, living in `tools/figma-token-exporter`.

- **Plugin** (`manifest.json` + `plugin/code.js` + `plugin/ui.html`) — imported into Figma Desktop; reads variables, collections, and text/paint/effect styles, resolves cross-library alias targets (so the meta sidecar is complete), and POSTs a raw payload to a local receiver.
- **Receiver** (`src/receiver.ts`, run via `tsx`) — listens on `localhost:3333` and writes the snapshot into `packages/design-tokens/.tmp/figma-tokens/`.
- **Converter** (`src/convert.ts`) — a faithful, trimmed port of figma-console's variable→DTCG serialization, so the snapshot is a **drop-in** for the existing `tiers/` emitters (no emitter changes needed to read it).

## Why

The Figma org isn't on Enterprise, so the REST Variables API is unavailable and reading variables needs the Plugin API — *something* must run inside Figma. This makes that something a small, repo-owned plugin with no external MCP dependency and no Desktop Bridge.

## Validation

- `typecheck`, `lint`, and **8/8** Vitest unit tests (converter + snapshot writer, incl. orphan→meta coverage) pass.
- Verified end-to-end: produced a real 823-variable snapshot; the orphan-coverage gate passed first try.

## Usage

```
# one-time: Figma Desktop → Plugins → Development → Import plugin from manifest → tools/figma-token-exporter/manifest.json
pnpm --filter @acronis-platform/figma-token-exporter receive
# then run the plugin in Figma and click "Send snapshot to repo"
```

Indexed in root `AGENTS.md` and `packages/design-tokens/context/figma-sync.md`. The token refresh this tool produced ships as a **separate PR**.

<img width="489" height="183" alt="Screenshot 2026-06-11 at 11 33 35" src="https://github.com/user-attachments/assets/9d88dbf1-8bd7-4b8c-885e-418973b38028" />
