### PR TITLE
feat(icons-react): generate from icons-svg-next with 3 sizes per icon

### DIFF
--- a/.changeset/icons-react-from-icons-svg-next.md
+++ b/.changeset/icons-react-from-icons-svg-next.md
@@ -1,0 +1,16 @@
+---
+'@acronis-platform/icons-react': minor
+---
+
+Generate icon components from `@acronis-platform/icons-svg-next` instead of
+`@acronis-platform/design-assets`. This swaps in the redesigned next-gen icon
+set, so the packs grow substantially — `stroke-mono` (395), `solid-mono` (59),
+`stroke-multi` (12), `solid-multi` (1) — and the size/stroke rule (sm/md/lg =
+16/24/32 with 1.6/2/2.5px stroke) is now a generator constant rather than read
+from design-assets manifests. The `size` prop, `currentColor` theming, per-icon
+gradient-id namespacing, and per-pack subpath exports are unchanged.
+
+Note: the icon set changed wholesale, so some previously exported names are gone
+(e.g. `BanIcon`, `ArrowSquareUpRightIcon`, `AcronisAIcon`) and many new ones are
+added. A few names still reflect work-in-progress Figma source (`*-duplicate`,
+`agent-qnap--32`) until that source is cleaned up.

--- a/apps/kitchen-sink/src/sections/icons.tsx
+++ b/apps/kitchen-sink/src/sections/icons.tsx
@@ -6,6 +6,10 @@ import { icons as strokeMulti } from '@acronis-platform/icons-react/stroke-multi
 
 type IconMap = Record<string, ComponentType<{ size?: number }>>;
 
+// The supported icon sizes (px) — each icon renders at all three so the
+// size/stroke rules baked into icons-react (1.6 / 2 / 2.5px stroke) are visible.
+const SIZES = [16, 24, 32] as const;
+
 const PACKS: { name: string; icons: IconMap }[] = [
   { name: 'stroke-mono', icons: strokeMono },
   { name: 'solid-mono', icons: solidMono },
@@ -18,7 +22,7 @@ function Gallery({ icons }: { icons: IconMap }) {
     <div
       style={{
         display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fill, minmax(80px, 1fr))',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))',
         gap: 12,
       }}
     >
@@ -30,13 +34,25 @@ function Gallery({ icons }: { icons: IconMap }) {
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',
-            gap: 6,
+            gap: 8,
             padding: 8,
             borderRadius: 6,
             border: '1px solid var(--ui-border-on-surface-border)',
           }}
         >
-          <Icon size={24} />
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'flex-end',
+              justifyContent: 'center',
+              gap: 8,
+              minHeight: 32,
+            }}
+          >
+            {SIZES.map((size) => (
+              <Icon key={size} size={size} />
+            ))}
+          </div>
           <span
             style={{
               fontSize: 9,
@@ -59,6 +75,17 @@ function Gallery({ icons }: { icons: IconMap }) {
 export function IconsSection() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
+      <p
+        style={{
+          fontSize: 12,
+          color: 'var(--ui-text-on-surface-secondary)',
+          margin: 0,
+        }}
+      >
+        Each icon is shown at all three sizes — sm 16px, md 24px, lg 32px —
+        applying the per-size stroke weights (1.6 / 2 / 2.5px) baked into
+        icons-react.
+      </p>
       {PACKS.map((pack) => (
         <div key={pack.name}>
           <h3

--- a/packages/icons-react/AGENTS.md
+++ b/packages/icons-react/AGENTS.md
@@ -1,18 +1,19 @@
 # AGENTS.md — `packages/icons-react`
 
 `@acronis-platform/icons-react` — React icon components **generated from**
-[`@acronis-platform/design-assets`](../design-assets). Published.
+[`@acronis-platform/icons-svg-next`](../icons-svg-next). Published.
 
 Repo-wide rules live in the repo root's `./context/`. This file documents
 only what's specific to this workspace.
 
 ## Icons are generated, not authored
 
-`scripts/generate-icons.ts` reads the design-assets pack manifests + 24px
-SVG masters + scaling rules and emits per-icon React components under
-`src/packs/<pack>/` — **gitignored**, regenerated on `build` / `typecheck`
-/ `test` / `storybook`. Don't hand-edit anything under `src/packs/`; change
-the upstream asset or the generator.
+`scripts/generate-icons.ts` reads the icons-svg-next name-list manifests
+(`src/figma/*.json`) + flat 24px SVG masters (`src/svg/*.svg`) and emits
+per-icon React components under `src/packs/<pack>/` — **gitignored**,
+regenerated on `build` / `typecheck` / `test` / `storybook`. Don't hand-edit
+anything under `src/packs/`; change the upstream icon (re-sync icons-svg-next)
+or the generator.
 
 The hand-written code is small:
 
@@ -20,21 +21,26 @@ The hand-written code is small:
   height, `currentColor`, rule-driven stroke width, a11y).
 - `scripts/generate-icons.ts` — the generator.
 - `scripts/packs.ts` — the **single source of truth** for which packs are
-  built. Add a pack here (and a matching `exports` subpath + Vite entry).
+  built and the size/stroke rule (`ICON_SIZES`, `STROKE_WIDTH_PX`). Add a pack
+  here (and a matching `exports` subpath + Vite entry).
 
-## How the design-assets model maps to components
+## How the icons-svg-next model maps to components
 
-- One 24px master SVG per icon (the `default: true` variant). 16/32 are
-  `$rules`-derived in the manifest; **no per-size SVGs exist**.
-- The scale + stroke rules (`scale-16`, `stroke-1-6`, …) are resolved at
-  generation time into a `size → stroke-width` map baked into each pack's
-  `icon.tsx`, applied at runtime via the `size` prop. So one master renders
-  at any size with the designed stroke weight (1.6px @16, 2px @24, 2.5px @32).
+- One 24px master SVG per icon, flat in `icons-svg-next/src/svg/`. Each pack's
+  icon names come from its manifest(s): a pack reads every manifest named
+  `<pack>` or `<pack>-<category>` (so `stroke-mono` merges its six category
+  manifests — `stroke-mono-arrows`, `…-shapes`, …) and resolves each name to
+  `svg/<name>.svg`. **No per-size SVGs exist.**
+- The size/stroke rule is a constant (`STROKE_WIDTH_PX` in `packs.ts`: 1.6px
+  @16, 2px @24, 2.5px @32 — matching the Figma "icon components (generated)"
+  set). The generator converts it into a `size → stroke-width` (viewBox units)
+  map baked into each stroke pack's `icon.tsx`, applied at runtime via the
+  `size` prop, so one master renders at any size with the designed stroke.
 - **mono** packs → `stroke`/`fill` become `currentColor` (inherit text
   color). **multi** packs → authored colors (incl. gradients) are kept
   verbatim; gradient/clip `id`s are namespaced per icon (`<asset>-<id>`) so
   they don't collide when multiple icons render on one page. Stroke packs
-  still take their stroke width from the rules even when multicolor.
+  still take their stroke width from the rule even when multicolor.
 
 ## Public API
 
@@ -49,11 +55,15 @@ The hand-written code is small:
 
 ## Packs
 
-All four design-assets icon packs are generated (see `scripts/packs.ts`):
-`stroke-mono` (40), `solid-mono` (3), `stroke-multi` (12), `solid-multi` (1).
-Counts grow as the upstream `@acronis-platform/design-assets` packs do — no
+All four icons-svg-next packs are generated (see `scripts/packs.ts`):
+`stroke-mono` (395), `solid-mono` (59), `stroke-multi` (12), `solid-multi` (1).
+Counts grow as the upstream `@acronis-platform/icons-svg-next` set does — no
 code change needed. `@acronis-platform/ui-react` depends on this package so
 components/stories can compose icons.
+
+The icons-svg-next source is a live WIP surface, so generated names can include
+collisions (`*-duplicate`) and size-suffixed strays (`agent-qnap--32`) until the
+Figma source is cleaned; fix at the source and re-sync rather than hand-editing.
 
 ## When you change anything
 

--- a/packages/icons-react/README.md
+++ b/packages/icons-react/README.md
@@ -1,8 +1,8 @@
 # @acronis-platform/icons-react
 
 React icon components, generated from
-[`@acronis-platform/design-assets`](../design-assets). Tree-shakeable, themed
-via `currentColor`, with the design-system scale/stroke rules baked in.
+[`@acronis-platform/icons-svg-next`](../icons-svg-next). Tree-shakeable, themed
+via `currentColor`, with the design-system size/stroke rules baked in.
 
 ## Install
 
@@ -14,7 +14,7 @@ pnpm add @acronis-platform/icons-react react react-dom
 
 ```tsx
 import {
-  BanIcon,
+  BoltIcon,
   ChevronDownIcon,
 } from '@acronis-platform/icons-react/stroke-mono';
 
@@ -22,15 +22,15 @@ export function Example() {
   return (
     <p style={{ color: 'crimson' }}>
       {/* inherits text color via currentColor */}
-      <BanIcon size={16} title="Blocked" />
+      <BoltIcon size={16} title="Power" />
       <ChevronDownIcon /> {/* defaults to 24px, decorative */}
     </p>
   );
 }
 ```
 
-`size` applies the design-assets scale + stroke rules — e.g. `size={16}` renders
-at 16px with a 1.6px stroke, `size={32}` at 32px with 2.5px, matching the design.
+`size` applies the design size + stroke rules — e.g. `size={16}` renders at 16px
+with a 1.6px stroke, `size={32}` at 32px with 2.5px, matching the design.
 
 ### Dynamic lookup
 
@@ -48,7 +48,7 @@ const Icon = icons['chevron-down'];
 ## Develop
 
 ```sh
-pnpm --filter @acronis-platform/icons-react generate    # regenerate from design-assets
+pnpm --filter @acronis-platform/icons-react generate    # regenerate from icons-svg-next
 pnpm --filter @acronis-platform/icons-react storybook    # browse the gallery
 pnpm --filter @acronis-platform/icons-react test         # Vitest + RTL
 pnpm --filter @acronis-platform/icons-react build        # generate + lib bundle

--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@acronis-platform/icons-react",
   "version": "0.3.0",
-  "description": "Acronis React icon components, generated from @acronis-platform/design-assets.",
+  "description": "Acronis React icon components, generated from @acronis-platform/icons-svg-next.",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -60,7 +60,7 @@
     }
   },
   "devDependencies": {
-    "@acronis-platform/design-assets": "workspace:*",
+    "@acronis-platform/icons-svg-next": "workspace:*",
     "react": "catalog:",
     "react-dom": "catalog:",
     "@storybook/addon-a11y": "10.4.1",

--- a/packages/icons-react/scripts/generate-icons.ts
+++ b/packages/icons-react/scripts/generate-icons.ts
@@ -1,49 +1,35 @@
 import { createRequire } from 'node:module';
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { toComponentName } from '../src/lib/naming.ts';
-import { PACKS, type PackConfig } from './packs.ts';
+import {
+  ICON_SIZES,
+  PACKS,
+  STROKE_WIDTH_PX,
+  type PackConfig,
+} from './packs.ts';
 
 const require = createRequire(import.meta.url);
 const here = dirname(fileURLToPath(import.meta.url));
 const srcPacks = resolve(here, '..', 'src', 'packs');
 
-// design-assets ships JSON manifests + SVG sources; resolve its root from the
-// package.json export and read packs/rules off the filesystem.
-const assetsRoot = dirname(
-  require.resolve('@acronis-platform/design-assets/package.json')
+// icons-svg-next ships flat SVG masters (src/svg) + per-pack/category name-list
+// manifests (src/figma). Resolve its root from the package.json export.
+const nextRoot = dirname(
+  require.resolve('@acronis-platform/icons-svg-next/package.json')
 );
-
-interface Rule {
-  kind: 'scale' | 'stroke';
-  target: { value: number; unit: string };
-}
-interface Manifest {
-  name: string;
-  values: Record<string, { default?: boolean; $rules?: string[] }>;
-  assets: Record<string, { values: Record<string, { $file?: string }> }>;
-}
+const svgDir = resolve(nextRoot, 'src', 'svg');
+const figmaDir = resolve(nextRoot, 'src', 'figma');
 
 function round(n: number): number {
   return Math.round(n * 1000) / 1000;
 }
 
-async function loadRules(): Promise<Map<string, Rule>> {
-  const names = [
-    'scale-16',
-    'scale-32',
-    'scale-96',
-    'stroke-1-6',
-    'stroke-2-5',
-  ];
-  const rules = new Map<string, Rule>();
-  for (const name of names) {
-    const file = resolve(assetsRoot, 'rules', `${name}.json`);
-    rules.set(name, JSON.parse(await readFile(file, 'utf8')) as Rule);
-  }
-  return rules;
+/** Manifest files feeding a pack: `<name>.json` or `<name>-<category>.json`. */
+function manifestMatcher(pack: PackConfig): RegExp {
+  return new RegExp(`^${pack.name}(-.*)?\\.json$`);
 }
 
 /** kebab-attr="…" → camelAttr="…" for JSX (leaving aria- and data- attrs alone). */
@@ -123,40 +109,43 @@ function wrapperSource(
   );
 }
 
-async function generatePack(
-  pack: PackConfig,
-  rules: Map<string, Rule>
-): Promise<number> {
-  const manifest = JSON.parse(
-    await readFile(
-      resolve(assetsRoot, 'packs', `${pack.assetPack}.json`),
-      'utf8'
-    )
-  ) as Manifest;
+/** Merge + de-dupe the icon names for a pack from its manifest file(s). */
+async function packIconNames(pack: PackConfig): Promise<string[]> {
+  const matcher = manifestMatcher(pack);
+  const files = (await readdir(figmaDir))
+    .filter((f) => f !== 'icons.json' && matcher.test(f))
+    .sort();
+  const names = new Set<string>();
+  for (const file of files) {
+    const list = JSON.parse(
+      await readFile(resolve(figmaDir, file), 'utf8')
+    ) as string[];
+    list.forEach((name) => names.add(name));
+  }
+  return [...names].sort();
+}
 
-  const defaultSize = Object.entries(manifest.values).find(
-    ([, v]) => v.default
-  )?.[0];
-  if (!defaultSize)
-    throw new Error(`${pack.assetPack}: no default size in manifest`);
+async function generatePack(pack: PackConfig): Promise<number> {
+  const names = await packIconNames(pack);
 
   const outDir = resolve(srcPacks, pack.name);
   await rm(outDir, { recursive: true, force: true });
   await mkdir(resolve(outDir, 'icons'), { recursive: true });
 
-  const assetNames = Object.keys(manifest.assets).sort();
-  let viewBox = '0 0 24 24';
-  let masterStroke = 2;
-
+  let viewBoxSize = 24;
   const components: { name: string; component: string; file: string }[] = [];
-  for (const assetName of assetNames) {
-    const file = manifest.assets[assetName].values[defaultSize]?.$file;
-    if (!file) continue;
-    const svg = await readFile(resolve(assetsRoot, file), 'utf8');
-    viewBox = svg.match(/viewBox="([^"]*)"/)?.[1] ?? viewBox;
-    masterStroke = Number(
-      svg.match(/stroke-width="([\d.]+)"/)?.[1] ?? masterStroke
-    );
+  for (const assetName of names) {
+    let svg: string;
+    try {
+      svg = await readFile(resolve(svgDir, `${assetName}.svg`), 'utf8');
+    } catch {
+      console.warn(
+        `⚠ icons-react: ${pack.name} — no SVG for "${assetName}", skipping`
+      );
+      continue;
+    }
+    const viewBox = svg.match(/viewBox="([^"]*)"/)?.[1] ?? '0 0 24 24';
+    viewBoxSize = Number(viewBox.split(/\s+/)[2]) || viewBoxSize;
 
     const component = toComponentName(assetName);
     const inner = toInnerJsx(svg, pack, assetName);
@@ -173,18 +162,10 @@ async function generatePack(
   }
 
   // Stroke-width map (stroke packs only): rendered px → viewBox user units.
-  const viewBoxSize = Number(viewBox.split(/\s+/)[2]) || 24;
   const strokeMap: Record<number, number> = {};
   if (pack.paint === 'stroke') {
-    for (const [sizeKey, value] of Object.entries(manifest.values)) {
-      const renderSize = Number(sizeKey);
-      const strokeRuleName = value.$rules?.find(
-        (r) => rules.get(r)?.kind === 'stroke'
-      );
-      const strokePx = strokeRuleName
-        ? rules.get(strokeRuleName)!.target.value
-        : masterStroke;
-      strokeMap[renderSize] = round((strokePx * viewBoxSize) / renderSize);
+    for (const size of ICON_SIZES) {
+      strokeMap[size] = round((STROKE_WIDTH_PX[size] * viewBoxSize) / size);
     }
   }
 
@@ -199,7 +180,7 @@ async function generatePack(
     components.map((c) => `  '${c.name}': ${c.component},`).join('\n') +
     `\n} as const;`;
   const index =
-    `// Generated by scripts/generate-icons.ts from @acronis-platform/design-assets. Do not edit.\n` +
+    `// Generated by scripts/generate-icons.ts from @acronis-platform/icons-svg-next. Do not edit.\n` +
     `export type { IconProps } from './icon';\n\n` +
     `${imports}\n\n${exportList}\n\n${registry}\n\n` +
     `export type IconName = keyof typeof icons;\n`;
@@ -209,10 +190,9 @@ async function generatePack(
 }
 
 async function main(): Promise<void> {
-  const rules = await loadRules();
   await mkdir(srcPacks, { recursive: true });
   for (const pack of PACKS) {
-    const count = await generatePack(pack, rules);
+    const count = await generatePack(pack);
     console.log(`✓ icons-react: ${pack.name} — ${count} icons`);
   }
 }

--- a/packages/icons-react/scripts/packs.ts
+++ b/packages/icons-react/scripts/packs.ts
@@ -1,45 +1,43 @@
 /**
- * Single source of truth for which @acronis-platform/design-assets packs
- * this library generates, shared by the generator and the Vite lib config.
+ * Single source of truth for the icon packs this library generates from
+ * `@acronis-platform/icons-svg-next`, shared by the generator and the Vite lib
+ * config.
  *
- * - `assetPack` — manifest name in design-assets.
- * - `name` — published subpath (the `icons-` prefix is dropped).
+ * - `name` — published subpath (the `icons-` prefix is dropped) and `src/packs`
+ *   directory.
  * - `paint` — `stroke` packs apply the rule-derived stroke width and default
  *   `fill: none`; `solid` packs paint via `fill`.
  * - `multicolor` — `false` (mono) collapses authored colors to `currentColor`
  *   so the icon inherits text color; `true` keeps the authored colors (and
  *   namespaces any gradient/clip ids to avoid cross-icon collisions).
+ *
+ * Pack → manifest mapping: a pack reads every icons-svg-next manifest named
+ * `<name>` or `<name>-<category>` (so `stroke-mono` merges its six category
+ * manifests), and resolves each icon name to the flat `svg/<name>.svg`.
  */
 export interface PackConfig {
-  assetPack: string;
   name: string;
   paint: 'stroke' | 'solid';
   multicolor: boolean;
 }
 
 export const PACKS: PackConfig[] = [
-  {
-    assetPack: 'icons-stroke-mono',
-    name: 'stroke-mono',
-    paint: 'stroke',
-    multicolor: false,
-  },
-  {
-    assetPack: 'icons-solid-mono',
-    name: 'solid-mono',
-    paint: 'solid',
-    multicolor: false,
-  },
-  {
-    assetPack: 'icons-stroke-multi',
-    name: 'stroke-multi',
-    paint: 'stroke',
-    multicolor: true,
-  },
-  {
-    assetPack: 'icons-solid-multi',
-    name: 'solid-multi',
-    paint: 'solid',
-    multicolor: true,
-  },
+  { name: 'stroke-mono', paint: 'stroke', multicolor: false },
+  { name: 'solid-mono', paint: 'solid', multicolor: false },
+  { name: 'stroke-multi', paint: 'stroke', multicolor: true },
+  { name: 'solid-multi', paint: 'solid', multicolor: true },
 ];
+
+/**
+ * The supported rendered sizes (px) and their designed stroke weights (px), per
+ * the Figma "icon components (generated)" rules — sm/md/lg = 16/24/32 with
+ * stroke 1.6/2.0/2.5. The md (24) artwork is the source SVG; for stroke packs
+ * the generator converts these px weights into viewBox user units per size, so
+ * one master renders at any size with the designed stroke weight.
+ */
+export const ICON_SIZES = [16, 24, 32] as const;
+export const STROKE_WIDTH_PX: Record<number, number> = {
+  16: 1.6,
+  24: 2,
+  32: 2.5,
+};

--- a/packages/icons-react/src/__stories__/stroke-mono.stories.tsx
+++ b/packages/icons-react/src/__stories__/stroke-mono.stories.tsx
@@ -1,17 +1,17 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { BanIcon, icons, type IconName } from '../packs/stroke-mono';
+import { BoltIcon, icons, type IconName } from '../packs/stroke-mono';
 
 /**
- * The `stroke-mono` pack, generated from `@acronis-platform/design-assets`.
- * Icons use `currentColor` (inherit text color) and apply the design-assets
- * scale + stroke rules via the `size` prop.
+ * The `stroke-mono` pack, generated from `@acronis-platform/icons-svg-next`.
+ * Icons use `currentColor` (inherit text color) and apply the design size +
+ * stroke rules via the `size` prop.
  */
 const meta = {
   title: 'Icons/Stroke Mono',
-  component: BanIcon,
+  component: BoltIcon,
   parameters: { layout: 'centered' },
-} satisfies Meta<typeof BanIcon>;
+} satisfies Meta<typeof BoltIcon>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -21,9 +21,9 @@ export const Default: Story = {};
 export const Sizes: Story = {
   render: () => (
     <div style={{ display: 'flex', alignItems: 'center', gap: 24 }}>
-      <BanIcon size={16} />
-      <BanIcon size={24} />
-      <BanIcon size={32} />
+      <BoltIcon size={16} />
+      <BoltIcon size={24} />
+      <BoltIcon size={32} />
     </div>
   ),
 };
@@ -32,13 +32,13 @@ export const InheritsColor: Story = {
   render: () => (
     <div style={{ display: 'flex', gap: 24, fontSize: 32 }}>
       <span style={{ color: '#1763cf' }}>
-        <BanIcon size={32} />
+        <BoltIcon size={32} />
       </span>
       <span style={{ color: '#d4380d' }}>
-        <BanIcon size={32} />
+        <BoltIcon size={32} />
       </span>
       <span style={{ color: 'currentColor' }}>
-        <BanIcon size={32} />
+        <BoltIcon size={32} />
       </span>
     </div>
   ),

--- a/packages/icons-react/src/__tests__/packs.test.tsx
+++ b/packages/icons-react/src/__tests__/packs.test.tsx
@@ -1,9 +1,9 @@
 import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import { AcronisAIcon } from '../packs/solid-mono';
+import { AcronisIcon } from '../packs/solid-mono';
 import { CircleCheckSolidIcon } from '../packs/stroke-multi';
-import { SparklesIcon } from '../packs/solid-multi';
+import { SparklesDuplicateIcon } from '../packs/solid-multi';
 
 function svgOf(container: HTMLElement): SVGSVGElement {
   const svg = container.querySelector('svg');
@@ -13,7 +13,7 @@ function svgOf(container: HTMLElement): SVGSVGElement {
 
 describe('solid-mono pack', () => {
   it('paints with currentColor fill (no authored color, no stroke width)', () => {
-    const svg = svgOf(render(<AcronisAIcon />).container);
+    const svg = svgOf(render(<AcronisIcon />).container);
     expect(svg).toHaveAttribute('fill', 'currentColor');
     expect(svg).not.toHaveAttribute('stroke-width');
     // authored fill on the path was stripped so the svg's fill cascades.
@@ -28,18 +28,18 @@ describe('multicolor packs keep authored colors', () => {
     expect(svg).not.toHaveAttribute('stroke'); // not forced to currentColor
     expect(svg).toHaveAttribute('stroke-width', '2.4'); // rule-driven at 16px
     const paths = svg.querySelectorAll('path');
-    expect(paths[0]).toHaveAttribute('fill', '#29A33D');
-    expect(paths[0]).toHaveAttribute('stroke', '#248F36');
-    expect(paths[1]).toHaveAttribute('stroke', 'white');
+    expect(paths[0]).toHaveAttribute('fill', '#29a33d');
+    expect(paths[0]).toHaveAttribute('stroke', '#248f36');
+    expect(paths[1]).toHaveAttribute('stroke', '#fff');
   });
 
   it('solid-multi preserves gradients with namespaced ids', () => {
-    const svg = svgOf(render(<SparklesIcon />).container);
-    expect(svg.querySelector('linearGradient')?.id).toBe(
-      'sparkles-paint0_linear_1208_893'
-    );
+    const svg = svgOf(render(<SparklesDuplicateIcon />).container);
+    const gradientId = svg.querySelector('linearGradient')?.id;
+    // ids are namespaced per-icon so gradients can't collide across icons.
+    expect(gradientId).toMatch(/^sparkles-duplicate-/);
     expect(svg.querySelector('path')?.getAttribute('fill')).toBe(
-      'url(#sparkles-paint0_linear_1208_893)'
+      `url(#${gradientId})`
     );
   });
 });

--- a/packages/icons-react/src/__tests__/stroke-mono.test.tsx
+++ b/packages/icons-react/src/__tests__/stroke-mono.test.tsx
@@ -2,7 +2,7 @@ import { createRef } from 'react';
 import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import { BanIcon, ChevronDownIcon, icons } from '../packs/stroke-mono';
+import { BoltIcon, ChevronDownIcon, icons } from '../packs/stroke-mono';
 
 function svgOf(container: HTMLElement): SVGSVGElement {
   const svg = container.querySelector('svg');
@@ -12,7 +12,7 @@ function svgOf(container: HTMLElement): SVGSVGElement {
 
 describe('stroke-mono icons', () => {
   it('renders an svg with the 24px viewBox and at least one path', () => {
-    const { container } = render(<BanIcon />);
+    const { container } = render(<BoltIcon />);
     const svg = svgOf(container);
     expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
     expect(svg.querySelectorAll('path').length).toBeGreaterThan(0);
@@ -30,28 +30,28 @@ describe('stroke-mono icons', () => {
 
   it('applies the rule-derived stroke width per size', () => {
     // 24 → 2 (master), 16 → 1.6px ⇒ 2.4 user units, 32 → 2.5px ⇒ 1.875.
-    expect(svgOf(render(<BanIcon />).container)).toHaveAttribute(
+    expect(svgOf(render(<BoltIcon />).container)).toHaveAttribute(
       'stroke-width',
       '2'
     );
-    expect(svgOf(render(<BanIcon size={16} />).container)).toHaveAttribute(
+    expect(svgOf(render(<BoltIcon size={16} />).container)).toHaveAttribute(
       'stroke-width',
       '2.4'
     );
-    expect(svgOf(render(<BanIcon size={32} />).container)).toHaveAttribute(
+    expect(svgOf(render(<BoltIcon size={32} />).container)).toHaveAttribute(
       'stroke-width',
       '1.875'
     );
   });
 
   it('sets width/height from the size prop', () => {
-    const svg = svgOf(render(<BanIcon size={16} />).container);
+    const svg = svgOf(render(<BoltIcon size={16} />).container);
     expect(svg).toHaveAttribute('width', '16');
     expect(svg).toHaveAttribute('height', '16');
   });
 
   it('is labelled (role=img) when a title is provided', () => {
-    const { container, getByText } = render(<BanIcon title="Blocked" />);
+    const { container, getByText } = render(<BoltIcon title="Blocked" />);
     const svg = svgOf(container);
     expect(svg).toHaveAttribute('role', 'img');
     expect(svg).toHaveAttribute('aria-label', 'Blocked');
@@ -61,7 +61,7 @@ describe('stroke-mono icons', () => {
   it('forwards className and ref to the svg', () => {
     const ref = createRef<SVGSVGElement>();
     const { container } = render(
-      <BanIcon ref={ref} className="text-red-500" />
+      <BoltIcon ref={ref} className="text-red-500" />
     );
     const svg = svgOf(container);
     expect(svg).toHaveClass('text-red-500');
@@ -70,7 +70,7 @@ describe('stroke-mono icons', () => {
 
   it('exposes a registry of all icons keyed by asset name', () => {
     expect(Object.keys(icons).length).toBeGreaterThan(0);
-    expect(icons.ban).toBe(BanIcon);
+    expect(icons.bolt).toBe(BoltIcon);
     expect(icons['chevron-down']).toBe(ChevronDownIcon);
   });
 });

--- a/packages/icons-react/src/lib/svg-icon.tsx
+++ b/packages/icons-react/src/lib/svg-icon.tsx
@@ -16,17 +16,17 @@ export interface IconProps extends Omit<
 export interface SvgIconProps extends IconProps {
   /**
    * Map of rendered size (px) → stroke width in viewBox user units, derived
-   * from the design-assets scale + stroke rules at generation time. Applied to
-   * the `<svg>` (stroke packs only); falls back to the canonical (24) value.
+   * from the design size/stroke rules at generation time. Applied to the
+   * `<svg>` (stroke packs only); falls back to the canonical (24) value.
    */
   strokeWidthBySize?: Record<number, number>;
   children: React.ReactNode;
 }
 
 /**
- * Shared renderer for generated icon components. The design-assets master is a
- * 24px vector; the scale + stroke rules are baked into `strokeWidthBySize` (by
- * the generator) so one source renders at any size with the designed stroke
+ * Shared renderer for generated icon components. The source master is a 24px
+ * vector; the size + stroke rules are baked into `strokeWidthBySize` (by the
+ * generator) so one source renders at any size with the designed stroke
  * weight. Paint defaults (`currentColor`, `fill: none`, line caps) are supplied
  * by each pack's generated wrapper and can be overridden per call.
  */

--- a/packages/ui-react/src/components/ui/search/search.tsx
+++ b/packages/ui-react/src/components/ui/search/search.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
-import { SearchIcon } from '@acronis-platform/icons-react/solid-mono';
-import { TimesIcon } from '@acronis-platform/icons-react/stroke-mono';
+import {
+  MagnifierIcon,
+  TimesIcon,
+} from '@acronis-platform/icons-react/stroke-mono';
 
 import { cn } from '@/lib/utils';
 
@@ -78,7 +80,7 @@ const Search = React.forwardRef<HTMLInputElement, SearchProps>(
           className
         )}
       >
-        <SearchIcon
+        <MagnifierIcon
           size={16}
           className="shrink-0 text-[var(--ui-form-icon-idle)] group-data-[disabled]:text-[var(--ui-form-icon-disabled)]"
         />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -436,9 +436,9 @@ importers:
 
   packages/icons-react:
     devDependencies:
-      '@acronis-platform/design-assets':
+      '@acronis-platform/icons-svg-next':
         specifier: workspace:*
-        version: link:../design-assets
+        version: link:../icons-svg-next
       '@storybook/addon-a11y':
         specifier: 10.4.1
         version: 10.4.1(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))


### PR DESCRIPTION
## What

Repoints `@acronis-platform/icons-react` from `@acronis-platform/design-assets` to the redesigned `@acronis-platform/icons-svg-next` set — the icon components in Figma node [`629:10692`](https://www.figma.com/design/lrU3ydIyvPYQNE6ixdsKtJ/shadcn-uikit?node-id=629-10692). The component model (a `size` prop applying the asset rules) was already in place; this swaps in the source and the full icon set. Builds on the per-pack/category manifests from #269.

## icons-react

- `generate-icons.ts` reads icons-svg-next name-list manifests (`src/figma/*.json`) + flat 24px masters (`src/svg/*.svg`). A pack merges every manifest named `<pack>` or `<pack>-<category>`, so `stroke-mono` pulls its six category files.
- `packs.ts` drops the design-assets coupling and carries the **size/stroke rule** as constants — `ICON_SIZES = [16,24,32]`, `STROKE_WIDTH_PX = {16:1.6, 24:2, 32:2.5}` — matching the Figma "icon components (generated)" set. Stroke packs bake a per-size `stroke-width` (viewBox units) map; mono → `currentColor`, multi → authored colors with namespaced gradient ids.
- devDep `design-assets` → `icons-svg-next`. Docs/stories/tests refreshed for the new set.

**Generated:** stroke-mono 395 · solid-mono 59 · stroke-multi 12 · solid-multi 1 (467 total).

## ui-react

- `search.tsx`: the new set has no `solid-mono` `SearchIcon` → use the `stroke-mono` `MagnifierIcon` (the only icon import that broke; swept the whole repo).

## kitchen-sink

- The icon galleries render **every icon at all three sizes (16 / 24 / 32)**, with a legend showing the per-size stroke weights — the "3 sizes per icon" example.

## ⚠️ Follow-up required (can't run here)

`ui-react` visual-regression baselines must be regenerated **in Docker** (Linux; host-rendered PNGs must not be committed) — the icon artwork changed (Search magnifier, and any story rendering chevrons/check/sparkles/etc.):

```
pnpm --filter @acronis-platform/ui-react storybook:test:visual:docker:update
```

Until then the visual-regression CI check will flag the changed icon snapshots.

## Breaking

The icon set changed wholesale: some previously exported names are gone (`BanIcon`, `ArrowSquareUpRightIcon`, `AcronisAIcon`, solid `SearchIcon`/`SparklesIcon`), many are added, and a few reflect WIP Figma source (`*-duplicate`, `AgentQnap32Icon`) until cleaned. Captured in the changeset (minor, 0.x).

## Test plan

- icons-react: `test` (14) / `typecheck` / `lint` / `build` ✅
- ui-react: `typecheck` + `test` (86) / `lint` ✅
- kitchen-sink: `typecheck` ✅
- ⬜ ui-react visual baselines (Docker) — see above