### PR TITLE
feat(kitchen-sink): full component coverage, brand switching, and sync skill

### DIFF
--- a/.claude/skills/kitchen-sink-sync/SKILL.md
+++ b/.claude/skills/kitchen-sink-sync/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: kitchen-sink-sync
+description: Audit and update the kitchen-sink app (apps/kitchen-sink) so it represents every ui-react component and its real variants/sizes/states. Use when components are added or re-themed, when token tiers are renamed, or when asked to "update the kitchen sink", "show all components", or check the kitchen sink for drift. Cross-checks ui-react exports + cva keys + ui-spec against what the page renders, and verifies every --ui-* token ref still resolves.
+argument-hint: '[ComponentName | all]'
+---
+
+# Skill: /kitchen-sink-sync
+
+Keep `apps/kitchen-sink` a faithful, **complete** visual reference for
+`@acronis-platform/ui-react`: every exported component, each with its real
+variants / sizes / states, wired to **live** `--ui-*` tokens.
+
+Read the workspace contract first — it overrides anything here on conflict:
+[apps/kitchen-sink/AGENTS.md](../../../apps/kitchen-sink/AGENTS.md). Repo-wide
+rules live in [context/conventions.md](../../../context/conventions.md) and
+[context/commits.md](../../../context/commits.md).
+
+## Why this skill exists (the failure mode it prevents)
+
+Two silent drifts make the kitchen sink lie:
+
+1. **Missing components.** A new ui-react export (e.g. `SidebarPrimary`) is never
+   added to `src/sections/components.tsx`, so the page silently under-represents
+   the library.
+2. **Dead token references.** `components.tsx` hardcodes token names in inline
+   styles — notably the `forcedStyle` / `forcedIconStyle` helpers that force a
+   button cell into a hover/active/focus state by referencing
+   `--ui-button-<variant>-container-color-<state>` etc. When a token sync renames
+   a tier (the recurring `-color-` infix rename:
+   `--ui-button-primary-container-idle` → `…-container-color-idle`), **nothing
+   fails** — `var(--missing)` just falls back to transparent/inherited, so the
+   matrix renders blank cells. The component itself may already be fixed; these
+   hand-written token strings drift independently and must be re-checked.
+
+This skill is the audit + fix loop for both. **Pure additive/QA work on a private
+app** — no published-package or token changes.
+
+## Invocation
+
+```
+/kitchen-sink-sync [ComponentName | all]
+```
+
+`all` (default) audits the whole page; a `ComponentName` scopes to one component.
+
+## Phase 1 — Inventory: exports vs. coverage
+
+```bash
+# Every exported component (the source of truth for "all available components")
+sed -n 's#.*/components/ui/\([a-z-]*\).*#\1#p' packages/ui-react/src/index.ts | sort -u
+# What the page already renders (component identifiers used in the section)
+grep -oE '<[A-Z][A-Za-z]+' apps/kitchen-sink/src/sections/components.tsx | sort -u
+```
+
+Any exported component dir with no corresponding render is **missing** — add it
+in Phase 3. (Composable components export many parts; match on the root name.)
+
+## Phase 2 — Per-component variants / sizes / states (the props to show)
+
+For each component, the real axes come from the **cva keys** and the **prop
+interface**, mirrored by the ui-spec contract — never guess:
+
+```bash
+# cva variant/size keys actually implemented:
+sed -n '/cva(/,/^);/p' packages/ui-react/src/components/ui/<name>/<name>.tsx
+# the framework-agnostic contract (variant/size enums, boolean state props):
+cat packages/ui-spec/components/<name>/api.yaml          # if a spec exists
+```
+
+Decide what to render: every `variant` × every `size`, plus the meaningful
+**states** — `idle / hover / active / disabled / focus` for interactive controls
+(buttons), and prop-driven states for the rest (`checked`, `indeterminate`,
+`disabled`, `aria-invalid`, `selected`, `open`, …). Mirror the existing matrix
+style (`STYLES` × `STATES` grid for buttons; `Row` lists for the others).
+
+## Phase 3 — Token-resolution check (do this every run — it's the silent bug)
+
+Every `--ui-*` reference that the page **hardcodes** (inline styles, the
+`forced*Style` template strings) must resolve against the **current** generated
+tier. Missing vars fail silently, so grep-verify:
+
+```bash
+# 1) Each component's tier must be injected in tokens.ts (per-component CSS is
+#    NOT bundled by ui-react/styles — see AGENTS.md).
+grep -oE "css/[A-Za-z]+/acronis.css" apps/kitchen-sink/src/lib/tokens.ts | sort -u
+
+# 2) Every --ui-* token string the section references must exist in some tier.
+#    (Template-literal refs like `--ui-button-${token}-container-color-${cs}`
+#    can't be grepped literally — expand them mentally to concrete names and
+#    check a representative one, plus check the static refs:)
+for t in $(grep -oE 'ui-[a-z-]+(-[a-z]+)*' apps/kitchen-sink/src/sections/components.tsx | sort -u); do
+  grep -qhrF -- "--$t" packages/tokens-pd/css && echo "OK   --$t" || echo "CHECK --$t"
+done
+```
+
+For the **button matrices specifically**, confirm the dynamic names the helpers
+build are real. The forced state strings must match the tier exactly:
+`--ui-button-<variant>-container-color-<state>`,
+`--ui-button-<variant>-label-color-<state>`,
+`--ui-button-<variant>-container-border-color-<state>` (border keeps its own
+`-color-`), and ButtonIcon's `--ui-button-icon-global-{container,icon}-color-<state>`.
+Spot-check one concrete name against the tier:
+
+```bash
+grep -o "ui-button-primary-container-color-idle" packages/tokens-pd/css/Button/acronis.css
+```
+
+If a referenced tier isn't injected in `tokens.ts`, add its
+`import x from '@acronis-platform/tokens-pd/css/<Tier>/acronis.css?raw'` and wire
+it into the injected list (so both rendering and the colors-section enumeration
+see it).
+
+## Phase 4 — Implement
+
+Edit `apps/kitchen-sink/src/sections/components.tsx`:
+
+- Add missing components (lift a minimal, representative composition from the
+  component's `__stories__/<name>.stories.tsx` — those are known-good).
+- For new variants/states on existing components, extend the matrix/row.
+- Layout-filling components (sidebars) need a bounded shell:
+  `<div style={{ display: 'flex', gap: 16, height: 440 }}>…</div>`.
+- Keep the page's house style: inline styles + `var(--ui-*)` tokens, **no
+  Tailwind here**, no hardcoded hex.
+- Update the `components.tsx` bullet in `apps/kitchen-sink/AGENTS.md` to list
+  what's now shown.
+
+## Phase 5 — Verify (build from dist + look at it)
+
+The app imports the libraries by package name from their **built `dist`**, so
+build deps first:
+
+```bash
+pnpm --filter "@acronis-platform/kitchen-sink^..." build   # ui-react, icons-react, deps
+pnpm --filter @acronis-platform/kitchen-sink typecheck
+pnpm --filter @acronis-platform/kitchen-sink lint
+pnpm --filter @acronis-platform/kitchen-sink build
+```
+
+**Always look at the result** — the whole point is visual correctness, and the
+token-drift bug is invisible to typecheck/lint/build:
+
+```bash
+pnpm --filter @acronis-platform/kitchen-sink exec vite preview --port 4180 &
+```
+
+Open `http://localhost:4180/#components`, scroll to the changed sections, and
+screenshot (Chrome DevTools MCP, or manually). Confirm **light and dark** (the
+header toggle) — tokens are `light-dark()`, so a blank/oddly-colored cell in one
+scheme is the dead-token signature. Stop the preview when done.
+
+## Output checklist (done = all green)
+
+- [ ] Every `ui-react` export renders in `components.tsx` (Phase 1 diff empty).
+- [ ] Each component shows its real cva variants × sizes + meaningful states.
+- [ ] Every hardcoded `--ui-*` ref resolves against the current tier; each used
+      tier is imported in `tokens.ts`.
+- [ ] `AGENTS.md` component list updated.
+- [ ] typecheck · lint · build pass (deps built first).
+- [ ] Visually verified in the browser, light **and** dark.
+
+## Notes
+
+- This app is **private** — no changeset, no VR baselines (it isn't in the
+  Storybook VR suite).
+- Don't fix component/token bugs _here_: if a token is genuinely missing upstream
+  (not just renamed), or a component renders wrong, that's a ui-react / tokens-pd
+  fix (use `/figma-component`), not a kitchen-sink patch.

--- a/.claude/skills/kitchen-sink-sync/SKILL.md
+++ b/.claude/skills/kitchen-sink-sync/SKILL.md
@@ -65,13 +65,28 @@ interface**, mirrored by the ui-spec contract — never guess:
 sed -n '/cva(/,/^);/p' packages/ui-react/src/components/ui/<name>/<name>.tsx
 # the framework-agnostic contract (variant/size enums, boolean state props):
 cat packages/ui-spec/components/<name>/api.yaml          # if a spec exists
+# OPTIONAL CONTENT-SLOT PROPS — easy to miss; grep the prop interface directly:
+grep -nE '\b(label|description|icon|render|placeholder)\??:' \
+  packages/ui-react/src/components/ui/<name>/<name>.tsx
 ```
 
-Decide what to render: every `variant` × every `size`, plus the meaningful
-**states** — `idle / hover / active / disabled / focus` for interactive controls
-(buttons), and prop-driven states for the rest (`checked`, `indeterminate`,
-`disabled`, `aria-invalid`, `selected`, `open`, …). Mirror the existing matrix
-style (`STYLES` × `STATES` grid for buttons; `Row` lists for the others).
+Three distinct axes to render — **all three**, not just cva:
+
+1. **cva `variant` / `size`** — every key (e.g. ButtonIcon's `ghost` _and_
+   `secondary`; Tag's 7 variants incl. `ai`). A re-theme often **adds** a variant.
+2. **States** — `idle / hover / active / disabled / focus` for interactive
+   controls (forced via the matrix helpers); prop-driven states for the rest
+   (`checked`, `indeterminate`, `disabled`, `aria-invalid`, `selected`, `open`).
+3. **Optional content-slot props** — `label`, `description`, `icon`, `render`.
+   These are **first-class things to show**, not just cva variants: a component
+   that gained a `label` / `description` (the field-style Checkbox/Switch) looks
+   complete in the box-only matrix yet under-represents its real API. Add a
+   dedicated row for each (a "With label", "With label & description" row, …).
+   This is where coverage gaps most often hide — check it on every run.
+
+Mirror the existing matrix style: `STYLES` × `STATES` grid for the buttons, `Row`
+lists for the rest (use `alignItems: 'flex-start'` for taller field rows that
+carry a description).
 
 ## Phase 3 — Token-resolution check (do this every run — it's the silent bug)
 
@@ -151,7 +166,8 @@ scheme is the dead-token signature. Stop the preview when done.
 ## Output checklist (done = all green)
 
 - [ ] Every `ui-react` export renders in `components.tsx` (Phase 1 diff empty).
-- [ ] Each component shows its real cva variants × sizes + meaningful states.
+- [ ] Each component shows its real cva variants × sizes, meaningful states, and
+      optional content-slot props (`label` / `description` / `icon` / `render`).
 - [ ] Every hardcoded `--ui-*` ref resolves against the current tier; each used
       tier is imported in `tokens.ts`.
 - [ ] `AGENTS.md` component list updated.
@@ -162,6 +178,10 @@ scheme is the dead-token signature. Stop the preview when done.
 
 - This app is **private** — no changeset, no VR baselines (it isn't in the
   Storybook VR suite).
+- **Commit headers must be ≤ 100 chars** (commitlint rejects longer). With the
+  `feat(kitchen-sink): …` prefix that leaves ~80 chars — list the components
+  added, not every variant (e.g. `feat(kitchen-sink): add ButtonIcon secondary,
+Switch/Checkbox labels, Tag ai`).
 - Don't fix component/token bugs _here_: if a token is genuinely missing upstream
   (not just renamed), or a component renders wrong, that's a ui-react / tokens-pd
   fix (use `/figma-component`), not a kitchen-sink patch.

--- a/.claude/skills/kitchen-sink-sync/SKILL.md
+++ b/.claude/skills/kitchen-sink-sync/SKILL.md
@@ -36,8 +36,8 @@ Three silent drifts make the kitchen sink lie:
    matrix renders blank cells. The component itself may already be fixed; these
    hand-written token strings drift independently and must be re-checked.
 
-This skill is the audit + fix loop for both. **Pure additive/QA work on a private
-app** — no published-package or token changes.
+This skill is the audit + fix loop for all three. **Pure additive/QA work on a
+private app** — no published-package or token changes.
 
 ## Invocation
 

--- a/.claude/skills/kitchen-sink-sync/SKILL.md
+++ b/.claude/skills/kitchen-sink-sync/SKILL.md
@@ -218,6 +218,12 @@ Stop the preview when done.
 
 - This app is **private** — no changeset, no VR baselines (it isn't in the
   Storybook VR suite).
+- **The audit one-liners must stay POSIX** — this repo runs on macOS (BSD `sed`),
+  which has no `\U` / `\L` case transforms. Don't normalize PascalCase↔kebab with
+  `sed -E 's/.../\U&/'` to auto-diff the export/render lists: BSD `sed` emits a
+  literal `U`/`L`, silently turning every entry into a false "missing". Compare
+  the two `sort -u` lists **by eye**, or match each export's PascalCase tag with a
+  plain `grep "<Pascal"` loop (no case folding).
 - **Commit headers must be ≤ 100 chars** (commitlint rejects longer). With the
   `feat(kitchen-sink): …` prefix that leaves ~80 chars — list the components
   added, not every variant (e.g. `feat(kitchen-sink): add ButtonIcon secondary,

--- a/.claude/skills/kitchen-sink-sync/SKILL.md
+++ b/.claude/skills/kitchen-sink-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kitchen-sink-sync
-description: Audit and update the kitchen-sink app (apps/kitchen-sink) so it represents every ui-react component and its real variants/sizes/states. Use when components are added or re-themed, when token tiers are renamed, or when asked to "update the kitchen sink", "show all components", or check the kitchen sink for drift. Cross-checks ui-react exports + cva keys + ui-spec against what the page renders, and verifies every --ui-* token ref still resolves.
+description: Audit and update the kitchen-sink app (apps/kitchen-sink) so it represents every ui-react component (with its real variants/sizes/states/props) and every brand tokens-pd ships. Use when components are added or re-themed, when token tiers or brands are added/renamed, or when asked to "update the kitchen sink", "show all components", or check the kitchen sink for drift. Cross-checks ui-react exports + cva keys + ui-spec + tokens-pd brands against what the page renders, and verifies every --ui-* token ref still resolves.
 argument-hint: '[ComponentName | all]'
 ---
 
@@ -17,12 +17,16 @@ rules live in [context/conventions.md](../../../context/conventions.md) and
 
 ## Why this skill exists (the failure mode it prevents)
 
-Two silent drifts make the kitchen sink lie:
+Three silent drifts make the kitchen sink lie:
 
 1. **Missing components.** A new ui-react export (e.g. `SidebarPrimary`) is never
    added to `src/sections/components.tsx`, so the page silently under-represents
-   the library.
-2. **Dead token references.** `components.tsx` hardcodes token names in inline
+   the library. (Also missed: new variants and content-slot props on components
+   that _are_ shown — see Phase 2.)
+2. **Missing brands.** tokens-pd ships a new override brand (e.g. `deep-sky`) but
+   the header brand `<select>` / `applyBrand` never gain it, so the page can only
+   preview the default brand — see Phase 4.
+3. **Dead token references.** `components.tsx` hardcodes token names in inline
    styles — notably the `forcedStyle` / `forcedIconStyle` helpers that force a
    button cell into a hover/active/focus state by referencing
    `--ui-button-<variant>-container-color-<state>` etc. When a token sync renames
@@ -125,7 +129,37 @@ If a referenced tier isn't injected in `tokens.ts`, add its
 it into the injected list (so both rendering and the colors-section enumeration
 see it).
 
-## Phase 4 — Implement
+## Phase 4 — Brand & scheme switchers (keep the header in sync with tokens-pd)
+
+The header must expose **every brand tokens-pd ships**, not just the ones wired
+when it was last touched (a new brand is as easy to miss as a new component).
+Brands are the root CSS files: `acronis` is the base; every other root file is an
+**override-only** brand layered on top.
+
+```bash
+# Brands tokens-pd actually ships (each non-acronis root file is an override brand):
+ls packages/tokens-pd/css/*.css | sed 's#.*/##; s/\.css$//'      # e.g. acronis, deep-sky
+# Brands the kitchen sink exposes — the Brand union + applyBrand + the <select>:
+grep -nE "type Brand|DEEP_SKY|applyBrand|'[a-z-]+'" apps/kitchen-sink/src/lib/tokens.ts
+grep -n "<option value=" apps/kitchen-sink/src/App.tsx
+```
+
+Any shipped brand missing from the `Brand` union / `applyBrand` override blob /
+the `App.tsx` `<select>` is a gap. To wire a new override brand `<b>`:
+
+- `find packages/tokens-pd/css -name '<b>.css'` — an override file exists only
+  where the brand diverges, so the set may be smaller than the acronis set.
+- In `tokens.ts`: `import … '@acronis-platform/tokens-pd/css/<Tier>/<b>.css?raw'`
+  for the semantic root + each component tier that has a `<b>.css`; concatenate
+  them into the brand's override blob; extend the `Brand` union; make `applyBrand`
+  swap that blob into the override `<style>` (kept **last** in `<head>`).
+- In `App.tsx`: add an `<option value="<b>">…</option>`.
+
+Override brands carry no `color-scheme` shell, so they inherit light/dark from the
+acronis base via the existing scheme toggle — **no per-brand scheme wiring**. The
+scheme toggle is one mechanism (`applyTheme`) and needs no per-brand audit.
+
+## Phase 5 — Implement
 
 Edit `apps/kitchen-sink/src/sections/components.tsx`:
 
@@ -139,7 +173,7 @@ Edit `apps/kitchen-sink/src/sections/components.tsx`:
 - Update the `components.tsx` bullet in `apps/kitchen-sink/AGENTS.md` to list
   what's now shown.
 
-## Phase 5 — Verify (build from dist + look at it)
+## Phase 6 — Verify (build from dist + look at it)
 
 The app imports the libraries by package name from their **built `dist`**, so
 build deps first:
@@ -161,7 +195,10 @@ pnpm --filter @acronis-platform/kitchen-sink exec vite preview --port 4180 &
 Open `http://localhost:4180/#components`, scroll to the changed sections, and
 screenshot (Chrome DevTools MCP, or manually). Confirm **light and dark** (the
 header toggle) — tokens are `light-dark()`, so a blank/oddly-colored cell in one
-scheme is the dead-token signature. Stop the preview when done.
+scheme is the dead-token signature — and switch to at least one **non-default
+brand** (the brand `<select>`): the components should re-theme (override-only, so
+some variants legitimately stay put), and switching back to `acronis` clears it.
+Stop the preview when done.
 
 ## Output checklist (done = all green)
 
@@ -170,9 +207,12 @@ scheme is the dead-token signature. Stop the preview when done.
       optional content-slot props (`label` / `description` / `icon` / `render`).
 - [ ] Every hardcoded `--ui-*` ref resolves against the current tier; each used
       tier is imported in `tokens.ts`.
+- [ ] Every brand tokens-pd ships is selectable (the `Brand` union, `applyBrand`'s
+      override blob, and the `App.tsx` `<select>` all agree with `css/*.css`).
 - [ ] `AGENTS.md` component list updated.
 - [ ] typecheck · lint · build pass (deps built first).
-- [ ] Visually verified in the browser, light **and** dark.
+- [ ] Visually verified in the browser — light **and** dark, default brand **and**
+      at least one override brand.
 
 ## Notes
 

--- a/apps/kitchen-sink/AGENTS.md
+++ b/apps/kitchen-sink/AGENTS.md
@@ -61,7 +61,8 @@ delivery model differs from the retired `design-theme`:
   `SECTIONS` in `App.tsx`) so it can be re-enabled if a base element layer ships.
 - `components.tsx` — the implemented `ui-react` components: `Button`
   (variants/sizes/states/with-icons), `ButtonIcon`, `Switch`, `Checkbox`,
-  `Radio`, `Input`, `Search`, `Select`, and `Breadcrumb`.
+  `Radio`, `Input`, `Search`, `Select`, `Breadcrumb`, `Tag`, `Tooltip`, and
+  `SidebarPrimary` / `SidebarSecondary`.
 - `icons.tsx` — galleries for all four `icons-react` packs.
 
 ## Run

--- a/apps/kitchen-sink/AGENTS.md
+++ b/apps/kitchen-sink/AGENTS.md
@@ -40,8 +40,9 @@ delivery model differs from the retired `design-theme`:
   by `ui-react/styles`, so `tokens.ts` imports the `css/<component>/acronis.css`
   files and injects them once (needed both to render components and to enumerate
   their names).
-- **Brand switching** injects `brand-b`'s _override-only_ `:root` stylesheet
-  (`applyBrand`) — it is not a class toggle.
+- **Brand switching** injects `deep-sky`'s _override-only_ `:root` stylesheets
+  (semantic + per-component) on top of the acronis base via `applyBrand` — it is
+  not a class toggle. The header's brand `<select>` (`App.tsx`) drives it.
 - **Light/dark** flips `color-scheme` (drives the tokens' `light-dark()`) and
   mirrors `[data-theme]` for ui-react's `dark:` variant (`applyTheme`) — it is
   not a `.dark` class.

--- a/apps/kitchen-sink/src/App.tsx
+++ b/apps/kitchen-sink/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ReactNode } from 'react';
 
-import { applyTheme, type ColorMode } from '@/lib/tokens';
+import { applyBrand, applyTheme, type Brand, type ColorMode } from '@/lib/tokens';
 import { ColorsSection } from '@/sections/colors';
 import { ComponentsSection } from '@/sections/components';
 import { IconsSection } from '@/sections/icons';
@@ -60,11 +60,17 @@ const MAIN_CONTENT_PADDING_BOTTOM = 96;
 
 export default function App() {
   const [mode, setMode] = useState<ColorMode>('light');
+  const [brand, setBrand] = useState<Brand>('acronis');
 
   // Light/dark drives the tokens' `light-dark()` via `color-scheme`.
   useEffect(() => {
     applyTheme(mode);
   }, [mode]);
+
+  // Brand layers deep-sky's `:root` overrides on top of the acronis base.
+  useEffect(() => {
+    applyBrand(brand);
+  }, [brand]);
 
   return (
     <div
@@ -103,6 +109,22 @@ export default function App() {
             </a>
           ))}
         </nav>
+        <select
+          value={brand}
+          onChange={(e) => setBrand(e.target.value as Brand)}
+          aria-label="Brand"
+          style={{
+            padding: '6px 10px',
+            borderRadius: 6,
+            cursor: 'pointer',
+            border: '1px solid var(--ui-border-on-surface-border)',
+            background: 'var(--ui-background-surface-secondary)',
+            color: 'inherit',
+          }}
+        >
+          <option value="acronis">Acronis</option>
+          <option value="deep-sky">Deep Sky</option>
+        </select>
         <button
           type="button"
           onClick={() => setMode((m) => (m === 'light' ? 'dark' : 'light'))}

--- a/apps/kitchen-sink/src/lib/tokens.ts
+++ b/apps/kitchen-sink/src/lib/tokens.ts
@@ -7,10 +7,12 @@
  * files (`css/<component>/acronis.css`), so we load those here — both to render
  * the components correctly and to enumerate their `--ui-<component>-*` names.
  *
- * acronis is the only brand: its semantic tokens are the base layer (no
- * override stylesheet). Light/dark is driven by the tokens' `light-dark()` +
- * `color-scheme`, so we flip `color-scheme` (and mirror `[data-theme]` for
- * ui-react's `dark:` variant).
+ * Two brands ship: `acronis` (the base layer — its semantic tokens are loaded by
+ * ui-react/styles, per-component ones injected here) and `deep-sky` (an
+ * override-only layer). Brand switching (`applyBrand`) injects/clears deep-sky's
+ * `:root` overrides on top of the base — it is not a class toggle. Light/dark is
+ * driven by the tokens' `light-dark()` + `color-scheme`, so we flip
+ * `color-scheme` (and mirror `[data-theme]` for ui-react's `dark:` variant).
  */
 
 // --- acronis: semantic is applied by ui-react/styles; we read it here only to
@@ -27,7 +29,22 @@ import switchAcronis from '@acronis-platform/tokens-pd/css/Switch/acronis.css?ra
 import tagAcronis from '@acronis-platform/tokens-pd/css/Tag/acronis.css?raw';
 import tooltipAcronis from '@acronis-platform/tokens-pd/css/Tooltip/acronis.css?raw';
 
+// --- deep-sky: override-only `:root` stylesheets, layered on the acronis base
+//     by `applyBrand`. One per tier (semantic + each component).
+import semanticDeepSky from '@acronis-platform/tokens-pd/css/deep-sky.css?raw';
+import breadcrumbDeepSky from '@acronis-platform/tokens-pd/css/Breadcrumb/deep-sky.css?raw';
+import buttonDeepSky from '@acronis-platform/tokens-pd/css/Button/deep-sky.css?raw';
+import buttonIconDeepSky from '@acronis-platform/tokens-pd/css/ButtonIcon/deep-sky.css?raw';
+import checkboxDeepSky from '@acronis-platform/tokens-pd/css/Checkbox/deep-sky.css?raw';
+import inputTextDeepSky from '@acronis-platform/tokens-pd/css/InputText/deep-sky.css?raw';
+import sidebarPrimaryDeepSky from '@acronis-platform/tokens-pd/css/SidebarPrimary/deep-sky.css?raw';
+import sidebarSecondaryDeepSky from '@acronis-platform/tokens-pd/css/SidebarSecondary/deep-sky.css?raw';
+import switchDeepSky from '@acronis-platform/tokens-pd/css/Switch/deep-sky.css?raw';
+import tagDeepSky from '@acronis-platform/tokens-pd/css/Tag/deep-sky.css?raw';
+import tooltipDeepSky from '@acronis-platform/tokens-pd/css/Tooltip/deep-sky.css?raw';
+
 export type ColorMode = 'light' | 'dark';
+export type Brand = 'acronis' | 'deep-sky';
 
 /** A row of tokens that share a role (paints `bg` / `text` / `border` / …). */
 export interface RoleGroup {
@@ -475,6 +492,43 @@ export function applyTheme(mode: ColorMode): void {
   const html = document.documentElement;
   html.dataset.theme = mode;
   html.style.colorScheme = mode;
+}
+
+const BRAND_OVERRIDE_STYLE_ID = 'ks-brand-override';
+
+/** deep-sky override CSS (semantic + every per-component tier), concatenated. */
+const DEEP_SKY_OVERRIDES = [
+  semanticDeepSky,
+  breadcrumbDeepSky,
+  buttonDeepSky,
+  buttonIconDeepSky,
+  checkboxDeepSky,
+  inputTextDeepSky,
+  sidebarPrimaryDeepSky,
+  sidebarSecondaryDeepSky,
+  switchDeepSky,
+  tagDeepSky,
+  tooltipDeepSky,
+].join('\n');
+
+/**
+ * Switch brand by layering deep-sky's override-only `:root` tokens on top of the
+ * acronis base (not a class toggle). The override `<style>` is kept **last** in
+ * `<head>` so it wins the cascade over ui-react/styles + the component-token
+ * style; selecting `acronis` clears it back to the base.
+ */
+export function applyBrand(brand: Brand): void {
+  if (typeof document === 'undefined') return;
+  let el = document.getElementById(
+    BRAND_OVERRIDE_STYLE_ID
+  ) as HTMLStyleElement | null;
+  if (!el) {
+    el = document.createElement('style');
+    el.id = BRAND_OVERRIDE_STYLE_ID;
+  }
+  // Re-append so it stays after the base + component-token stylesheets.
+  document.head.appendChild(el);
+  el.textContent = brand === 'deep-sky' ? DEEP_SKY_OVERRIDES : '';
 }
 
 /**

--- a/apps/kitchen-sink/src/sections/components.tsx
+++ b/apps/kitchen-sink/src/sections/components.tsx
@@ -20,6 +20,27 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  SidebarPrimary,
+  SidebarPrimaryCollapseTrigger,
+  SidebarPrimaryContent,
+  SidebarPrimaryFooter,
+  SidebarPrimaryHeader,
+  SidebarPrimaryMenu,
+  SidebarPrimaryMenuItem,
+  SidebarPrimarySection,
+  SidebarSecondary,
+  SidebarSecondaryCollapseTrigger,
+  SidebarSecondaryContent,
+  SidebarSecondaryFooter,
+  SidebarSecondaryHeader,
+  SidebarSecondaryMenu,
+  SidebarSecondaryMenuItem,
+  SidebarSecondaryMenuSub,
+  SidebarSecondaryMenuSubContent,
+  SidebarSecondaryMenuSubItem,
+  SidebarSecondaryMenuSubTrigger,
+  SidebarSecondarySection,
+  SidebarSecondarySectionLabel,
   Switch,
   Tag,
   Tooltip,
@@ -27,8 +48,14 @@ import {
   TooltipTrigger,
 } from '@acronis-platform/ui-react';
 import {
+  BoxIcon,
   CircleCheckIcon,
+  CircleHelpIcon,
+  LayoutGridIcon,
+  PanelLeftIcon,
   PlusIcon,
+  ServerIcon,
+  UsersIcon,
 } from '@acronis-platform/icons-react/stroke-mono';
 
 type Variant =
@@ -397,6 +424,88 @@ export function ComponentsSection() {
             <TooltipContent side="bottom">Helpful hint</TooltipContent>
           </Tooltip>
         </Row>
+      </div>
+
+      <div>
+        <h3 style={{ marginBottom: 12 }}>Sidebars — primary &amp; secondary</h3>
+        {/* Sidebars fill their container height; bound them to a fixed shell. */}
+        <div style={{ display: 'flex', gap: 16, height: 440 }}>
+          <SidebarPrimary>
+            <SidebarPrimaryHeader>
+              <PlusIcon />
+            </SidebarPrimaryHeader>
+            <SidebarPrimaryContent>
+              <SidebarPrimarySection>
+                <SidebarPrimaryMenu>
+                  <SidebarPrimaryMenuItem href="#" icon={<BoxIcon />} selected>
+                    Assets
+                  </SidebarPrimaryMenuItem>
+                  <SidebarPrimaryMenuItem href="#" icon={<ServerIcon />}>
+                    Protection
+                  </SidebarPrimaryMenuItem>
+                  <SidebarPrimaryMenuItem href="#" icon={<UsersIcon />}>
+                    Clients
+                  </SidebarPrimaryMenuItem>
+                  <SidebarPrimaryMenuItem href="#" icon={<LayoutGridIcon />}>
+                    Automation
+                  </SidebarPrimaryMenuItem>
+                </SidebarPrimaryMenu>
+              </SidebarPrimarySection>
+            </SidebarPrimaryContent>
+            <SidebarPrimaryFooter>
+              <SidebarPrimaryMenu>
+                <SidebarPrimaryMenuItem href="#" icon={<CircleHelpIcon />}>
+                  Help
+                </SidebarPrimaryMenuItem>
+                <SidebarPrimaryCollapseTrigger icon={<PanelLeftIcon />}>
+                  Collapse menu
+                </SidebarPrimaryCollapseTrigger>
+              </SidebarPrimaryMenu>
+            </SidebarPrimaryFooter>
+          </SidebarPrimary>
+
+          <SidebarSecondary>
+            <SidebarSecondaryHeader label="Protection" />
+            <SidebarSecondaryContent>
+              <SidebarSecondarySection>
+                <SidebarSecondarySectionLabel>Overview</SidebarSecondarySectionLabel>
+                <SidebarSecondaryMenu>
+                  <SidebarSecondaryMenuItem href="#" icon={<LayoutGridIcon />} selected>
+                    Dashboard
+                  </SidebarSecondaryMenuItem>
+                  <SidebarSecondaryMenuItem href="#" icon={<ServerIcon />}>
+                    Devices
+                  </SidebarSecondaryMenuItem>
+                </SidebarSecondaryMenu>
+              </SidebarSecondarySection>
+              <SidebarSecondarySection>
+                <SidebarSecondarySectionLabel>Configuration</SidebarSecondarySectionLabel>
+                <SidebarSecondaryMenu>
+                  <SidebarSecondaryMenuSub defaultOpen>
+                    <SidebarSecondaryMenuSubTrigger icon={<BoxIcon />}>
+                      Policies
+                    </SidebarSecondaryMenuSubTrigger>
+                    <SidebarSecondaryMenuSubContent>
+                      <SidebarSecondaryMenuSubItem href="#" selected>
+                        Backup
+                      </SidebarSecondaryMenuSubItem>
+                      <SidebarSecondaryMenuSubItem href="#">
+                        Antivirus
+                      </SidebarSecondaryMenuSubItem>
+                    </SidebarSecondaryMenuSubContent>
+                  </SidebarSecondaryMenuSub>
+                </SidebarSecondaryMenu>
+              </SidebarSecondarySection>
+            </SidebarSecondaryContent>
+            <SidebarSecondaryFooter>
+              <SidebarSecondaryMenu>
+                <SidebarSecondaryCollapseTrigger icon={<PanelLeftIcon />}>
+                  Collapse menu
+                </SidebarSecondaryCollapseTrigger>
+              </SidebarSecondaryMenu>
+            </SidebarSecondaryFooter>
+          </SidebarSecondary>
+        </div>
       </div>
     </div>
   );

--- a/apps/kitchen-sink/src/sections/components.tsx
+++ b/apps/kitchen-sink/src/sections/components.tsx
@@ -88,10 +88,11 @@ const FOCUS_RING =
 // the matching next-gen `--ui-button-*` state tokens. Focus reuses the idle
 // colors and adds the design's focus ring. Idle/disabled render the real
 // component (idle untouched, disabled via the `disabled` prop) so its own
-// styling is exercised. The container fill is `--ui-button-<variant>-container-*`
-// (a gradient for `ai`); the border only exists for the `secondary`/`inverted`
-// variants (`-container-border-color-*`) — for the others the var is undefined,
-// so the declaration is ignored and the component's transparent border shows.
+// styling is exercised. The container fill is
+// `--ui-button-<variant>-container-color-*` (a gradient for `ai`); the border
+// only exists for the `secondary`/`inverted` variants (`-container-border-color-*`)
+// — for the others the var is undefined, so the declaration is ignored and the
+// component's transparent border shows.
 function forcedStyle(
   token: string,
   state: 'hover' | 'active' | 'focus',
@@ -99,9 +100,9 @@ function forcedStyle(
 ): CSSProperties {
   const cs = state === 'focus' ? 'idle' : state;
   const style: CSSProperties = gradient
-    ? { backgroundImage: `var(--ui-button-${token}-container-${cs})` }
-    : { backgroundColor: `var(--ui-button-${token}-container-${cs}, transparent)` };
-  style.color = `var(--ui-button-${token}-label-${cs})`;
+    ? { backgroundImage: `var(--ui-button-${token}-container-color-${cs})` }
+    : { backgroundColor: `var(--ui-button-${token}-container-color-${cs}, transparent)` };
+  style.color = `var(--ui-button-${token}-label-color-${cs})`;
   // Only `secondary`/`inverted` define a border token; for the others the var is
   // undefined and falls back to `transparent` (an undefined var in an inline
   // longhand would otherwise compute to `currentColor` and paint a stray border).
@@ -115,8 +116,8 @@ function forcedStyle(
 function forcedIconStyle(state: 'hover' | 'active' | 'focus'): CSSProperties {
   const cs = state === 'focus' ? 'idle' : state;
   const style: CSSProperties = {
-    backgroundColor: `var(--ui-button-icon-global-container-${cs})`,
-    color: `var(--ui-button-icon-global-icon-${cs})`,
+    backgroundColor: `var(--ui-button-icon-global-container-color-${cs})`,
+    color: `var(--ui-button-icon-global-icon-color-${cs})`,
   };
   if (state === 'focus') style.boxShadow = FOCUS_RING;
   return style;

--- a/apps/kitchen-sink/src/sections/components.tsx
+++ b/apps/kitchen-sink/src/sections/components.tsx
@@ -111,14 +111,24 @@ function forcedStyle(
   return style;
 }
 
-// ButtonIcon has a single (borderless) style under `--ui-button-icon-global-*`:
-// a transparent container fill and a per-state glyph color.
-function forcedIconStyle(state: 'hover' | 'active' | 'focus'): CSSProperties {
+// ButtonIcon shares one container/glyph color set under
+// `--ui-button-icon-global-*`; the `secondary` variant adds a 1px border
+// (`--ui-button-icon-secondary-container-border-color-*`). `ghost` (default) has
+// no border, so its border var is undefined and falls back to transparent.
+type IconVariant = 'ghost' | 'secondary';
+
+function forcedIconStyle(
+  state: 'hover' | 'active' | 'focus',
+  variant: IconVariant
+): CSSProperties {
   const cs = state === 'focus' ? 'idle' : state;
   const style: CSSProperties = {
     backgroundColor: `var(--ui-button-icon-global-container-color-${cs})`,
     color: `var(--ui-button-icon-global-icon-color-${cs})`,
   };
+  if (variant === 'secondary') {
+    style.borderColor = `var(--ui-button-icon-secondary-container-border-color-${cs}, transparent)`;
+  }
   if (state === 'focus') style.boxShadow = FOCUS_RING;
   return style;
 }
@@ -158,21 +168,26 @@ function ButtonCell({ variant, token, state }: { variant: Variant; token: string
   );
 }
 
-function ButtonIconCell({ state }: { state: State }) {
+const ICON_VARIANTS: { variant: IconVariant; label: string }[] = [
+  { variant: 'ghost', label: 'Ghost' },
+  { variant: 'secondary', label: 'Secondary' },
+];
+
+function ButtonIconCell({ variant, state }: { variant: IconVariant; state: State }) {
   if (state === 'idle')
     return (
-      <ButtonIcon aria-label="Add">
+      <ButtonIcon variant={variant} aria-label="Add">
         <PlusIcon />
       </ButtonIcon>
     );
   if (state === 'disabled')
     return (
-      <ButtonIcon aria-label="Add" disabled>
+      <ButtonIcon variant={variant} aria-label="Add" disabled>
         <PlusIcon />
       </ButtonIcon>
     );
   return (
-    <ButtonIcon aria-label="Add" style={forcedIconStyle(state)}>
+    <ButtonIcon variant={variant} aria-label="Add" style={forcedIconStyle(state, variant)}>
       <PlusIcon />
     </ButtonIcon>
   );
@@ -234,7 +249,7 @@ export function ComponentsSection() {
       </div>
 
       <div>
-        <h3 style={{ marginBottom: 12 }}>ButtonIcon — states</h3>
+        <h3 style={{ marginBottom: 12 }}>ButtonIcon — styles × states</h3>
         <div
           style={{
             display: 'grid',
@@ -244,11 +259,15 @@ export function ComponentsSection() {
           }}
         >
           <ColumnHeaders />
-          <span style={{ fontSize: 13, color: 'var(--ui-text-on-surface-primary)' }}>
-            Default
-          </span>
-          {STATES.map((state) => (
-            <ButtonIconCell key={state} state={state} />
+          {ICON_VARIANTS.map((v) => (
+            <Fragment key={v.variant}>
+              <span style={{ fontSize: 13, color: 'var(--ui-text-on-surface-primary)' }}>
+                {v.label}
+              </span>
+              {STATES.map((state) => (
+                <ButtonIconCell key={state} variant={v.variant} state={state} />
+              ))}
+            </Fragment>
           ))}
         </div>
       </div>
@@ -273,6 +292,11 @@ export function ComponentsSection() {
           <Switch aria-label="Disabled off" disabled />
           <Switch aria-label="Disabled on" disabled defaultChecked />
         </Row>
+        <Row label="With label">
+          <Switch label="Notifications" />
+          <Switch label="Auto-update" defaultChecked />
+          <Switch label="Disabled" disabled defaultChecked />
+        </Row>
       </div>
 
       <div>
@@ -284,6 +308,19 @@ export function ComponentsSection() {
           <Checkbox aria-label="Disabled" disabled />
           <Checkbox aria-label="Disabled checked" disabled defaultChecked />
         </Row>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 12 }}>
+          <span style={{ fontSize: 12, color: 'var(--ui-text-on-surface-secondary)' }}>
+            With label &amp; description
+          </span>
+          <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'flex-start', gap: 24 }}>
+            <Checkbox label="Email notifications" />
+            <Checkbox label="Auto-renew" defaultChecked />
+            <Checkbox
+              label="Share usage data"
+              description="Anonymous analytics to help improve the product."
+            />
+          </div>
+        </div>
       </div>
 
       <div>
@@ -403,6 +440,7 @@ export function ComponentsSection() {
             <Tag variant="critical">Critical</Tag>
             <Tag variant="danger">Danger</Tag>
             <Tag variant="neutral">Neutral</Tag>
+            <Tag variant="ai">AI</Tag>
           </Row>
           <Row label="Sizes & icon">
             <Tag variant="success" icon={<CircleCheckIcon />}>


### PR DESCRIPTION
Brings the kitchen-sink up to a complete, faithful visual reference for `@acronis-platform/ui-react`, and adds a skill to keep it that way.

## Component coverage
- **Added the missing components** — `SidebarPrimary` and `SidebarSecondary` (their token tiers were already injected; just unrendered).
- **Filled under-represented props/variants** found by the new skill's audit:
  - `ButtonIcon` — added the `secondary` variant (was ghost-only).
  - `Switch` — added a "With label" row (the `label` prop).
  - `Checkbox` — added a "With label & description" row.
  - `Tag` — added the `ai` variant (merged via #305).

## Fixes
- **Button / ButtonIcon state matrices rendered blank cells** — the `forcedStyle`/`forcedIconStyle` helpers hardcoded the pre-`-color-` token names (`--ui-button-primary-container-idle` → `…-container-color-idle`). `var(--missing)` fails silently, so hover/active/focus cells lost their fill. Re-wired to the current tier names.

## Brand switching (restored)
- tokens-pd now ships two brands — `acronis` (base) + `deep-sky` (override-only). `tokens.ts` had been reduced to acronis-only and the old wiring referenced the dropped `brand-b`. Added `applyBrand()` (layers deep-sky's `:root` overrides last in `<head>`, clears for acronis) and a header brand `<select>` in `App.tsx`. Composes with the existing light/dark toggle.

## New skill — `/kitchen-sink-sync`
`.claude/skills/kitchen-sink-sync/` — a repeatable audit + fix loop that catches exactly the two drifts above: (1) exports vs. rendered-components diff, (2) per-component cva variants / states / **content-slot props** (`label`/`description`/`icon`), and (3) a token-resolution check (every hardcoded `--ui-*` ref must resolve against the current tier — the silent failure mode). Verifies by building from dist + visual check in light **and** dark.

## Verification
- typecheck · lint · build pass (kitchen-sink + deps).
- Visually verified every changed section in the browser, **light and dark**, plus the **deep-sky brand** (Primary → slate `rgb(68 81 93)`, matching the token; override-only variants like Destructive/AI correctly unchanged).

Private app — no changeset, no VR baselines.