### PR TITLE
test(icons-react): fix packs test for renamed multi icons

### DIFF
--- a/packages/icons-react/src/__tests__/packs.test.tsx
+++ b/packages/icons-react/src/__tests__/packs.test.tsx
@@ -2,8 +2,8 @@ import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import { BrandAcronisIcon } from '../packs/solid-mono';
-import { CircleCheckColorIcon } from '../packs/stroke-multi';
-import { SparklesColorIcon } from '../packs/solid-multi';
+import { CircleCheckMultiIcon } from '../packs/stroke-multi';
+import { SparklesMultiIcon } from '../packs/solid-multi';
 
 function svgOf(container: HTMLElement): SVGSVGElement {
   const svg = container.querySelector('svg');
@@ -23,7 +23,7 @@ describe('solid-mono pack', () => {
 
 describe('multicolor packs keep authored colors', () => {
   it('stroke-multi preserves per-path colors but takes stroke width from rules', () => {
-    const svg = svgOf(render(<CircleCheckColorIcon size={16} />).container);
+    const svg = svgOf(render(<CircleCheckMultiIcon size={16} />).container);
     expect(svg).toHaveAttribute('fill', 'none');
     expect(svg).not.toHaveAttribute('stroke'); // not forced to currentColor
     expect(svg).toHaveAttribute('stroke-width', '2.4'); // rule-driven at 16px
@@ -34,7 +34,7 @@ describe('multicolor packs keep authored colors', () => {
   });
 
   it('solid-multi preserves gradients with namespaced ids', () => {
-    const svg = svgOf(render(<SparklesColorIcon />).container);
+    const svg = svgOf(render(<SparklesMultiIcon />).container);
     const gradientId = svg.querySelector('linearGradient')?.id;
     // ids are namespaced per-icon so gradients can't collide across icons.
     expect(gradientId).toMatch(/^sparkles-/);


### PR DESCRIPTION
## Problem

CI `pnpm -r typecheck` fails in `icons-react`:

```
src/__tests__/packs.test.tsx(5,10): error TS2724: '"../packs/stroke-multi"' has no exported member named 'CircleCheckColorIcon'. Did you mean 'CircleCheckMultiIcon'?
src/__tests__/packs.test.tsx(6,10): error TS2305: Module '"../packs/solid-multi"' has no exported member 'SparklesColorIcon'.
```

The icon-set sync (#3086a83e, *"add new multi-colored icons and update existing icon references"*) renamed the multicolor exports `*ColorIcon` → `*MultiIcon`, but `packs.test.tsx` still imported the old names. It's on `main`, so it reddens CI on every open PR.

## Fix

Update the test's imports + usages: `CircleCheckColorIcon` → `CircleCheckMultiIcon` (stroke-multi), `SparklesColorIcon` → `SparklesMultiIcon` (solid-multi). Test-only; no change to generated/published output.

## Verification

- `pnpm --filter @acronis-platform/icons-react typecheck` ✓
- `pnpm --filter @acronis-platform/icons-react test` — 14/14 pass (the color `#29a33d`/`#248f36`/`#fff` and `sparkles-` gradient-id assertions still hold after the re-sync)
- `pnpm -r typecheck` green end-to-end

No changeset — test files aren't shipped, so there's no consumer-facing change.