### PR TITLE
feat(skills): add component-readiness gate + fix surfaced spec token drift

### DIFF
--- a/.claude/skills/component-readiness/SKILL.md
+++ b/.claude/skills/component-readiness/SKILL.md
@@ -6,8 +6,10 @@ description: >
   that every --ui-* reference resolves in tokens-pd, that each referenced token
   tier is imported in styles/index.css, that the ui-spec 7-file set is present and
   conformance passes, that tests exist, and that the Figma link is intact
-  (index.yaml node + a COMPLETE Code Connect) — plus a live design-parity diff
-  (variants/states/tokens vs. the Figma node) via the Figma MCP. Reports a
+  (index.yaml node + a COMPLETE Code Connect). A deep mode adds Figma design
+  parity: structural (variants/states), value-level (each design variable's value
+  == the referenced --ui-* token's resolved value), and an advisory screenshot
+  pixel-diff — via the Figma MCP + bundled scripts. Reports a
   READY / DRIFT / INCOMPLETE matrix; never edits files. Invoke with
   /component-readiness [ComponentName | all].
 argument-hint: '[ComponentName | all]'
@@ -128,6 +130,42 @@ Diff the design against the implementation and report mismatches (do not fix her
   unwired, no hardcoded value substituted.
 - **Code Connect** — `figma.enum(...)` property names equal the design's exact
   property names (run `figma:connect` to validate).
+
+### Value-level parity — `scripts/parity-values.mjs`
+
+Confirms each design variable's **value** equals the resolved value of the
+`--ui-*` token the component references (not just that a token is wired). Save the
+MCP output and run the (dependency-free) comparator:
+
+```bash
+# 1. agent: dump the node's design variables to JSON (node must be selected in Figma desktop)
+#    get_variable_defs({ nodeId, fileKey })  →  save as figma-vars.json
+# 2. compare against tokens-pd resolved values:
+node .claude/skills/component-readiness/scripts/parity-values.mjs <Component> figma-vars.json [--theme light|dark] [--brand acronis]
+```
+
+It maps each Figma variable name → `--ui-*` token (Option-A kebab), then reports
+`MATCH` / `VALUE-DIFF` (name-paired, **exit 1**) and `MISSING` (a design value no
+referenced token carries — advisory, may be out of the component's scope). Colors
+are compared alpha-aware (`#191B23E5` ≡ `rgb(25 27 35 / 0.898)`); dimensions by
+number (`12` ≡ `12px`).
+
+### Visual parity — `scripts/parity-image.mjs` (advisory)
+
+Pixel-diffs a Figma node screenshot against a Storybook render and writes a
+highlighted diff PNG:
+
+```bash
+# 1. agent: capture the node image via the Figma MCP (get_screenshot / get_design_context) → figma.png
+# 2. storybook render: a committed VR baseline works, or a fresh Playwright capture
+node .claude/skills/component-readiness/scripts/parity-image.mjs figma.png \
+  packages/ui-react/test/__snapshots__/ui-<name>--default.png --out parity-diff.png
+```
+
+Reuses `pixelmatch` + `pngjs` from the pnpm store (no new deps); resizes the
+Storybook image to the Figma dims before diffing. **Advisory only** — the two
+aren't pixel-aligned (framing/scale differ), so the % is a delta signal; read the
+diff PNG. Crop the Storybook capture to just the component for the cleanest result.
 
 > **Selection-bound caveat (same as `/figma-component` Phase 1):** the Figma MCP
 > in this setup rejects reads with "nothing selected" even given a valid

--- a/.claude/skills/component-readiness/SKILL.md
+++ b/.claude/skills/component-readiness/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: component-readiness
+description: >
+  Read-only pre-flight gate that audits ui-react components for token drift and
+  spec/test completeness BEFORE running /figma-component. Per component it checks
+  that every --ui-* reference resolves in tokens-pd, that each referenced token
+  tier is imported in styles/index.css, that the ui-spec 7-file set is present and
+  conformance passes, that tests exist, and that the Figma link is intact
+  (index.yaml node + a COMPLETE Code Connect) — plus a live design-parity diff
+  (variants/states/tokens vs. the Figma node) via the Figma MCP. Reports a
+  READY / DRIFT / INCOMPLETE matrix; never edits files. Invoke with
+  /component-readiness [ComponentName | all].
+argument-hint: '[ComponentName | all]'
+---
+
+# Skill: /component-readiness
+
+A **read-only gate**. Run it **before** [`/figma-component`](../figma-component/SKILL.md)
+(especially before an `--update`) to learn, per component, whether it is safe to
+build on or is silently drifted. It produces a status matrix and a verdict — it
+**does not edit anything**. Fixes are done by `/figma-component` or by the agent
+afterward.
+
+Why this exists: a `var(--ui-does-not-exist)` reference is a **silent** failure —
+it makes the CSS property invalid and the element falls back to inherited values;
+nothing fails the build, typecheck, lint, or `ui-spec test`. A token-sync (e.g.
+`/figma-to-design-tokens`) can rename or remove tokens out from under a shipped
+component, and the conformance test only regexes token **names**, never checks
+they **exist** in `tokens-pd` (the gap tracked in issue #297). This gate closes
+that gap.
+
+Read the workspace contracts first — they override anything here on conflict:
+
+- [packages/ui-react/AGENTS.md](../../../packages/ui-react/AGENTS.md) +
+  [context/conventions.md](../../../packages/ui-react/context/conventions.md)
+- [packages/ui-spec/AGENTS.md](../../../packages/ui-spec/AGENTS.md)
+
+Related: [`/kitchen-sink-sync`](../kitchen-sink-sync/SKILL.md) verifies token
+resolution for the kitchen-sink showcase; this skill is the per-component
+pre-build gate. The token-resolution discipline mirrors `/figma-component` Phase 2.
+
+---
+
+## Invocation
+
+```
+/component-readiness [ComponentName | all]
+```
+
+| Arg             | Meaning                                                                    |
+| --------------- | -------------------------------------------------------------------------- |
+| `ComponentName` | One component — PascalCase (`InputTextArea`) or kebab (`input-text-area`). |
+| `all`           | Every component under `packages/ui-react/src/components/ui/` (default).    |
+
+---
+
+## What it checks (per component)
+
+| Column      | Check                                                                                                                                                                                                                                                                                                       | Blocking?                      |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| **TOKENS**  | Every `--ui-*` referenced in the component's code (`.tsx`/`.ts`: `var(--ui-*)` bindings, test/story class assertions) **and** in its `ui-spec` YAML (`tokens.yaml`, `anatomy.yaml`) resolves to a token defined in `packages/tokens-pd/css/**`.                                                             | **Yes** → DRIFT                |
+| **IMPORTS** | Every component **tier** whose tokens it references (e.g. `--ui-radio-*` → `Radio`) is `@import`-ed in `packages/ui-react/src/styles/index.css`. Component tiers are **opt-in**; a missing import means the tokens are undefined at runtime even though they exist in `tokens-pd`.                          | **Yes** → DRIFT                |
+| **SPEC**    | The `ui-spec` 7-file set is present (`index.yaml`, `anatomy.yaml`, `api.yaml`, `tokens.yaml`, `behavior.md`, `accessibility.md`, `README.md`).                                                                                                                                                              | No → INCOMPLETE                |
+| **TESTS**   | `__tests__/<name>.test.tsx` exists.                                                                                                                                                                                                                                                                         | No → INCOMPLETE                |
+| **FIGMA**   | **Linkage parity:** `index.yaml` has a `figma.node` **and** a `<name>.figma.tsx` marked `COMPLETE` whose `figma.codeConnect` path resolves. Values: `LINKED` / `DRAFT` (Code Connect unfinished) / `PARTIAL` (one side missing/broken) / `NONE`. The script surfaces both node IDs for the live diff below. | No → INCOMPLETE (NONE/PARTIAL) |
+
+> **Node IDs are not equality-checked.** The spec's `figma.node` is often the
+> component-**set** frame while Code Connect targets a specific **variant** node
+> (e.g. Button: spec `1173-2789`, Code Connect `2236-5696`) — both are correct.
+
+**Non-blocking advisory:** stale `--ui-*` token names mentioned in spec **prose**
+(`behavior.md` etc.) that no longer resolve are reported but do **not** fail the
+gate (prose is documentation, not a live binding) — clean them during an update.
+
+---
+
+## Run it
+
+**1. Static pass (fast, no build)** — the bundled script does the token / import /
+spec-files / tests / Code-Connect checks and prints the matrix:
+
+```bash
+bash .claude/skills/component-readiness/scripts/audit.sh all          # or a single component
+bash .claude/skills/component-readiness/scripts/audit.sh InputTextArea
+```
+
+**2. Dynamic checks (run for the target component, or repo-wide before a release).**
+The static pass confirms files _exist_; these confirm they _pass_:
+
+```bash
+pnpm --filter @acronis-platform/ui-react exec vitest run src/components/ui/<name>   # unit tests
+pnpm --filter @acronis-platform/ui-react typecheck
+pnpm --filter @acronis-platform/ui-react lint
+pnpm --filter @acronis-platform/ui-spec test            # schema + cva conformance (all specs)
+pnpm --filter @acronis-platform/ui-react exec figma:connect   # Code Connect validity (optional)
+```
+
+---
+
+## Figma design parity (live — agent step)
+
+The static `FIGMA` column only proves the **link exists**. True conformity — that
+the implemented variants, states, geometry, and tokens still match the design —
+requires reading the node. The script prints the node IDs to diff; the agent then
+compares against the design via the Figma MCP (same tools as `/figma-component`
+Phase 1):
+
+```
+get_context_for_code_connect({ nodeId, fileKey })   # exact variant / prop names + options
+get_variable_defs({ nodeId, fileKey })              # the --ui-* / design vars the node uses
+get_design_context({ nodeId, fileKey })             # states + part structure (+ screenshot)
+```
+
+`fileKey` is in the `.figma.tsx` connect URL (`figma.com/design/:fileKey/…`); use
+the **Code Connect** node ID (the specific variant) for `get_context_for_code_connect`.
+
+Diff the design against the implementation and report mismatches (do not fix here):
+
+- **Variants / sizes** — every Figma variant option maps to a `cva` key + an
+  `api.yaml` enum value, and vice-versa (no design variant missing in code, no code
+  variant absent from the design). This is the parity the `cva`↔`api.yaml`
+  conformance test can't see across the Figma boundary.
+- **States** — interaction states (`hover`/`active`/`focus`/`disabled`) and
+  structural distinctions (e.g. "current page") are represented per
+  `anatomy.yaml` (states vs. parts).
+- **Tokens** — each design variable the node uses (`component/<x>/<y>`) has a
+  matching `--ui-<x>-<y>` token the component references — no design token left
+  unwired, no hardcoded value substituted.
+- **Code Connect** — `figma.enum(...)` property names equal the design's exact
+  property names (run `figma:connect` to validate).
+
+> **Selection-bound caveat (same as `/figma-component` Phase 1):** the Figma MCP
+> in this setup rejects reads with "nothing selected" even given a valid
+> `nodeId`/`fileKey`. Ask the user to open the node URL in the Figma **desktop**
+> app and click the layer, then retry. If Figma is unavailable, report `FIGMA`
+> linkage status from the static pass and note the live diff was skipped.
+
+---
+
+## Verdict → gate decision
+
+| Verdict        | Meaning                                                                           | Action before `/figma-component`                                                                                                               |
+| -------------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **READY**      | No token drift; spec + tests present.                                             | Proceed.                                                                                                                                       |
+| **DRIFT**      | A `--ui-*` ref doesn't resolve, or a tier isn't imported. **Will render broken.** | **Fix first.** Rewire dead token names to the current `tokens-pd` tier; add the missing `@import` to `styles/index.css`. Then re-run the gate. |
+| **INCOMPLETE** | Renders fine, but the spec or tests are missing.                                  | Safe to build; close the gap in the same change (`/figma-component` Phases 3–4 produce these).                                                 |
+
+For a **`--update`** run of `/figma-component`, a `READY` verdict on the target
+component means you're refreshing a sound baseline; a `DRIFT` verdict means the
+update must include the rewire, not just the design refresh.
+
+---
+
+## Discipline
+
+- **Read-only.** This skill never edits files. If it finds DRIFT, hand the fix to
+  `/figma-component` or apply it directly — then re-run the gate to confirm green.
+- **Resolution is union-of-brands.** A token counts as defined if any brand CSS in
+  `tokens-pd/css/**` defines it (`acronis` is primary). Per-brand gaps are out of
+  scope here.
+- **Dynamic prefixes are ignored.** Refs built by string concat
+  (`var(--ui-button-${variant}-…)`) end in `-` and are skipped — the script can't
+  resolve a runtime-constructed name, and they aren't literal danglers.

--- a/.claude/skills/component-readiness/scripts/audit.sh
+++ b/.claude/skills/component-readiness/scripts/audit.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# Component readiness audit for @acronis-platform/ui-react.
+#
+# Static (no-build) pre-flight checks run BEFORE /figma-component. Read-only —
+# never edits files. Prints a per-component matrix + verdict.
+#
+# Usage:
+#   bash .claude/skills/component-readiness/scripts/audit.sh [ComponentName | kebab-name | all]
+#
+# Columns:
+#   TOKENS    every --ui-* ref (.tsx + tests + stories + spec) resolves in tokens-pd
+#   IMPORTS   every referenced component tier is @import-ed in ui-react styles/index.css
+#   SPEC      ui-spec 7-file set present
+#   TESTS     __tests__/<name>.test.tsx present
+#   CODECONN  <name>.figma.tsx present + marked COMPLETE
+#   VERDICT   READY | DRIFT (token/import failure) | INCOMPLETE (spec/tests/CC gap)
+#
+# The dynamic checks (vitest run, typecheck, lint, `ui-spec test` conformance) are
+# slower and run by the caller per SKILL.md — this script does the fast static pass.
+
+# Note: no `set -e` — grep/comm return non-zero on "no match", which is expected here.
+set -uo pipefail
+
+ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT" || exit 1
+
+UI=packages/ui-react/src/components/ui
+SPEC=packages/ui-spec/components
+TOKENS=packages/tokens-pd/css
+STYLES=packages/ui-react/src/styles/index.css
+
+to_kebab() { printf '%s' "$1" | sed -E 's/([a-z0-9])([A-Z])/\1-\2/g' | tr '[:upper:]' '[:lower:]'; }
+
+arg="${1:-all}"
+if [ "$arg" = "all" ]; then
+  comps=$(ls "$UI")
+else
+  comps=$(to_kebab "$arg")
+fi
+
+# Every --ui-* token DEFINED in tokens-pd (union across tiers + brands).
+defined="$(mktemp)"
+grep -rho -- '--ui-[a-z0-9-]*' "$TOKENS" | sort -u > "$defined"
+
+fail=0
+printf '%-22s %-7s %-8s %-8s %-6s %-8s %s\n' COMPONENT TOKENS IMPORTS SPEC TESTS FIGMA VERDICT
+printf '%-22s %-7s %-8s %-8s %-6s %-8s %s\n' "----------------------" "------" "-------" "-------" "-----" "-------" "-------"
+
+for c in $comps; do
+  if [ ! -d "$UI/$c" ]; then
+    echo "$c: no such component dir under $UI"
+    fail=1
+    continue
+  fi
+
+  # ---- TOKENS: dangling refs in LIVE bindings only ----
+  # Blocking scan = code (.tsx/.ts: var(--ui-*) bindings + test/story assertions)
+  # + spec YAML (tokens.yaml is the canonical name list; anatomy.yaml schematic).
+  # Prose (.md) is intentionally excluded — a stale token *name* in behavior.md is
+  # doc drift, not a render-breaking ref; it surfaces below as a non-blocking note.
+  refs="$(mktemp)"
+  { grep -rho --include='*.tsx' --include='*.ts' -- '--ui-[a-z0-9-]*' "$UI/$c" 2>/dev/null
+    grep -rho --include='*.yaml' -- '--ui-[a-z0-9-]*' "$SPEC/$c" 2>/dev/null
+  } | grep -v -- '-$' | sort -u > "$refs"
+  dangling="$(comm -23 "$refs" "$defined")"
+  if [ -z "$dangling" ]; then tok=PASS; else tok=FAIL; fi
+
+  # Non-blocking: stale token names mentioned in spec prose (.md) that no longer resolve.
+  prose_refs="$(grep -rho --include='*.md' -- '--ui-[a-z0-9-]*' "$SPEC/$c" 2>/dev/null \
+                | grep -v -- '-$' | sort -u)"
+  prose_stale="$(comm -23 <(printf '%s\n' "$prose_refs" | sort -u) "$defined" 2>/dev/null)"
+
+  # ---- IMPORTS: each referenced component tier is imported in styles/index.css ----
+  miss_imp=""
+  while read -r t; do
+    [ -z "$t" ] && continue
+    tier="$(grep -rl -- "$t:" "$TOKENS"/*/acronis.css 2>/dev/null | head -1 \
+            | sed -E "s|$TOKENS/([^/]+)/acronis.css|\1|")"
+    [ -z "$tier" ] && continue   # base/shared token (css/acronis.css) — always imported
+    grep -qF "css/$tier/acronis.css" "$STYLES" || miss_imp="$miss_imp $tier"
+  done < "$refs"
+  miss_imp="$(printf '%s' "$miss_imp" | tr ' ' '\n' | sort -u | tr '\n' ' ' | sed 's/^ *//;s/ *$//')"
+  if [ -z "$miss_imp" ]; then imp=PASS; else imp=FAIL; fi
+
+  # ---- SPEC: 7-file set present ----
+  spec_missing=""
+  if [ -d "$SPEC/$c" ]; then
+    for f in index.yaml anatomy.yaml api.yaml tokens.yaml behavior.md accessibility.md README.md; do
+      [ -f "$SPEC/$c/$f" ] || spec_missing="$spec_missing $f"
+    done
+    if [ -z "$spec_missing" ]; then spec=PASS; else spec=PARTIAL; fi
+  else
+    spec=NONE
+  fi
+
+  # ---- TESTS presence ----
+  if [ -f "$UI/$c/__tests__/$c.test.tsx" ]; then tst=PASS; else tst=NONE; fi
+
+  # ---- FIGMA: linkage parity (static) ----
+  # Both sides of the design link must exist and agree structurally:
+  #   index.yaml `figma.node` + `figma.codeConnect` ↔ a COMPLETE <name>.figma.tsx.
+  # Node IDs are surfaced (not equality-checked) — the spec node is often the
+  # component-set frame while Code Connect targets a specific variant; the live
+  # design comparison is an agent MCP step (see SKILL.md §Figma design parity).
+  idx="$SPEC/$c/index.yaml"
+  ff="$UI/$c/$c.figma.tsx"
+  fig_node=""; cc_path=""
+  if [ -f "$idx" ]; then
+    fig_node="$(grep -E '^[[:space:]]+node:' "$idx" 2>/dev/null | head -1 \
+                | sed -E "s/.*node:[[:space:]]*['\"]?([0-9:-]+)['\"]?.*/\1/")"
+    cc_path="$(grep -E '^[[:space:]]+codeConnect:' "$idx" 2>/dev/null | head -1 \
+                | sed -E 's/.*codeConnect:[[:space:]]*//; s/[[:space:]]*$//')"
+  fi
+  cc_node="$(grep -oE 'node-id=[0-9-]+' "$ff" 2>/dev/null | head -1 | sed 's/node-id=//')"
+  if [ ! -f "$ff" ] && [ -z "$fig_node" ]; then
+    fig=NONE
+  elif [ ! -f "$ff" ] || [ -z "$fig_node" ]; then
+    fig=PARTIAL                                   # only one side of the link exists
+  elif ! grep -q COMPLETE "$ff"; then
+    fig=DRAFT                                      # Code Connect not finalized
+  elif [ -n "$cc_path" ] && [ ! -f "$cc_path" ]; then
+    fig=PARTIAL                                    # index.yaml codeConnect path is broken
+  else
+    fig=LINKED
+  fi
+
+  # ---- VERDICT ----
+  if [ "$tok" = FAIL ] || [ "$imp" = FAIL ]; then
+    verdict="DRIFT"; fail=1
+  elif [ "$spec" != PASS ] || [ "$tst" != PASS ] || [ "$fig" = NONE ] || [ "$fig" = PARTIAL ]; then
+    verdict="INCOMPLETE"
+  else
+    verdict="READY"
+  fi
+
+  printf '%-22s %-7s %-8s %-8s %-6s %-8s %s\n' "$c" "$tok" "$imp" "$spec" "$tst" "$fig" "$verdict"
+  [ -n "$dangling" ]      && echo "    ↳ dangling tokens: $(printf '%s' "$dangling" | tr '\n' ' ')"
+  [ -n "$miss_imp" ]      && echo "    ↳ missing tier imports (add to $STYLES): $miss_imp"
+  [ "$spec" = PARTIAL ]   && echo "    ↳ missing spec files:$spec_missing"
+  [ "$spec" = NONE ]      && echo "    ↳ no ui-spec dir ($SPEC/$c)"
+  [ "$tst" = NONE ]       && echo "    ↳ no unit test ($UI/$c/__tests__/$c.test.tsx)"
+  [ "$fig" = NONE ]       && echo "    ↳ no Figma link (index.yaml figma.node + <name>.figma.tsx)"
+  [ "$fig" = PARTIAL ]    && echo "    ↳ Figma link incomplete (one side missing or codeConnect path broken)"
+  [ "$fig" = DRAFT ]      && echo "    ↳ Code Connect not COMPLETE ($ff)"
+  [ -n "$fig_node" ]      && echo "    ↳ figma parity: spec node $fig_node, code-connect node ${cc_node:-none} — run live diff (SKILL §Figma design parity)"
+  [ -n "$prose_stale" ]   && echo "    ↳ (non-blocking) stale token names in spec prose: $(printf '%s' "$prose_stale" | tr '\n' ' ')"
+  rm -f "$refs"
+done
+
+rm -f "$defined"
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "RESULT: DRIFT present — resolve dangling tokens / missing imports before /figma-component."
+else
+  echo "RESULT: no token drift. Review INCOMPLETE rows; run the dynamic checks (SKILL.md §Dynamic checks)."
+fi
+exit "$fail"

--- a/.claude/skills/component-readiness/scripts/parity-image.mjs
+++ b/.claude/skills/component-readiness/scripts/parity-image.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+//
+// Deep parity — VISUAL level (advisory). Pixel-diffs a Figma node screenshot
+// against a rendered Storybook screenshot and writes a highlighted diff PNG.
+//
+// The Figma read is selection-bound (MCP), so this script does NOT call Figma.
+// The agent saves the node image (Figma MCP `get_screenshot` / get_design_context
+// screenshot) to a PNG and passes it here, alongside a Storybook render of the
+// matching story (a committed VR baseline under test/__snapshots__/ works, or a
+// fresh Playwright capture).
+//
+// Usage:
+//   node parity-image.mjs <figma.png> <storybook.png> [--out diff.png] [--threshold 0.1]
+//
+// ADVISORY only: a Figma node screenshot and a Storybook story are not pixel-
+// aligned (different framing/padding/scale), so the % is a delta signal, not a
+// pass/fail. Read the diff PNG. Best results: crop the Storybook capture to just
+// the component. Uses pixelmatch + pngjs from the repo's pnpm store (no new deps).
+
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const ROOT = execSync('git rev-parse --show-toplevel').toString().trim();
+
+// Resolve pixelmatch + pngjs from the pnpm store (transitive deps of
+// jest-image-snapshot, already installed for visual regression).
+function fromStore(pkg, preferVersion) {
+  const store = `${ROOT}/node_modules/.pnpm`;
+  if (!fs.existsSync(store)) return null;
+  const dirs = fs.readdirSync(store).filter((d) => d.startsWith(`${pkg}@`));
+  if (!dirs.length) return null;
+  const pick = (preferVersion && dirs.find((d) => d.startsWith(`${pkg}@${preferVersion}`))) || dirs.sort().pop();
+  const p = `${store}/${pick}/node_modules/${pkg}`;
+  return fs.existsSync(p) ? p : null;
+}
+
+let PNG, pixelmatch;
+try {
+  const pngPath = fromStore('pngjs', '6');
+  const pmPath = fromStore('pixelmatch', '5');
+  if (!pngPath || !pmPath) throw new Error('not found');
+  ({ PNG } = require(pngPath));
+  pixelmatch = require(pmPath);
+} catch {
+  console.error(
+    'Could not load pixelmatch/pngjs from the pnpm store.\n' +
+      'Run `pnpm install` at the repo root (they ship with jest-image-snapshot), or\n' +
+      'fall back to ImageMagick:  compare -metric AE figma.png storybook.png diff.png'
+  );
+  process.exit(2);
+}
+
+const [, , figmaPath, storyPath, ...rest] = process.argv;
+if (!figmaPath || !storyPath) {
+  console.error('usage: parity-image.mjs <figma.png> <storybook.png> [--out diff.png] [--threshold 0.1]');
+  process.exit(2);
+}
+const outPath = rest.includes('--out') ? rest[rest.indexOf('--out') + 1] : 'parity-diff.png';
+const threshold = rest.includes('--threshold') ? Number(rest[rest.indexOf('--threshold') + 1]) : 0.1;
+
+const figma = PNG.sync.read(fs.readFileSync(figmaPath));
+const story = PNG.sync.read(fs.readFileSync(storyPath));
+
+// Nearest-neighbor resize `src` (RGBA) to w×h.
+function resize(src, w, h) {
+  const out = Buffer.alloc(w * h * 4);
+  for (let y = 0; y < h; y++) {
+    const sy = Math.min(src.height - 1, (y * src.height / h) | 0);
+    for (let x = 0; x < w; x++) {
+      const sx = Math.min(src.width - 1, (x * src.width / w) | 0);
+      src.data.copy(out, (y * w + x) * 4, (sy * src.width + sx) * 4, (sy * src.width + sx) * 4 + 4);
+    }
+  }
+  return out;
+}
+
+const { width, height } = figma;
+const a = figma.data;
+const b = story.width === width && story.height === height ? story.data : resize(story, width, height);
+if (story.width !== width || story.height !== height) {
+  console.log(`note: resized storybook ${story.width}×${story.height} → ${width}×${height} (figma dims) before diff`);
+}
+
+const diff = new PNG({ width, height });
+const mismatch = pixelmatch(a, b, diff.data, width, height, { threshold });
+fs.writeFileSync(outPath, PNG.sync.write(diff));
+
+const ratio = mismatch / (width * height);
+console.log(`mismatched pixels: ${mismatch} / ${width * height}  (${(ratio * 100).toFixed(2)}%)`);
+console.log(`diff image: ${outPath}`);
+console.log(
+  ratio > 0.2
+    ? 'RESULT: large visual delta — inspect the diff PNG (could be framing, or a real design mismatch).'
+    : 'RESULT: visual delta within advisory range — inspect the diff PNG to confirm parity.'
+);

--- a/.claude/skills/component-readiness/scripts/parity-values.mjs
+++ b/.claude/skills/component-readiness/scripts/parity-values.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+//
+// Deep parity — VALUE level. Compares the resolved values of the design
+// variables a Figma node uses against the resolved values of the --ui-* tokens
+// the component references in tokens-pd.
+//
+// The Figma read is selection-bound (MCP), so this script does NOT call Figma.
+// The agent saves the output of `get_variable_defs({ nodeId, fileKey })` to a
+// JSON file and passes its path here; this script does the deterministic compare.
+//
+// Usage:
+//   node parity-values.mjs <ComponentName|kebab> <figma-vars.json> [--brand acronis] [--theme light|dark]
+//
+// figma-vars.json: either { "component/Tooltip/container/color": "#191B23E5", ... }
+//                  or [ { "name": "...", "value": "..." }, ... ]
+//
+// Exit 1 if any NAME-PAIRED value differs (the high-confidence signal). Unpaired
+// design values that don't appear anywhere in the component are reported as
+// advisory (MISSING) — they may be out of this component's scope.
+
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+
+const ROOT = execSync('git rev-parse --show-toplevel').toString().trim();
+const TOKENS = `${ROOT}/packages/tokens-pd/css`;
+const UI = `${ROOT}/packages/ui-react/src/components/ui`;
+
+const [, , rawName, figmaJsonPath, ...rest] = process.argv;
+if (!rawName || !figmaJsonPath) {
+  console.error('usage: parity-values.mjs <Component> <figma-vars.json> [--theme light|dark]');
+  process.exit(2);
+}
+const theme = rest.includes('--theme') ? rest[rest.indexOf('--theme') + 1] : 'light';
+const kebab = rawName.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+
+// --- normalize a color/dimension value to a canonical comparable string ---
+function norm(v) {
+  if (v == null) return null;
+  if (typeof v === 'number') return `${v}`; // dimension
+  let s = String(v).trim();
+
+  // hex → r,g,b,a
+  let m = s.match(/^#([0-9a-fA-F]{3,8})$/);
+  if (m) {
+    let h = m[1];
+    if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+    if (h.length === 4) h = h.split('').map((c) => c + c).join('');
+    const r = parseInt(h.slice(0, 2), 16), g = parseInt(h.slice(2, 4), 16), b = parseInt(h.slice(4, 6), 16);
+    const a = h.length >= 8 ? +(parseInt(h.slice(6, 8), 16) / 255).toFixed(3) : 1;
+    return `${r},${g},${b},${a}`;
+  }
+  // rgb(r g b / a) | rgb(r,g,b) | rgba(...)
+  m = s.match(/rgba?\(([^)]+)\)/i);
+  if (m) {
+    const parts = m[1].replace('/', ' ').split(/[\s,]+/).filter(Boolean).map(Number);
+    const [r, g, b] = parts;
+    const a = parts.length >= 4 ? +parts[3].toFixed(3) : 1;
+    return `${r},${g},${b},${a}`;
+  }
+  // dimension like "12px" / "0.5rem"
+  m = s.match(/^(-?[\d.]+)(px|rem|em)?$/);
+  if (m) return `${parseFloat(m[1])}`;
+  return s.toLowerCase();
+}
+
+// --- map a Figma variable name → --ui-* token name (best effort, Option-A) ---
+function toToken(figmaName) {
+  const segs = String(figmaName).split('/').filter((s) => s && s.toLowerCase() !== 'component');
+  const kebabed = segs.map((s) =>
+    s.replace(/^_/, '')                                  // _global → global
+     .replace(/([a-z0-9])([A-Z])/g, '$1-$2')             // camel/Pascal → kebab
+     .toLowerCase()
+  );
+  return `--ui-${kebabed.join('-')}`;
+}
+
+// --- resolve --ui-* token values from tokens-pd for the chosen brand/theme ---
+function loadTokenValues(brand) {
+  const map = new Map();
+  const files = [`${TOKENS}/${brand}.css`];
+  for (const d of fs.readdirSync(TOKENS)) {
+    const p = `${TOKENS}/${d}/${brand}.css`;
+    if (fs.existsSync(p)) files.push(p);
+  }
+  const re = /(--ui-[a-z0-9-]+)\s*:\s*([^;]+);/g;
+  for (const f of files) {
+    if (!fs.existsSync(f)) continue;
+    const css = fs.readFileSync(f, 'utf8');
+    let m;
+    while ((m = re.exec(css))) {
+      const name = m[1];
+      let val = m[2].trim();
+      const ld = val.match(/light-dark\(\s*(.+?)\s*,\s*(.+?)\s*\)$/);
+      if (ld) val = theme === 'dark' ? ld[2] : ld[1];
+      map.set(name, val);
+    }
+  }
+  return map;
+}
+
+// --- referenced tokens in the component source (.tsx/.ts) ---
+function referencedTokens() {
+  const dir = `${UI}/${kebab}`;
+  const out = new Set();
+  const walk = (d) => {
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = `${d}/${e.name}`;
+      if (e.isDirectory()) walk(p);
+      else if (/\.(tsx?|ts)$/.test(e.name)) {
+        for (const t of fs.readFileSync(p, 'utf8').match(/--ui-[a-z0-9-]+/g) || []) {
+          if (!t.endsWith('-')) out.add(t);
+        }
+      }
+    }
+  };
+  if (fs.existsSync(dir)) walk(dir);
+  return out;
+}
+
+// --- load figma vars json into [{name, value}] ---
+function loadFigma(path) {
+  const j = JSON.parse(fs.readFileSync(path, 'utf8'));
+  if (Array.isArray(j)) return j.map((x) => ({ name: x.name, value: x.value }));
+  return Object.entries(j).map(([name, value]) => ({ name, value }));
+}
+
+const brand = rest.includes('--brand') ? rest[rest.indexOf('--brand') + 1] : 'acronis';
+const tokenVals = loadTokenValues(brand);
+const refd = referencedTokens();
+const figma = loadFigma(figmaJsonPath);
+
+// value→[tokenNames] index over the component's referenced tokens (for unpaired lookup)
+const refdValueSet = new Map();
+for (const t of refd) {
+  const nv = norm(tokenVals.get(t));
+  if (nv != null) (refdValueSet.get(nv) || refdValueSet.set(nv, []).get(nv)).push(t);
+}
+
+let paired = 0, diffs = 0, missing = 0;
+console.log(`Value parity — ${kebab} (brand ${brand}, ${theme})  [figma ${figma.length} vars vs ${refd.size} referenced tokens]\n`);
+for (const { name, value } of figma) {
+  const tok = toToken(name);
+  const fval = norm(value);
+  if (refd.has(tok)) {
+    paired++;
+    const tval = norm(tokenVals.get(tok));
+    if (fval === tval) {
+      console.log(`  MATCH      ${name}  →  ${tok}`);
+    } else {
+      diffs++;
+      console.log(`  VALUE-DIFF ${name} = ${fval}  →  ${tok} = ${tval}`);
+    }
+  } else if (fval != null && refdValueSet.has(fval)) {
+    console.log(`  ~ unpaired ${name} = ${fval}  (value present via ${refdValueSet.get(fval).join(', ')}; name didn't map to a referenced token)`);
+  } else {
+    missing++;
+    console.log(`  MISSING    ${name} = ${fval}  (no referenced token maps to this name or value)`);
+  }
+}
+
+console.log(`\nsummary: ${paired} name-paired, ${diffs} value-diff, ${missing} missing(advisory)`);
+if (diffs > 0) {
+  console.log('RESULT: VALUE DRIFT — a referenced token resolves to a different value than the design.');
+  process.exit(1);
+}
+console.log('RESULT: no name-paired value drift. Review MISSING rows (may be out of component scope).');

--- a/.claude/skills/figma-component/SKILL.md
+++ b/.claude/skills/figma-component/SKILL.md
@@ -46,6 +46,30 @@ Parse the URL: `figma.com/design/:fileKey/…?node-id=1017-2852` →
 
 ---
 
+## Phase 0 — Readiness gate (prerequisite)
+
+Before reading the design, run the [`/component-readiness`](../component-readiness/SKILL.md)
+gate. It is **read-only** and catches the silent failures this recipe is most
+exposed to — dead `var(--ui-*)` refs and un-imported token tiers (see Phase 2).
+
+```bash
+bash .claude/skills/component-readiness/scripts/audit.sh <ComponentName>   # or `all`
+```
+
+- **`--update` an existing component:** run the gate on **that component first**.
+  A `DRIFT` verdict means the update must include the token rewire (dead names →
+  current `tokens-pd` tier, missing `@import` in `styles/index.css`), not just the
+  design refresh. Don't layer new work on a silently-broken baseline.
+- **New component:** run it on `all` (or skip — there's nothing to audit yet) to
+  confirm you're not about to build alongside pre-existing drift you'd be blamed
+  for. `INCOMPLETE`/`READY` are fine to proceed on; resolve any `DRIFT` rows or
+  flag them to the user.
+
+This gate fills the issue-#297 gap: `ui-spec test` validates token-name _shape_
+but never that the names _exist_ in `tokens-pd`, so drift otherwise passes CI.
+
+---
+
 ## Phase 1 — Read the design (Figma MCP)
 
 Call these (no skill prerequisite for reads):

--- a/packages/ui-spec/components/checkbox/behavior.md
+++ b/packages/ui-spec/components/checkbox/behavior.md
@@ -55,7 +55,7 @@
 
 **Given** an enabled Checkbox
 **When** the pointer hovers it
-**Then** the border uses `--ui-form-border-hover`
+**Then** the border uses `--ui-checkbox-unchecked-box-border-color-hover`
 
 ### Focus
 
@@ -67,8 +67,8 @@
 
 **Given** a checked or indeterminate Checkbox
 **When** it renders
-**Then** the box fills with `--ui-form-background-active` and the border with
-`--ui-form-border-active`
+**Then** the box fills with `--ui-checkbox-checked-box-color-idle` and the border with
+`--ui-checkbox-checked-box-border-color-idle`
 
 ---
 

--- a/packages/ui-spec/components/input/README.md
+++ b/packages/ui-spec/components/input/README.md
@@ -20,7 +20,7 @@ and, when validation fails, an associated error message.
 | State    | How            | Visual                                          |
 | -------- | -------------- | ----------------------------------------------- |
 | Idle     | default        | Idle border, white fill                         |
-| Hover    | pointer hover  | `--ui-form-border-hover`                        |
+| Hover    | pointer hover  | `--ui-input-text-normal-box-border-color-hover` |
 | Focus    | focus          | Active border + 3px `--ui-focus-primary` ring   |
 | Error    | `aria-invalid` | Error border + `--ui-focus-error` ring on focus |
 | Disabled | `disabled`     | Faint fill/border, muted text, not interactive  |
@@ -67,6 +67,6 @@ Error state:
 | `index.yaml`       | Identity, status, category, Figma link                      |
 | `anatomy.yaml`     | Root element/role, pseudo + prop states                     |
 | `api.yaml`         | Framework-agnostic contract + framework adapters            |
-| `tokens.yaml`      | `--ui-form-*` + focus-ring token references                 |
+| `tokens.yaml`      | `--ui-input-text-*` + focus-ring token references           |
 | `behavior.md`      | Given/When/Then behavior scenarios                          |
 | `accessibility.md` | ARIA, keyboard map, screen-reader and contrast requirements |

--- a/packages/ui-spec/components/input/anatomy.yaml
+++ b/packages/ui-spec/components/input/anatomy.yaml
@@ -6,14 +6,14 @@ schematic: |
   | Placeholder / Value           |   root: <input> (role="textbox")
   +-------------------------------+
    border idle / hover / active(focus) / error / disabled
-   text -> --ui-form-text-value ; placeholder -> --ui-form-text-placeholder
+   text -> --ui-input-text-global-value-color-idle ; placeholder -> --ui-input-text-global-placeholder-color-idle
 
 root:
   element: input
   role: textbox
   description: >-
     Native single-line text input. Geometry (32px tall, 12px x-padding, 4px
-    radius, 1px border) and all colors come from the `--ui-form-*` tokens; the
+    radius, 1px border) and all colors come from the `--ui-input-text-*` tokens; the
     focus ring uses `--ui-focus-primary` (and `--ui-focus-error` when invalid).
 
 # A bare input has no named sub-parts — the placeholder/value live on the native

--- a/packages/ui-spec/components/input/behavior.md
+++ b/packages/ui-spec/components/input/behavior.md
@@ -7,7 +7,7 @@
 **Given** an Input with no value
 **When** it renders
 **Then** it exposes `role="textbox"` with `type="text"` by default
-**And** the placeholder (if set) is shown in `--ui-form-text-placeholder`
+**And** the placeholder (if set) is shown in `--ui-input-text-global-placeholder-color-idle`
 
 ### Honors a custom type
 
@@ -41,20 +41,20 @@
 
 **Given** an enabled, valid Input
 **When** the pointer hovers it
-**Then** the border uses `--ui-form-border-hover`
+**Then** the border uses `--ui-input-text-normal-box-border-color-hover`
 
 ### Focus
 
 **Given** an Input
 **When** it receives focus
-**Then** the border uses `--ui-form-border-active`
+**Then** the border uses `--ui-input-text-normal-box-border-color-hover`
 **And** a 3px `--ui-focus-primary` ring is shown
 
 ### Error (aria-invalid)
 
 **Given** an Input with `aria-invalid`
 **When** it renders
-**Then** the border uses `--ui-form-border-error`
+**Then** the border uses `--ui-input-text-error-msg-box-border-color-idle`
 **And** on focus the ring uses `--ui-focus-error` (not the primary ring)
 **And** the error styling overrides the hover/focus border
 

--- a/packages/ui-spec/components/search/README.md
+++ b/packages/ui-spec/components/search/README.md
@@ -28,7 +28,7 @@ filtering a table, or global search).
 | State    | How           | Visual                                         |
 | -------- | ------------- | ---------------------------------------------- |
 | Idle     | default       | Idle border, magnifier + placeholder           |
-| Hover    | pointer hover | `--ui-form-border-hover`                       |
+| Hover    | pointer hover | `--ui-input-search-border-color-hover`         |
 | Focus    | input focus   | Active border + 3px `--ui-focus-primary` ring  |
 | Filled   | has a value   | Value text + clear (×) button                  |
 | Disabled | `disabled`    | Faint tokens; no clear button; not interactive |
@@ -61,6 +61,6 @@ function TableFilter() {
 | `index.yaml`       | Identity, status, category, dependencies, Figma link        |
 | `anatomy.yaml`     | Root, icon / input / clear parts, states                    |
 | `api.yaml`         | Framework-agnostic contract + framework adapters            |
-| `tokens.yaml`      | `--ui-form-*` + focus-ring token references                 |
+| `tokens.yaml`      | `--ui-input-search-*` + focus-ring token references         |
 | `behavior.md`      | Given/When/Then behavior scenarios                          |
 | `accessibility.md` | ARIA, keyboard map, screen-reader and contrast requirements |

--- a/packages/ui-spec/components/search/anatomy.yaml
+++ b/packages/ui-spec/components/search/anatomy.yaml
@@ -5,7 +5,7 @@ schematic: |
   +-------------------------------------------+
   | (icon)  input text / placeholder   (clear)|   root: <div> (the box)
   +-------------------------------------------+
-   icon  = leading magnifier (--ui-form-icon-idle)
+   icon  = leading magnifier (--ui-input-search-icon-search-color-idle)
    input = borderless <input type="search"> (role="searchbox")
    clear = trailing × button, shown once there's a value
 
@@ -19,8 +19,8 @@ root:
 parts:
   - id: icon
     description: >-
-      Leading magnifier (SearchIcon). `--ui-form-icon-idle`, or
-      `--ui-form-icon-disabled` when the field is disabled.
+      Leading magnifier (SearchIcon). `--ui-input-search-icon-search-color-idle`, or
+      `--ui-input-search-icon-search-color-disabled` when the field is disabled.
     element: svg
   - id: input
     description: Borderless native `<input type="search">` (role="searchbox").

--- a/packages/ui-spec/components/search/behavior.md
+++ b/packages/ui-spec/components/search/behavior.md
@@ -8,7 +8,7 @@
 **When** it renders
 **Then** the input exposes `role="searchbox"` (native `type="search"`)
 **And** a leading magnifier icon is shown
-**And** the placeholder (if set) uses `--ui-form-text-placeholder`
+**And** the placeholder (if set) uses `--ui-input-search-placeholder-color-idle`
 
 ---
 
@@ -46,7 +46,7 @@
 
 **Given** an enabled Search
 **When** the pointer hovers the box
-**Then** the border uses `--ui-form-border-hover`
+**Then** the border uses `--ui-input-search-border-color-hover`
 
 ### Focus
 

--- a/packages/ui-spec/components/tooltip/accessibility.md
+++ b/packages/ui-spec/components/tooltip/accessibility.md
@@ -27,5 +27,5 @@ Provided by the Base UI Tooltip primitive; verify these hold after styling.
 
 ## Contrast
 
-- `--ui-tooltip-label` on `--ui-tooltip-background` meets contrast; the bubble's
+- `--ui-tooltip-label-color` on `--ui-tooltip-container-color` meets contrast; the bubble's
   ~90% opacity keeps text legible over varied backgrounds.

--- a/packages/ui-spec/components/tooltip/anatomy.yaml
+++ b/packages/ui-spec/components/tooltip/anatomy.yaml
@@ -12,8 +12,8 @@ schematic: |
   | popup: <div role=tooltip>   (portaled, positioned)
   |   label               |
   +-----------------------+
-   popup -> dark bubble (--ui-tooltip-background)
-   label -> hint text (--ui-tooltip-label)
+   popup -> dark bubble (--ui-tooltip-container-color)
+   label -> hint text (--ui-tooltip-label-color)
 
 root:
   element: button
@@ -26,12 +26,12 @@ parts:
   - id: popup
     description: >-
       The floating bubble (`role="tooltip"`), portaled and positioned relative to
-      the trigger. Dark, ~90%-opaque background (`--ui-tooltip-background`), 4px
+      the trigger. Dark, ~90%-opaque background (`--ui-tooltip-container-color`), 4px
       radius, 12/8px padding, 48–256px wide. No arrow.
     element: div
   - id: label
     description: >-
-      The hint text inside the popup — 12px medium, `--ui-tooltip-label`.
+      The hint text inside the popup — 12px medium, `--ui-tooltip-label-color`.
 
 layout:
   type: flex

--- a/packages/ui-spec/components/tooltip/tokens.yaml
+++ b/packages/ui-spec/components/tooltip/tokens.yaml
@@ -6,21 +6,25 @@ source: '@acronis-platform/tokens-pd'
 
 tokens:
   - {
-      name: --ui-tooltip-background,
+      name: --ui-tooltip-container-color,
       affects: popup,
       description: Bubble background (dark ~90% opaque),
     }
-  - { name: --ui-tooltip-label, affects: label, description: Hint text color }
-  - { name: --ui-tooltip-global-padding-x, affects: popup }
-  - { name: --ui-tooltip-global-padding-y, affects: popup }
-  - { name: --ui-tooltip-global-radius, affects: popup }
   - {
-      name: --ui-tooltip-global-width-min,
+      name: --ui-tooltip-label-color,
+      affects: label,
+      description: Hint text color,
+    }
+  - { name: --ui-tooltip-container-padding-x, affects: popup }
+  - { name: --ui-tooltip-container-padding-y, affects: popup }
+  - { name: --ui-tooltip-container-border-radius, affects: popup }
+  - {
+      name: --ui-tooltip-container-width-min,
       affects: popup,
       description: Minimum width (48px),
     }
   - {
-      name: --ui-tooltip-global-width-max,
+      name: --ui-tooltip-container-width-max,
       affects: popup,
       description: Maximum width (256px),
     }


### PR DESCRIPTION
## What

Adds a reusable **read-only pre-flight gate** that audits ui-react components before `/figma-component`, and fixes the real drift it surfaced.

### New skill — `/component-readiness [ComponentName | all]`
`.claude/skills/component-readiness/` (`SKILL.md` + `scripts/audit.sh`). Per component it checks:

| Check | Blocking |
|---|---|
| **TOKENS** — every `--ui-*` ref (code `.tsx`/`.ts` + spec YAML) resolves in `tokens-pd` | DRIFT |
| **IMPORTS** — each referenced token tier is `@import`-ed in `styles/index.css` | DRIFT |
| **SPEC** — ui-spec 7-file set present | INCOMPLETE |
| **TESTS** — `__tests__/<name>.test.tsx` present | INCOMPLETE |
| **FIGMA** — linkage parity: `index.yaml` node + a `COMPLETE` `<name>.figma.tsx` (LINKED/DRAFT/PARTIAL/NONE) | INCOMPLETE |

Prints a `READY / DRIFT / INCOMPLETE` matrix, exits non-zero on DRIFT, **never edits files**. Prose token mentions in `.md` are reported non-blocking. SKILL.md also documents the **live Figma design-parity diff** (variants/states/tokens vs. the node) via the Figma MCP as an agent step. Wired into `figma-component` as **Phase 0**.

This closes the **issue #297** gap: `ui-spec test` only regexes token-name *shape*, never that names *exist* in `tokens-pd`, so renamed/removed tokens drift past CI silently.

### Drift it surfaced and fixed (ui-spec)
- **tooltip** — `tokens.yaml`/`anatomy.yaml`/`accessibility.md` referenced pre-rename `--ui-tooltip-{background,label,global-*}` → current `--ui-tooltip-{container-color,label-color,container-*}`.
- **input** — `anatomy.yaml`/`behavior.md`/`README.md` still on legacy `--ui-form-*` (PR #314 rewired the component + `tokens.yaml` but missed these) → `--ui-input-text-*`.
- **search** — `anatomy.yaml`/`behavior.md`/`README.md` `--ui-form-*` → `--ui-input-search-*`.
- **checkbox** — `behavior.md` prose `--ui-form-*` → `--ui-checkbox-*`.

### Known gaps (left as-is, blocked on external inputs)
- **select** — DRIFT, intentionally stranded: `tokens-pd` ships no `--ui-select-*` tier yet.
- **input-text-area** — INCOMPLETE: no Figma Code Connect (built tokens-first in #314; needs a Figma node to link).

## Verify
- `bash .claude/skills/component-readiness/scripts/audit.sh all` → all READY except the two known gaps above.
- `pnpm --filter @acronis-platform/ui-spec test` → 93/93.

No published-package code changed (ui-spec is private; skill is tooling), so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)