### PR TITLE
test(style-dictionary): fix asset fixtures broken by #286 rename

### DIFF
--- a/tools/style-dictionary/src/assets/__tests__/executor.test.ts
+++ b/tools/style-dictionary/src/assets/__tests__/executor.test.ts
@@ -12,8 +12,8 @@ const stroke16 = rules.get('stroke-1-6')!;
 const scale96 = rules.get('scale-96')!;
 
 const src = (rel: string): string => readSvg(resolveBinary(rel).absPath);
-const BAN = './packs/icons-stroke-mono/ban-24.svg';
-const DOT = './packs/icons-stroke-multi/dot-blue-solid-24.svg';
+const BAN = './packs/icons-stroke-mono/CircleBan.svg';
+const DOT = './packs/icons-stroke-multi/DotBlue.svg';
 const ILLU = './packs/illustrations/0001-full-image-backup-48.svg';
 
 describe('executor', () => {

--- a/tools/style-dictionary/src/assets/__tests__/svgo.test.ts
+++ b/tools/style-dictionary/src/assets/__tests__/svgo.test.ts
@@ -9,7 +9,7 @@ import { readSvg, resolveBinary } from '../read';
 
 const src = (rel: string): string => readSvg(resolveBinary(rel).absPath);
 const ILLU = './packs/illustrations/0001-full-image-backup-48.svg';
-const DOT = './packs/icons-stroke-multi/dot-blue-solid-24.svg';
+const DOT = './packs/icons-stroke-multi/DotBlue.svg';
 
 describe('svgo config', () => {
   it('keeps the viewBox (removeViewBox stays off in v4)', () => {


### PR DESCRIPTION
## Why

`main`'s **`ci`** check has been red since **#286** ("add 4 icon packs with PascalCase SVGs and Figma sync tool", commit `6be6bc65`). #286 renamed the `design-assets` icon packs to PascalCase (dropping the `-NN` size suffix) but didn't update the `tools/style-dictionary` asset tests, which hardcode the old kebab fixture names:

```
ENOENT … packages/design-assets/packs/icons-stroke-mono/ban-24.svg
ENOENT … packages/design-assets/packs/icons-stroke-multi/dot-blue-solid-24.svg
```

They pass on a stale local working tree (old files linger) but ENOENT on a clean CI checkout → 5 failing tests, `ci` red on every PR since.

## Fix

Repoint the two stale fixtures to files that exist on current `main`, preserving every assertion:

| Old (gone) | New | Test it backs |
|---|---|---|
| `icons-stroke-mono/ban-24.svg` | `icons-stroke-mono/CircleBan.svg` | scale / stroke-width=2.4 / mono→currentColor |
| `icons-stroke-multi/dot-blue-solid-24.svg` | `icons-stroke-multi/DotBlue.svg` | preserve keeps `#1763cf` + `#1354ae` |

- **Illustrations weren't renamed**, so the `ILLU` fixture is unchanged.
- `resolve.test.ts` uses a synthetic `concept-pack` — unaffected.
- `DotBlue.svg` verified to still carry both asserted hexes; `CircleBan.svg` verified against the scale/stroke/mono assertions.

## Verify
- `pnpm --filter @acronis-platform/style-dictionary test` → **106/106**
- `pnpm --filter @acronis-platform/style-dictionary typecheck` → clean
- No other repo references to the old fixture names.

Private tool package — no changeset. Unblocks `ci` for all open PRs (incl. #316).

🤖 Generated with [Claude Code](https://claude.com/claude-code)