### PR TITLE
test(icons-react): fix packs test broken by #286 icon rename

### DIFF
--- a/packages/icons-react/src/__tests__/packs.test.tsx
+++ b/packages/icons-react/src/__tests__/packs.test.tsx
@@ -1,9 +1,9 @@
 import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import { BrandAcronisIcon } from '../packs/solid-mono';
-import { CircleCheckStrokeMultiIcon } from '../packs/stroke-multi';
-import { SparklesSolidMultiIcon } from '../packs/solid-multi';
+import { AcronisIcon } from '../packs/solid-mono';
+import { CircleCheckGreenIcon } from '../packs/stroke-multi';
+import { AcronisAiMultiIcon } from '../packs/solid-multi';
 
 function svgOf(container: HTMLElement): SVGSVGElement {
   const svg = container.querySelector('svg');
@@ -13,7 +13,7 @@ function svgOf(container: HTMLElement): SVGSVGElement {
 
 describe('solid-mono pack', () => {
   it('paints with currentColor fill (no authored color, no stroke width)', () => {
-    const svg = svgOf(render(<BrandAcronisIcon />).container);
+    const svg = svgOf(render(<AcronisIcon />).container);
     expect(svg).toHaveAttribute('fill', 'currentColor');
     expect(svg).not.toHaveAttribute('stroke-width');
     // authored fill on the path was stripped so the svg's fill cascades.
@@ -24,7 +24,7 @@ describe('solid-mono pack', () => {
 describe('multicolor packs keep authored colors', () => {
   it('stroke-multi preserves per-path colors but takes stroke width from rules', () => {
     const svg = svgOf(
-      render(<CircleCheckStrokeMultiIcon size={16} />).container
+      render(<CircleCheckGreenIcon size={16} />).container
     );
     expect(svg).toHaveAttribute('fill', 'none');
     expect(svg).not.toHaveAttribute('stroke'); // not forced to currentColor
@@ -36,10 +36,10 @@ describe('multicolor packs keep authored colors', () => {
   });
 
   it('solid-multi preserves gradients with namespaced ids', () => {
-    const svg = svgOf(render(<SparklesSolidMultiIcon />).container);
+    const svg = svgOf(render(<AcronisAiMultiIcon />).container);
     const gradientId = svg.querySelector('linearGradient')?.id;
     // ids are namespaced per-icon so gradients can't collide across icons.
-    expect(gradientId).toMatch(/^sparkles-/);
+    expect(gradientId).toMatch(/^acronis-ai-multi-/);
     expect(svg.querySelector('path')?.getAttribute('fill')).toBe(
       `url(#${gradientId})`
     );


### PR DESCRIPTION
## Why

`main`'s **`ci`** is red on `icons-react` typecheck — a second pre-existing casualty of **#286** ("add 4 icon packs with PascalCase SVGs"), the sibling of #319. #286 renamed the design-assets icons to PascalCase, changing the generated `icons-react` exports, but `src/__tests__/packs.test.tsx` kept the old names. Since `icons-react`'s `typecheck` runs `generate && tsc`, a clean checkout fails:

```
TS2724 '"../packs/solid-mono"' has no exported member 'BrandAcronisIcon' (did you mean 'AcronisIcon'?)
TS2305 '"../packs/stroke-multi"' has no exported member 'CircleCheckStrokeMultiIcon'
TS2305 '"../packs/solid-multi"' has no exported member 'SparklesSolidMultiIcon'
```

The file is byte-identical on every open branch, so every PR's `ci` inherits the red.

## Fix

Repoint the three imports to icons that exist post-#286, preserving each assertion:

| Old (gone) | New | Assertion kept |
|---|---|---|
| `BrandAcronisIcon` (solid-mono) | `AcronisIcon` | paints `currentColor`, no stroke-width |
| `CircleCheckStrokeMultiIcon` (stroke-multi) | `CircleCheckGreenIcon` | colors unchanged: `#29a33d` / `#248f36` / `#fff`, `stroke-width=2.4` |
| `SparklesSolidMultiIcon` (solid-multi) | `AcronisAiMultiIcon` | gradient with namespaced id; regex updated `^sparkles-` → `^acronis-ai-multi-` |

(`solid-multi` ships exactly one icon post-#286 — `AcronisAiMultiIcon`.)

## Verify
- `pnpm --filter @acronis-platform/icons-react typecheck` → clean (`generate && tsc`)
- `pnpm --filter @acronis-platform/icons-react exec vitest run src/__tests__/packs.test.tsx` → 3/3

Private package — no changeset. Unblocks `ci` repo-wide (incl. #317).

🤖 Generated with [Claude Code](https://claude.com/claude-code)