### PR TITLE
fix(release): correct skip-if-published guard in release-token.yml

### DIFF
--- a/.github/workflows/release-token.yml
+++ b/.github/workflows/release-token.yml
@@ -79,7 +79,11 @@ jobs:
           publish() {
             local pkg="$1"; local dir="$2"
             local ver; ver=$(node -p "require('./$dir/package.json').version")
-            if npm view "$pkg@$ver" version --json 2>/dev/null | grep -q '"'; then
+            # `npm view <pkg>@<ver> version` prints the version when published and
+            # nothing when absent (the E404 goes to stderr). Do NOT use --json: for
+            # a never-published package npm prints an error OBJECT to stdout, whose
+            # quotes defeat a naive existence test and skip every package.
+            if [ -n "$(npm view "$pkg@$ver" version 2>/dev/null)" ]; then
               echo "⏭  $pkg@$ver already on npm, skipping"
             else
               echo "🚀 Publishing $pkg@$ver"


### PR DESCRIPTION
## Problem

A manual run of \`release-token.yml\` skipped **every** package — \`⏭ …@… already on npm, skipping\` — even though none are published.

## Root cause

The existence guard was:
\`\`\`bash
if npm view "$pkg@$ver" version --json 2>/dev/null | grep -q '"'; then  # skip
\`\`\`
For a never-published package, \`npm view --json\` prints an **error object** to **stdout**:
\`\`\`json
[{ "error": { "code": "E404", "summary": "Not Found …" } }]
\`\`\`
Those quotes match \`grep -q '"'\`, so the guard treats absent packages as published and skips them. (The \`2>/dev/null\` only hides stderr; the JSON error is on stdout.)

## Fix

Use the plain form — `npm view <pkg>@<ver> version` prints the version when published and **nothing** when absent (E404 → stderr) — and test for non-empty stdout:
\`\`\`bash
if [ -n "$(npm view "$pkg@$ver" version 2>/dev/null)" ]; then  # skip
\`\`\`

Verified locally: absent pkg → PUBLISH, real published pkg → SKIP.

After merge, re-running the workflow will actually publish the 6 first-time packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)