### PR TITLE
fix(release): add repository field to published packages for npm provenance

### DIFF
--- a/packages/design-assets/package.json
+++ b/packages/design-assets/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@acronis-platform/design-assets",
   "version": "0.4.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/acronis/uikit.git",
+    "directory": "packages/design-assets"
+  },
   "description": "Acronis visual assets — icons and illustrations as JSON manifests + bundled binaries.",
   "license": "MIT AND ISC",
   "type": "module",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@acronis-platform/design-tokens",
   "version": "1.6.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/acronis/uikit.git",
+    "directory": "packages/design-tokens"
+  },
   "description": "Acronis design tokens",
   "license": "MIT",
   "type": "module",

--- a/packages/icons-react/package.json
+++ b/packages/icons-react/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@acronis-platform/icons-react",
   "version": "0.4.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/acronis/uikit.git",
+    "directory": "packages/icons-react"
+  },
   "description": "Acronis React icon components, generated from @acronis-platform/icons-svg-next.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/icons-sprite/package.json
+++ b/packages/icons-sprite/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@acronis-platform/icons-sprite",
   "version": "0.2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/acronis/uikit.git",
+    "directory": "packages/icons-sprite"
+  },
   "description": "Optimized SVG sprites (combined / monocolor / multicolor) generated from @acronis-platform/icons-svg.",
   "license": "MIT",
   "type": "module",

--- a/packages/tokens-pd/package.json
+++ b/packages/tokens-pd/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@acronis-platform/tokens-pd",
   "version": "1.6.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/acronis/uikit.git",
+    "directory": "packages/tokens-pd"
+  },
   "description": "Acronis platform (PD) design tokens: per-brand CSS custom properties, per-component CSS, Tailwind presets, and a DTCG intermediate — generated from @acronis-platform/design-tokens via @acronis-platform/style-dictionary.",
   "license": "MIT",
   "type": "module",

--- a/packages/ui-react/package.json
+++ b/packages/ui-react/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@acronis-platform/ui-react",
   "version": "0.21.2",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/acronis/uikit.git",
+    "directory": "packages/ui-react"
+  },
   "description": "Acronis React component library — a Base UI implementation, themed by @acronis-platform/design-tokens.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Problem

The token-release run reached the publish step (guard fixed in #328) but npm rejected the first package:

\`\`\`
npm error 422 Unprocessable Entity — Error verifying sigstore provenance bundle:
package.json: "repository.url" is "", expected to match "https://github.com/acronis/uikit" from provenance
\`\`\`

With \`NPM_CONFIG_PROVENANCE=true\`, npm validates that each package's \`repository.url\` matches the building repo. None of the six published packages declared a \`repository\`, so publish was rejected (and \`bash -e\` aborted the rest → nothing published).

## Fix

Add \`repository\` to all six (design-assets, design-tokens, icons-react, icons-sprite, tokens-pd, ui-react):
\`\`\`json
"repository": {
  "type": "git",
  "url": "git+https://github.com/acronis/uikit.git",
  "directory": "packages/<name>"
}
\`\`\`
URL matches the already-published \`@acronis-platform/shadcn-uikit\` (ui-legacy); \`directory\` gives npm the monorepo subpath. After merge, re-dispatching \`release-token.yml\` will publish all six.

🤖 Generated with [Claude Code](https://claude.com/claude-code)