### PR TITLE
ci(demo-deploy): publish ui-react Storybook alongside ui-legacy

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -1,5 +1,5 @@
-# Builds the demo + Storybook + docs + kitchen-sink into a single GitHub Pages
-# artefact and deploys it.
+# Builds the demo + Storybook (ui-legacy and ui-react) + docs + kitchen-sink
+# into a single GitHub Pages artefact and deploys it.
 #
 # All sub-sites must ship in ONE artefact: GitHub Pages serves a single artefact
 # per deployment, so each deploy replaces the whole site. A separate per-app
@@ -70,6 +70,23 @@ jobs:
         run: |
           rm -rf apps/demo/dist/storybook
           cp -r packages/ui-legacy/storybook-static apps/demo/dist/storybook
+
+      # ui-react Storybook, served alongside the legacy one at /uikit/storybook-react.
+      # ui-react consumes its generated deps (icons-react, which pulls in
+      # tokens-pd/design-assets/style-dictionary) from dist, so build those first;
+      # ui-react's own source is bundled by Storybook via the .storybook alias.
+      # Storybook's static build uses relative asset paths, so it works under the
+      # subpath with no base flag (same as the legacy build above).
+      - name: Build ui-react storybook dependencies
+        run: pnpm --filter @acronis-platform/icons-react... run build
+
+      - name: Build ui-react storybook
+        run: pnpm --filter ./packages/ui-react run storybook:build
+
+      - name: Copy ui-react storybook to demo dist
+        run: |
+          rm -rf apps/demo/dist/storybook-react
+          cp -r packages/ui-react/storybook-static apps/demo/dist/storybook-react
 
       - name: Build docs
         run: DOCS_STATIC_EXPORT=true DOCS_BASE_PATH=/uikit/docs pnpm --filter ./apps/docs run build


### PR DESCRIPTION
## Summary

Publishes the **ui-react** Storybook as part of the GitHub Pages deployment, next to the existing ui-legacy Storybook. Follows the same model `demo-deploy.yml` already uses for the legacy Storybook (built, then copied into the single `apps/demo/dist` Pages artifact).

### What changed (`.github/workflows/demo-deploy.yml`)
- Build ui-react's generated dependencies first (`@acronis-platform/icons-react...`, which pulls in `tokens-pd` / `design-assets` / `style-dictionary`) — ui-react consumes them from `dist`; its own source is bundled by Storybook via the `.storybook` alias. This is the same dependency build the visual-regression workflow uses.
- Run `pnpm --filter ./packages/ui-react run storybook:build`.
- Copy the output to `apps/demo/dist/storybook-react`.

### Serving paths
| Site | Path |
|------|------|
| ui-legacy Storybook (existing) | `/uikit/storybook` |
| **ui-react Storybook (new)** | `/uikit/storybook-react` |

Storybook's static build emits relative asset paths, so it works under the subpath with no base flag — same as the legacy build.

### Trigger
Unchanged: the Pages site deploys on `release: published` (a real Changesets publish) and via manual `workflow_dispatch`. So this can be smoke-tested from the Actions tab without cutting a release.

## Notes
- No application/source code changes — workflow only.
- A separate, redundant `feat/new_storybook` branch got re-created on origin during this work (the original was auto-deleted when #338 squash-merged). It's stale and safe to delete — left untouched here since branch deletion wasn't requested.