### PR TITLE
chore(ui-react): both-modes visual-regression scripts + skill dark-VR docs

### DIFF
--- a/.claude/skills/figma-component/SKILL.md
+++ b/.claude/skills/figma-component/SKILL.md
@@ -325,20 +325,19 @@ Stories must be checked in light **and** dark mode in Storybook
 `jest-image-snapshot`, config in `.storybook/test-runner.ts`; baselines in
 `test/__snapshots__/`). CI runs a **light _and_ dark** matrix
 (`.github/workflows/visual-regression.yml`), so every story has **two** baselines:
-`<id>.png` (light) and `<id>--dark.png` (dark). The Docker update command defaults
-to `STORYBOOK_COLOR_MODE=light` — you MUST regenerate **both** modes or the dark CI
-job fails on the light-only baselines. After adding/updating stories, regenerate the
+`<id>.png` (light) and `<id>--dark.png` (dark). The plain `:docker:update` writes only
+the light baselines — you MUST regenerate **both** modes or the dark CI job fails on the
+light-only baselines. Use the `:all` scripts (they run light then the
+`STORYBOOK_COLOR_MODE=dark` pass). After adding/updating stories, regenerate the
 **Linux** baselines for both modes and review the PNGs before committing:
 
 ```bash
-# Light (default)
-pnpm --filter @acronis-platform/ui-react storybook:test:visual:docker:update
-# Dark — same command, STORYBOOK_COLOR_MODE=dark (writes the `--dark.png` baselines)
-STORYBOOK_COLOR_MODE=dark pnpm --filter @acronis-platform/ui-react storybook:test:visual:docker:update
-# Check both (what CI runs)
-pnpm --filter @acronis-platform/ui-react storybook:test:visual:docker
-STORYBOOK_COLOR_MODE=dark pnpm --filter @acronis-platform/ui-react storybook:test:visual:docker
+pnpm --filter @acronis-platform/ui-react storybook:test:visual:docker:update:all  # regenerate light + dark
+pnpm --filter @acronis-platform/ui-react storybook:test:visual:docker:all         # check both (what CI runs)
 ```
+
+(For a single mode, the `:docker:update` / `:docker:update:dark` and `:docker` /
+`:docker:dark` variants exist too.)
 
 When you **remove or rename** a story, delete BOTH its baselines (`<id>.png` and
 `<id>--dark.png`) — the runner only writes/updates existing stories, leaving orphans.
@@ -362,8 +361,8 @@ the committed baselines still pass, and commit no PNGs.
       `render`-prop composition.
 - [ ] `__stories__/<name>.stories.tsx` (hand) + `<name>.generated.stories.tsx`.
 - [ ] VR baselines regenerated in Docker for **both** light and dark
-      (`storybook:test:visual:docker:update` + the `STORYBOOK_COLOR_MODE=dark` variant)
-      and reviewed; both `<id>.png` and `<id>--dark.png` committed (orphans deleted).
+      (`storybook:test:visual:docker:update:all`) and reviewed; both `<id>.png` and
+      `<id>--dark.png` committed (orphans deleted).
 - [ ] `<name>.figma.tsx` — `COMPLETE`, validated by `figma:connect`.
 - [ ] `packages/ui-spec/components/<name>/` — 7 files, `ui-spec test` green.
 - [ ] Changeset for `@acronis-platform/ui-react`.

--- a/.claude/skills/figma-component/SKILL.md
+++ b/.claude/skills/figma-component/SKILL.md
@@ -323,16 +323,28 @@ Stories must be checked in light **and** dark mode in Storybook
 
 **Visual regression.** Stories are also VR cases (`@storybook/test-runner` +
 `jest-image-snapshot`, config in `.storybook/test-runner.ts`; baselines in
-`test/__snapshots__/`). After adding/updating stories, regenerate the **Linux**
-baselines in Docker and review the PNGs before committing them:
+`test/__snapshots__/`). CI runs a **light _and_ dark** matrix
+(`.github/workflows/visual-regression.yml`), so every story has **two** baselines:
+`<id>.png` (light) and `<id>--dark.png` (dark). The Docker update command defaults
+to `STORYBOOK_COLOR_MODE=light` — you MUST regenerate **both** modes or the dark CI
+job fails on the light-only baselines. After adding/updating stories, regenerate the
+**Linux** baselines for both modes and review the PNGs before committing:
 
 ```bash
-pnpm --filter @acronis-platform/ui-react storybook:test:visual:docker:update  # regenerate
-pnpm --filter @acronis-platform/ui-react storybook:test:visual:docker         # check (what CI runs)
+# Light (default)
+pnpm --filter @acronis-platform/ui-react storybook:test:visual:docker:update
+# Dark — same command, STORYBOOK_COLOR_MODE=dark (writes the `--dark.png` baselines)
+STORYBOOK_COLOR_MODE=dark pnpm --filter @acronis-platform/ui-react storybook:test:visual:docker:update
+# Check both (what CI runs)
+pnpm --filter @acronis-platform/ui-react storybook:test:visual:docker
+STORYBOOK_COLOR_MODE=dark pnpm --filter @acronis-platform/ui-react storybook:test:visual:docker
 ```
 
+When you **remove or rename** a story, delete BOTH its baselines (`<id>.png` and
+`<id>--dark.png`) — the runner only writes/updates existing stories, leaving orphans.
+
 Never commit baselines rendered on macOS/Windows — they won't match CI's Linux
-renderer. CI: `.github/workflows/visual-regression.yml`.
+renderer.
 
 On `--update`, the `:docker:update` run may legitimately rewrite **zero** PNGs —
 that happens when you're fixing code to match an already-correct baseline (e.g. a
@@ -349,8 +361,9 @@ the committed baselines still pass, and commit no PNGs.
 - [ ] `__tests__/<name>.test.tsx` — render, variants/states, a11y roles, ref,
       `render`-prop composition.
 - [ ] `__stories__/<name>.stories.tsx` (hand) + `<name>.generated.stories.tsx`.
-- [ ] VR baselines regenerated in Docker (`storybook:test:visual:docker:update`)
-      and reviewed; `test/__snapshots__/*.png` committed.
+- [ ] VR baselines regenerated in Docker for **both** light and dark
+      (`storybook:test:visual:docker:update` + the `STORYBOOK_COLOR_MODE=dark` variant)
+      and reviewed; both `<id>.png` and `<id>--dark.png` committed (orphans deleted).
 - [ ] `<name>.figma.tsx` — `COMPLETE`, validated by `figma:connect`.
 - [ ] `packages/ui-spec/components/<name>/` — 7 files, `ui-spec test` green.
 - [ ] Changeset for `@acronis-platform/ui-react`.

--- a/packages/ui-react/package.json
+++ b/packages/ui-react/package.json
@@ -44,7 +44,11 @@
     "storybook:test:visual": "test-storybook",
     "storybook:test:visual:update": "test-storybook --updateSnapshot",
     "storybook:test:visual:docker": "pnpm storybook:build && docker compose -f ./docker-compose.storybook.yml up --build --abort-on-container-exit --exit-code-from test-runner",
+    "storybook:test:visual:docker:dark": "STORYBOOK_COLOR_MODE=dark pnpm storybook:test:visual:docker",
+    "storybook:test:visual:docker:all": "pnpm storybook:test:visual:docker && pnpm storybook:test:visual:docker:dark",
     "storybook:test:visual:docker:update": "pnpm storybook:build && docker compose -f ./docker-compose.storybook.yml -f ./docker-compose.storybook.update.yml up --build --abort-on-container-exit --exit-code-from test-runner",
+    "storybook:test:visual:docker:update:dark": "STORYBOOK_COLOR_MODE=dark pnpm storybook:test:visual:docker:update",
+    "storybook:test:visual:docker:update:all": "pnpm storybook:test:visual:docker:update && pnpm storybook:test:visual:docker:update:dark",
     "figma:connect": "figma connect parse",
     "figma:connect:publish": "figma connect publish",
     "figma:connect:unpublish": "figma connect unpublish"


### PR DESCRIPTION
## Summary

Since #372 added a **light + dark** VR CI matrix, every story has two baselines (`<id>.png` and `<id>--dark.png`), but the `/figma-component` skill only regenerated **light** — so new/updated components passed `light` and failed `dark` until someone manually ran the dark pass (this bit PR #377).

This makes the both-modes flow a single command and points the skill at it.

### `packages/ui-react/package.json` — new VR scripts

- `storybook:test:visual:docker:dark` / `…:update:dark` — the dark pass (`STORYBOOK_COLOR_MODE=dark`).
- `storybook:test:visual:docker:all` / `…:update:all` — run **light then dark** in one go.

### `/figma-component` skill (Phase 5 + checklist)

- Regenerate with `storybook:test:visual:docker:update:all`, check with `storybook:test:visual:docker:all`.
- Documents the two-baseline-per-story model and the "delete **both** baselines when removing/renaming a story" rule (the runner only writes existing stories, leaving orphans).

The package.json change trips the VR workflow's paths-filter, so the light + dark jobs run here — they should pass (no component/baseline changes).