### PR TITLE
chore(ui-react): declare sideEffects for tree-shaking

### DIFF
--- a/.changeset/ui-react-side-effects.md
+++ b/.changeset/ui-react-side-effects.md
@@ -1,0 +1,9 @@
+---
+'@acronis-platform/ui-react': patch
+---
+
+Declare `"sideEffects": ["**/*.css"]` in package.json. This lets bundlers
+tree-shake unused component modules (the JS is side-effect-free) while still
+preserving the stylesheet entry (`@acronis-platform/ui-react/styles`), which
+must not be dropped. Consumers importing a subset of components now get a
+smaller bundle with no configuration.

--- a/packages/ui-react/package.json
+++ b/packages/ui-react/package.json
@@ -8,6 +8,9 @@
   },
   "description": "Acronis React component library — a Base UI implementation, themed by @acronis-platform/design-tokens.",
   "type": "module",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Adds `"sideEffects": ["**/*.css"]` to `packages/ui-react/package.json`.

The package shipped without a `sideEffects` hint, so bundlers conservatively
assumed every module might have import side effects and kept code that could
otherwise be dropped — even though the docs describe ui-react as fully
tree-shakeable.

The `["**/*.css"]` value:
- marks the stylesheet entry (`@acronis-platform/ui-react/styles`) as
  side-effectful so it is **never** tree-shaken away, and
- lets bundlers drop unused component modules (the component JS is
  side-effect-free — `forwardRef` + Base UI `useRender`, no top-level effects
  or CSS imports).

Consumers importing a subset of components get a smaller bundle, with no
configuration.

## Verification

- `packages/ui-react/package.json` is valid JSON; field = `["**/*.css"]`
- `pnpm --filter @acronis-platform/ui-react build` → exit 0; `dist/ui-react.css` still emitted
- No component JS imports `.css` directly (verified), so marking only CSS as
  side-effectful is safe
- Changeset included (`patch`)