### PR TITLE
ci(deploy): build ui-react library before the docs build

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -88,6 +88,13 @@ jobs:
           rm -rf apps/demo/dist/storybook-react
           cp -r packages/ui-react/storybook-static apps/demo/dist/storybook-react
 
+      # The docs import @acronis-platform/ui-react (and icons-react) from their
+      # built dist — the ui-react Storybook build above only bundles src, it does
+      # not emit the library dist — so build the ui-react library (+ its deps)
+      # before the docs build, or the static export fails to resolve the package.
+      - name: Build docs dependencies
+        run: pnpm --filter "@acronis-platform/ui-react..." run build
+
       - name: Build docs
         run: DOCS_STATIC_EXPORT=true DOCS_BASE_PATH=/uikit/docs pnpm --filter ./apps/docs run build
 

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ storybook-static
 
 # Fumadocs
 .source
+/apps/docs/out/
 
 # AI
 .ai


### PR DESCRIPTION
## Problem

After merging the docs refocus (#396), the **Demo & Storybook – Deploy to Pages**
workflow fails at the **Build docs** step:

```
Module not found: Can't resolve '@acronis-platform/ui-react'
```

(see run https://github.com/acronis/uikit/actions/runs/28189001614)

## Cause

The deploy workflow builds the **ui-legacy** dist, the **icons-react** dist, and
the ui-react **Storybook** (which only bundles `src`) — but never the ui-react
**library** dist (`dist/index.js`). The docs now import
`@acronis-platform/ui-react` (live component previews + the `/api/ui-react-css`
route reads `dist/ui-react.css`), which resolves to that unbuilt dist, so the
static export can't resolve the package.

This only surfaced in the **static-export deploy** path; the regular `next build`
and `next dev` resolve fine once a dist exists locally.

## Fix

Add a `Build docs dependencies` step (`pnpm --filter "@acronis-platform/ui-react..." run build`)
before `Build docs`, so the ui-react library and its deps are built first. Also
gitignore the docs static-export output (`apps/docs/out/`).

## Verification

Reproduced the exact deploy command locally with the ui-react dist present:

```
DOCS_STATIC_EXPORT=true DOCS_BASE_PATH=/uikit/docs pnpm --filter ./apps/docs run build
→ exit 0, apps/docs/out/ generated (all routes prerendered)
```

confirming the demos + route handler are static-export compatible and the only
gap was the missing library build.