### PR TITLE
fix(docs): load preview stylesheet via basePath in static export

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -21,6 +21,13 @@ const basePath = process.env.DOCS_BASE_PATH ?? '';
 const config = {
   reactStrictMode: true,
   transpilePackages: ['@acronis-platform/shadcn-uikit-demos'],
+  // Expose the basePath to client code. basePath auto-applies to <Link>,
+  // next/image, and `_next` assets, but NOT to manual fetch() — the shadow-DOM
+  // previews fetch /api/ui-react-css, which must be prefixed when deployed
+  // under a subpath (e.g. /uikit/docs on GitHub Pages).
+  env: {
+    NEXT_PUBLIC_DOCS_BASE_PATH: basePath,
+  },
   // Skip type checking during build -- the monorepo has @types/react version
   // conflicts between the root (v18) and docs (v19) packages that cause false
   // positives. Type checking is done separately via tsc.

--- a/apps/docs/src/components/ShadowDemo.tsx
+++ b/apps/docs/src/components/ShadowDemo.tsx
@@ -27,7 +27,10 @@ let sheetPromise: Promise<CSSStyleSheet | null> | null = null;
 
 function getSheet(): Promise<CSSStyleSheet | null> {
   if (!sheetPromise) {
-    sheetPromise = fetch('/api/ui-react-css')
+    // basePath isn't applied to manual fetch(), so prefix it explicitly — the
+    // route lives at <basePath>/api/ui-react-css when deployed under a subpath.
+    const basePath = process.env.NEXT_PUBLIC_DOCS_BASE_PATH ?? '';
+    sheetPromise = fetch(`${basePath}/api/ui-react-css`)
       .then((r) => r.text())
       .then((cssText) => {
         const sheet = new CSSStyleSheet();


### PR DESCRIPTION
## Problem

On the deployed docs (GitHub Pages, basePath `/uikit/docs`) the live component
previews render **unstyled**, with a console error:

```
/api/ui-react-css  Failed to load resource: 404
```

## Cause

`ShadowDemo` fetches `/api/ui-react-css` to inject ui-react's stylesheet into
the preview's shadow root. Next applies `basePath` automatically to `<Link>`,
`next/image`, and `_next` assets — **but not to manual `fetch()`**. So the
request hit `https://acronis.github.io/api/ui-react-css` (domain root) instead
of `…/uikit/docs/api/ui-react-css`, 404'd, and no stylesheet was adopted.

## Fix

- Expose the basePath to client code as `NEXT_PUBLIC_DOCS_BASE_PATH` (next.config `env`).
- Prefix the `ShadowDemo` fetch with it.

In non-export builds basePath is `""`, so behavior is unchanged (dev + regular build still fetch `/api/ui-react-css`).

## Verification

Built the static export (`DOCS_STATIC_EXPORT=true DOCS_BASE_PATH=/uikit/docs`),
served `out/` under `/uikit/docs/`, and loaded a component page:

- `GET /uikit/docs/api/ui-react-css` → **200** (was 404 at the root path)
- bundle now fetches `/uikit/docs/api/ui-react-css`
- Tag preview renders fully styled (`adoptedStyleSheets: 1`), all variants colored