### PR TITLE
fix(docs): point Storybook nav link at the sibling app, not under docs basePath

### DIFF
--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -170,6 +170,16 @@ const mono: React.CSSProperties = { fontFamily: 'ui-monospace, monospace' };
 const muted = 'var(--color-fd-muted-foreground, #64748b)';
 const primary = 'var(--color-fd-primary)';
 
+// Storybook and the demo SPA are sibling apps deployed alongside the docs (one
+// level up from the docs basePath: /uikit/docs -> /uikit). They are NOT under
+// the docs basePath, so link to them as external — otherwise Fumadocs prefixes
+// the basePath and produces /uikit/docs/storybook-react instead of
+// /uikit/storybook-react.
+const siteRoot = (process.env.NEXT_PUBLIC_DOCS_BASE_PATH ?? '').replace(
+  /\/[^/]+$/,
+  ''
+);
+
 export default function HomePage() {
   return (
     <HomeLayout
@@ -178,8 +188,13 @@ export default function HomePage() {
       links={[
         { type: 'main', text: 'Documentation', url: '/docs' },
         { type: 'main', text: 'Components', url: '/docs/components' },
-        { type: 'main', text: 'Storybook', url: '/storybook-react' },
-        // { type: 'main', text: 'Demo', url: '/demo' },
+        {
+          type: 'main',
+          text: 'Storybook',
+          url: `${siteRoot}/storybook-react`,
+          external: true,
+        },
+        // { type: 'main', text: 'Demo', url: `${siteRoot}/`, external: true },
       ]}
     >
       {/* ── Hero ─────────────────────────────────────────────────────────── */}


### PR DESCRIPTION
## Problem

On the deployed landing, the **Storybook** nav link points to
`https://acronis.github.io/uikit/docs/storybook-react`, but Storybook is
deployed at `https://acronis.github.io/uikit/storybook-react`.

## Cause

Fumadocs treats a root-relative `url` (`/storybook-react`) as **internal** and
prefixes the docs basePath (`/uikit/docs`). Storybook is a **sibling** app under
the demo site root (`/uikit/`), one level above the docs basePath.

## Fix

Mark the link `external: true` — Fumadocs then renders a plain anchor and skips
the basePath prefix — and point it at the basePath's parent + `/storybook-react`,
derived from `NEXT_PUBLIC_DOCS_BASE_PATH`:

```
/uikit/docs  ->  /uikit  ->  /uikit/storybook-react
```

Using the env keeps it correct in dev (basePath `""` → `/storybook-react`). The
commented-out Demo link is updated the same way for when it's re-enabled.

## Verification

Static export under basePath `/uikit/docs`:

- landing's Storybook anchor is now `href="/uikit/storybook-react"` (was `/uikit/docs/storybook-react`)
- `typecheck` clean; export build exit 0