### PR TITLE
feat(ui-react): add Textarea alias for InputTextArea

### DIFF
--- a/.changeset/textarea-alias.md
+++ b/.changeset/textarea-alias.md
@@ -1,0 +1,7 @@
+---
+'@acronis-platform/ui-react': minor
+---
+
+Add a `Textarea` alias (and `TextareaProps`) for `InputTextArea`, mirroring the
+`Input` / `Search` aliases of `InputText` / `InputSearch`. `InputTextArea`
+remains the canonical export; `Textarea` is an additional name for discovery.

--- a/packages/ui-react/src/index.ts
+++ b/packages/ui-react/src/index.ts
@@ -14,9 +14,10 @@ export * from './components/ui/input-text';
 export * from './components/ui/input-text-area';
 export * from './components/ui/link';
 export * from './components/ui/search-global';
-// `Input` / `Search` are aliases of the full-field components `InputText` /
-// `InputSearch`. The bare input/search boxes are internal primitives (`InputBox`
-// / `SearchBox`), consumed by those fields and not exported.
+// `Input` / `Search` / `Textarea` are aliases of the full-field components
+// `InputText` / `InputSearch` / `InputTextArea`. The bare input/search boxes are
+// internal primitives (`InputBox` / `SearchBox`), consumed by those fields and
+// not exported.
 export {
   InputText as Input,
   type InputTextProps as InputProps,
@@ -25,6 +26,10 @@ export {
   InputSearch as Search,
   type InputSearchProps as SearchProps,
 } from './components/ui/input-search';
+export {
+  InputTextArea as Textarea,
+  type InputTextAreaProps as TextareaProps,
+} from './components/ui/input-text-area';
 export * from './components/ui/select';
 export * from './components/ui/resizable';
 export * from './components/ui/sidebar-primary';


### PR DESCRIPTION
## What

Exports `Textarea` (and `TextareaProps`) as an alias of `InputTextArea`, mirroring the `Input` / `Search` aliases of `InputText` / `InputSearch` added in #407.

- `InputTextArea` remains the canonical export; `Textarea` is an additional name for discovery.
- `InputTextArea` is self-contained (renders `<textarea>` directly), so — unlike Input/Search — there's no bare primitive to demote. Purely additive, non-breaking.

## Verification

- `pnpm -r typecheck` ✓ (incl. kitchen-sink/docs), ui-react tests (242) ✓, lint ✓, build ✓ — `Textarea`/`TextareaProps` present in both `dist/index.js` and the bundled `.d.ts`.
- `minor` (additive) changeset included.