### PR TITLE
docs(input-text-area): note Textarea is an alias of InputTextArea

### DIFF
--- a/apps/docs/content/docs/components/input-text-area.mdx
+++ b/apps/docs/content/docs/components/input-text-area.mdx
@@ -17,6 +17,12 @@ optional label (with a `required` marker), helper description, and error
 message. Without a label it renders just the box. Themed by the
 `--ui-input-text-area-*` tokens.
 
+> **`Textarea` is an alias of `InputTextArea`.** The legacy bare `Textarea` box
+> is replaced by this design-system-native field; `import { Textarea } from
+> '@acronis-platform/ui-react'` re-exports `InputTextArea` — same props. Without
+> a `label` it's a drop-in for the bare textarea. Prefer `InputTextArea` in new
+> code.
+
 ## Examples
 
 


### PR DESCRIPTION
Closes out the **Textarea** WS-A item.

**No code change needed** — `Textarea` is already a re-export alias of
`InputTextArea` (added in PR #408), and `InputTextArea` extends native
`<textarea>` props with an *optional* `label`, so `<Textarea placeholder=… />`
(no label) is a genuine drop-in for the legacy bare textarea box. The legacy
generic `Textarea` is superseded by the design-system-native field — the same
`Badge → Tag` decision pattern.

This adds the one missing piece: a discoverability note on the InputTextArea docs
page (mirroring the Badge note on the Tag page) pointing `Textarea` seekers at
`InputTextArea`. Docs-only; `apps/docs` is private, so no changeset.