### PR TITLE
fix(docs): drop /docs prefix from internal links (double-path)

### DIFF
--- a/apps/docs/content/docs/patterns/index.mdx
+++ b/apps/docs/content/docs/patterns/index.mdx
@@ -18,9 +18,9 @@ truth — and is rendered + explained here.
 
 ## Available patterns
 
-- [Filter popover](/docs/patterns/filter-popover) — a trigger that opens a
+- [Filter popover](/patterns/filter-popover) — a trigger that opens a
   popover of filter fields with Apply / Reset. Replaces the legacy
   `el-multi-search`.
-- [Data table bulk actions](/docs/patterns/data-table-bulk-actions) — row
+- [Data table bulk actions](/patterns/data-table-bulk-actions) — row
   selection driving a contextual bulk-action bar (Export / Delete / Clear) over
   one shared table instance.

--- a/apps/docs/content/docs/token-reference.mdx
+++ b/apps/docs/content/docs/token-reference.mdx
@@ -5,14 +5,14 @@ description: Every --ui-* design token shipped by @acronis-platform/tokens-pd, g
 
 import { TokenReference } from '@/components/TokenReference';
 
-[`@acronis-platform/tokens-pd`](/docs/packages/tokens-pd) ships design tokens as
+[`@acronis-platform/tokens-pd`](/packages/tokens-pd) ships design tokens as
 CSS custom properties (`--ui-*`). The **Semantic** tier (`css/acronis.css`) is
 bundled by `@acronis-platform/ui-react/styles`; each **component** tier
 (`css/<Component>/acronis.css`) is opt-in.
 
 Values are shown for the `acronis` brand exactly as authored — many resolve via
-[`light-dark()`](/docs/theming), so the active color scheme picks the light or
+[`light-dark()`](/theming), so the active color scheme picks the light or
 dark value at runtime. For more on how brands and color schemes are delivered,
-see [Theming](/docs/theming).
+see [Theming](/theming).
 
 <TokenReference />

--- a/apps/docs/content/docs/typography.mdx
+++ b/apps/docs/content/docs/typography.mdx
@@ -5,7 +5,7 @@ description: The typography scale shipped by @acronis-platform/tokens-pd as .ui-
 
 import { TypographyCatalog } from '@/components/TypographyCatalog';
 
-[`@acronis-platform/tokens-pd`](/docs/packages/tokens-pd) emits the typography
+[`@acronis-platform/tokens-pd`](/packages/tokens-pd) emits the typography
 scale as `.ui-typography-*` utility classes (in `css/acronis.css`), rather than
 as `--ui-*` custom properties. Apply a class to set a complete text style —
 font family, size, weight, line height, and letter spacing — in one place:


### PR DESCRIPTION
The docs site serves content at `baseUrl: '/'` (Fumadocs) under a deploy
`basePath` (`/uikit/docs`) that Next **auto-applies** to `<Link>`/routes. So an
internal link written as `/docs/<page>` resolves to `/uikit/docs/docs/<page>` — a
dead double path. The repo convention (used by ~40 other links) is `/<page>`.

Fixed the 6 stray `/docs/`-prefixed links:

- `typography.mdx` → `/packages/tokens-pd`
- `token-reference.mdx` → `/packages/tokens-pd`, `/theming` (×2)
- `patterns/index.mdx` → `/patterns/filter-popover`, `/patterns/data-table-bulk-actions`

Verified no `/docs/`-prefixed links remain anywhere in `apps/docs` (content or
source). Docs-only, private workspace — no changeset.