### PR TITLE
refactor(checkbox): center the box inline via align-middle

### DIFF
--- a/.changeset/checkbox-align-middle.md
+++ b/.changeset/checkbox-align-middle.md
@@ -1,0 +1,13 @@
+---
+'@acronis-platform/ui-react': patch
+---
+
+refactor(checkbox): center the checkbox box inline (align-middle)
+
+Move `align-middle` onto the `Checkbox` root so the box stays vertically centered
+whenever it sits inline next to text (it previously defaulted to the text
+baseline and sat high). This replaces the table-scoped
+`[&_[role=checkbox]]:align-middle` rule added in the cell-alignment fix — the
+Table no longer needs it, and any inline checkbox now centers everywhere, not
+just in tables. No visual change to existing baselines (the computed alignment is
+identical; just declared on the component instead of the cell).

--- a/packages/ui-react/src/components/ui/checkbox/checkbox.tsx
+++ b/packages/ui-react/src/components/ui/checkbox/checkbox.tsx
@@ -30,7 +30,9 @@ import { cn } from '@/lib/utils';
 // the box renders on its own (name it with `aria-label`).
 const boxClasses = [
   // geometry + focus ring
-  'inline-flex size-[var(--ui-checkbox-global-box-size)] shrink-0 cursor-pointer items-center justify-center rounded-[var(--ui-checkbox-global-box-border-radius)] border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-focus-primary)] [&_svg]:shrink-0',
+  // `align-middle` keeps the box vertically centered when it sits inline next to
+  // text (e.g. in a table cell) rather than defaulting to the text baseline.
+  'inline-flex size-[var(--ui-checkbox-global-box-size)] shrink-0 cursor-pointer items-center justify-center rounded-[var(--ui-checkbox-global-box-border-radius)] border align-middle transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-focus-primary)] [&_svg]:shrink-0',
   // unchecked (base): idle / hover / active
   'bg-[var(--ui-checkbox-unchecked-box-color-idle)] border-[var(--ui-checkbox-unchecked-box-border-color-idle)]',
   'not-data-[disabled]:hover:bg-[var(--ui-checkbox-unchecked-box-color-hover)] not-data-[disabled]:hover:border-[var(--ui-checkbox-unchecked-box-border-color-hover)]',

--- a/packages/ui-react/src/components/ui/table/table.tsx
+++ b/packages/ui-react/src/components/ui/table/table.tsx
@@ -133,7 +133,7 @@ const TableHead = React.forwardRef<HTMLTableCellElement, TableHeadProps>(
               : undefined
       }
       className={cn(
-        'h-10 px-[var(--ui-table-header-cell-padding-x)] text-left align-middle text-sm font-semibold text-[var(--ui-table-header-label-color)] [&:has([role=checkbox])]:pr-0 [&_[role=checkbox]]:align-middle',
+        'h-10 px-[var(--ui-table-header-cell-padding-x)] text-left align-middle text-sm font-semibold text-[var(--ui-table-header-label-color)] [&:has([role=checkbox])]:pr-0',
         sortable &&
           'cursor-pointer transition-colors hover:bg-[var(--ui-table-header-cell-color-hover)]',
         className
@@ -164,7 +164,7 @@ const TableCell = React.forwardRef<
   <td
     ref={ref}
     className={cn(
-      'h-10 px-[var(--ui-table-global-cell-padding-x)] py-[var(--ui-table-global-cell-padding-y)] align-middle text-sm [&:has([role=checkbox])]:pr-0 [&_[role=checkbox]]:align-middle',
+      'h-10 px-[var(--ui-table-global-cell-padding-x)] py-[var(--ui-table-global-cell-padding-y)] align-middle text-sm [&:has([role=checkbox])]:pr-0',
       className
     )}
     {...props}


### PR DESCRIPTION
Follow-up to the data-table cell-alignment fix (#432): move the checkbox
vertical-centering from the table-scoped rule into the `Checkbox` component itself.

- `Checkbox`: add `align-middle` to the root, so the box centers whenever it sits
  inline next to text instead of defaulting to the text baseline (sitting high).
- `Table`: drop the now-redundant `[&_[role=checkbox]]:align-middle` from the
  header and body cells.

Net effect: identical rendering for tables (the computed `vertical-align` on the
checkbox is the same — just declared on the component, not the cell), **plus** any
inline checkbox-next-to-text now centers everywhere, not only in tables.

## Verification
- ✅ ui-react test (321), lint, typecheck
- ✅ Docker VR light + dark — **275/275 pass, zero baseline changes** (confirms the
  refactor is pixel-identical)

Changeset: `@acronis-platform/ui-react` patch.