### PR TITLE
feat(patterns): add sheet-detail-panel usage pattern

### DIFF
--- a/apps/docs/content/docs/patterns/index.mdx
+++ b/apps/docs/content/docs/patterns/index.mdx
@@ -24,3 +24,6 @@ truth — and is rendered + explained here.
 - [Data table bulk actions](/patterns/data-table-bulk-actions) — row
   selection driving a contextual bulk-action bar (Export / Delete / Clear) over
   one shared table instance.
+- [Sheet detail panel](/patterns/sheet-detail-panel) — details of a selected
+  item in a side Sheet: title, property list, content states (loading / empty),
+  and footer actions. The React composition of the Vue `Details`.

--- a/apps/docs/content/docs/patterns/meta.json
+++ b/apps/docs/content/docs/patterns/meta.json
@@ -1,4 +1,9 @@
 {
   "title": "Patterns",
-  "pages": ["index", "filter-popover", "data-table-bulk-actions"]
+  "pages": [
+    "index",
+    "filter-popover",
+    "data-table-bulk-actions",
+    "sheet-detail-panel"
+  ]
 }

--- a/apps/docs/content/docs/patterns/sheet-detail-panel.mdx
+++ b/apps/docs/content/docs/patterns/sheet-detail-panel.mdx
@@ -1,0 +1,80 @@
+---
+title: Sheet detail panel
+description: Show the details of a selected item in a side Sheet — title, properties, content states, and footer actions.
+---
+
+import { DemoReact } from "@/components/DemoReact";
+import { SheetDetailPanelDemo } from "@/components/demos-react/patterns/sheet-detail-panel";
+
+The approved way to present "details of the selected thing" beside its list. A
+**`Sheet`** anchored to the right edge with a header (title + close), a body that
+switches by **content state** (loading → **`Spinner`**, empty/error →
+**`Empty`**, otherwise a key/value property list), and a footer of **`Button`**
+actions. This is the React composition of the Vue kit's feature-rich `Details`
+component — its content-state, properties, and action-bar behavior live in the
+recipe, not as props baked into the `Sheet` primitive.
+
+<DemoReact>
+  <SheetDetailPanelDemo />
+</DemoReact>
+
+## When to use
+
+- Inspecting or acting on a selected row/entity next to its table or list.
+- A detail view that must load, can be empty, and offers a few actions.
+
+## When not to use
+
+- A centered confirmation or short form — use `Dialog`.
+- Persistent, non-modal page chrome — use `SidebarSecondary`, not a modal Sheet.
+- A simple message with no data/actions — a plain `Sheet` is enough.
+
+## Anti-patterns
+
+- Hand-rolling a fixed side panel instead of composing `Sheet` — you lose the
+  focus trap, scroll lock, ARIA, and animations.
+- Mixing states — switch the **whole** body by `contentState`; don't scatter a
+  spinner/empty inline among real content.
+- More than ~2–3 primary footer actions — overflow belongs in a menu.
+- Omitting `SheetTitle` — the panel then has no accessible name.
+
+## How it works
+
+Keep the header (title + close) and footer (actions) stable; switch only the body
+by a `contentState`:
+
+```tsx
+<Sheet open={open} onOpenChange={setOpen}>
+  <SheetContent side="right">
+    <SheetHeader>
+      <SheetTitle>{item?.name ?? 'Details'}</SheetTitle>
+      <SheetCloseButton />
+    </SheetHeader>
+    <SheetBody>
+      {contentState === 'loading' ? (
+        <div className="flex h-full items-center justify-center"><Spinner /></div>
+      ) : contentState === 'empty' ? (
+        <Empty>
+          <EmptyHeader>
+            <EmptyTitle>Nothing to show</EmptyTitle>
+            <EmptyDescription>This item has no details yet.</EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : (
+        <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm">
+          {item.properties.map((p) => (
+            <Fragment key={p.label}>
+              <dt className="text-muted-foreground">{p.label}</dt>
+              <dd className="font-medium">{p.value}</dd>
+            </Fragment>
+          ))}
+        </dl>
+      )}
+    </SheetBody>
+    <SheetFooter>
+      <SheetClose render={<Button variant="ghost">Close</Button>} />
+      <Button>Edit</Button>
+    </SheetFooter>
+  </SheetContent>
+</Sheet>
+```

--- a/apps/docs/src/components/demos-react/patterns/sheet-detail-panel.tsx
+++ b/apps/docs/src/components/demos-react/patterns/sheet-detail-panel.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { Fragment, useState } from 'react';
+import {
+  Button,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+  Sheet,
+  SheetBody,
+  SheetClose,
+  SheetCloseButton,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  Spinner,
+} from '@acronis-platform/ui-react';
+import { useShadowMount } from '@/components/ShadowDemo';
+
+type ContentState = 'content' | 'loading' | 'empty';
+
+const properties = [
+  { label: 'Status', value: 'Protected' },
+  { label: 'Last backup', value: '5 minutes ago' },
+  { label: 'Owner', value: 'ken99@example.com' },
+  { label: 'Plan', value: 'Total protection' },
+];
+
+const STATES: { id: ContentState; label: string }[] = [
+  { id: 'content', label: 'Details' },
+  { id: 'loading', label: 'Loading' },
+  { id: 'empty', label: 'Empty' },
+];
+
+export function SheetDetailPanelDemo() {
+  const mount = useShadowMount();
+  const [open, setOpen] = useState(false);
+  const [state, setState] = useState<ContentState>('content');
+
+  const show = (s: ContentState) => {
+    setState(s);
+    setOpen(true);
+  };
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {STATES.map((s) => (
+        <Button key={s.id} variant="secondary" onClick={() => show(s.id)}>
+          {s.label}
+        </Button>
+      ))}
+
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent side="right" portalContainer={mount}>
+          <SheetHeader>
+            <SheetTitle>Workload details</SheetTitle>
+            <SheetCloseButton />
+          </SheetHeader>
+          <SheetBody>
+            {state === 'loading' ? (
+              <div className="flex h-40 items-center justify-center">
+                <Spinner />
+              </div>
+            ) : state === 'empty' ? (
+              <Empty>
+                <EmptyHeader>
+                  <EmptyTitle>Nothing to show</EmptyTitle>
+                  <EmptyDescription>
+                    This workload has no details yet.
+                  </EmptyDescription>
+                </EmptyHeader>
+              </Empty>
+            ) : (
+              <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm">
+                {properties.map((p) => (
+                  <Fragment key={p.label}>
+                    <dt className="text-muted-foreground">{p.label}</dt>
+                    <dd className="font-medium">{p.value}</dd>
+                  </Fragment>
+                ))}
+              </dl>
+            )}
+          </SheetBody>
+          <SheetFooter>
+            <SheetClose render={<Button variant="ghost">Close</Button>} />
+            <Button>Edit</Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}

--- a/packages/ui-spec/patterns/sheet-detail-panel/pattern.yaml
+++ b/packages/ui-spec/patterns/sheet-detail-panel/pattern.yaml
@@ -1,0 +1,80 @@
+spec_version: '1.0'
+pattern: SheetDetailPanel
+name: sheet-detail-panel
+status: draft
+category: overlays
+since: 0.42.0
+intent: Show the details of a selected item in a side Sheet — title, key/value properties, content states, and footer actions.
+replaces: AvDetails
+description: >-
+  The sanctioned way to present "details of the selected thing" beside its list:
+  a `Sheet` anchored to the right edge with a header (title + close), a body that
+  renders either a key/value property list or a content state (loading → Spinner,
+  empty/error → Empty), and a footer of actions. This is the React composition of
+  the Vue kit's feature-rich `Details` component — its content-state, properties,
+  and action-bar behavior become a composed recipe rather than props baked into
+  the Sheet primitive.
+
+when_to_use:
+  - Inspecting/acting on a selected row or entity next to its table or list.
+  - A detail view that must load, can be empty, and offers a few actions.
+when_not_to_use:
+  - A centered confirmation or short form — use `Dialog`.
+  - Persistent, non-modal page chrome — use `SidebarSecondary`, not a modal Sheet.
+  - A simple message with no data/actions — a plain `Sheet` is enough.
+
+anti_patterns:
+  - Hand-rolling a fixed side panel instead of composing `Sheet` (loses focus trap, scroll lock, ARIA, animations).
+  - Rendering a spinner/empty state inline in the body INSTEAD of switching the whole body by a `contentState` — mixed states confuse.
+  - Putting more than ~2–3 primary actions in the footer; overflow belongs in a menu.
+  - Omitting `SheetTitle` — the panel then has no accessible name.
+
+components:
+  - Sheet
+  - Button
+  - Spinner
+  - Empty
+
+demo: apps/docs/src/components/demos-react/patterns/sheet-detail-panel.tsx
+docs: apps/docs/content/docs/patterns/sheet-detail-panel.mdx
+
+# Approved starting point. Switch the whole body by `contentState`; keep the
+# header (title + close) and footer (actions) stable across states.
+example: |
+  function DetailPanel({ open, onOpenChange, contentState, item }) {
+    return (
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent side="right">
+          <SheetHeader>
+            <SheetTitle>{item?.name ?? 'Details'}</SheetTitle>
+            <SheetCloseButton />
+          </SheetHeader>
+          <SheetBody>
+            {contentState === 'loading' ? (
+              <div className="flex h-full items-center justify-center"><Spinner /></div>
+            ) : contentState === 'empty' ? (
+              <Empty>
+                <EmptyHeader>
+                  <EmptyTitle>Nothing to show</EmptyTitle>
+                  <EmptyDescription>This item has no details yet.</EmptyDescription>
+                </EmptyHeader>
+              </Empty>
+            ) : (
+              <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm">
+                {item.properties.map((p) => (
+                  <Fragment key={p.label}>
+                    <dt className="text-muted-foreground">{p.label}</dt>
+                    <dd className="font-medium">{p.value}</dd>
+                  </Fragment>
+                ))}
+              </dl>
+            )}
+          </SheetBody>
+          <SheetFooter>
+            <SheetClose render={<Button variant="ghost">Close</Button>} />
+            <Button>Edit</Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    );
+  }


### PR DESCRIPTION
The first **Sheet pattern** — the React composition of the Vue kit's feature-rich
`Details` component, as an approved recipe (the follow-up promised in the Sheet PR
#439).

A right-anchored **`Sheet`** with a stable header (title + close) and footer
(actions), and a body that switches by **content state**:
- `loading` → **`Spinner`**
- `empty` / error → **`Empty`**
- otherwise → a key/value property list

This keeps `Details`' content-state / properties / action-bar behavior in a
composed recipe rather than baked into the `Sheet` primitive.

## Included
- `packages/ui-spec/patterns/sheet-detail-panel/pattern.yaml` — the AI source of
  truth (intent, when/when-not, **anti-patterns**, components, approved example).
- A live `<DemoReact>` demo (toggle Details / Loading / Empty) + the Patterns
  docs page, registered in the nav + index.

## Enforcement (the bigger goal)
This lands the *recipe*. Making it **enforced** (so AI + humans always use it) is
the next step I proposed: an ESLint rule that flags ad-hoc side panels / mixed
content-states (its messages drawn from the pattern's `anti_patterns`), and
optionally a `SheetDetails` preset component so the easy path *is* the pattern.
Tracked as a follow-up.

## Verification
- ✅ ui-spec test (277 — pattern.yaml validates; all referenced components exist in ui-react)
- ✅ docs typecheck (the demo compiles)

No changeset — `ui-spec` and `apps/docs` are private.