### PR TITLE
feat(grammar): add screen-descriptor specs + validation (Phase 2)

### DIFF
--- a/packages/ui-spec/AGENTS.md
+++ b/packages/ui-spec/AGENTS.md
@@ -88,6 +88,19 @@ off-grid-spacing as `should`). It reads severities from the grammar registry and
 `must` finding fails CI. Add a detector by appending to the `DETECTORS` array and
 its grammar rule's `detector` id.
 
+## Screens (application layer)
+
+`screens/<slug>/screen.yaml` describes a real **product screen** assembled from
+real ui-react components — the layer above `components/`/`patterns/`/`grammar/`,
+and the input to the future rendered screen audit. Each descriptor has `regions[]`
+(layout + `components[]` with `$bind`/`$token` props + governing grammar `rules`),
+a `stateMachine`, and a `figma` node. Validated by `__tests__/screens.test.ts`
+against `schema/screen.schema.json`: schema, component refs resolve in ui-react,
+grammar-rule refs resolve, the `pattern` slug exists, and the state machine has
+one initial + all-reachable states. First example: `screens/protection-dashboard`
+(the App Shell with-secondary screen). **Phase 2** of the kit-consistency proposal;
+a `ProductDescriptor` (flows/entry) and the audit follow. See [`screens/README.md`](./screens/README.md).
+
 ## Scripts
 
 `build`/`dev`/`clean` are no-ops (ships source YAML/MD). `lint`/`typecheck` run

--- a/packages/ui-spec/__tests__/screens.test.ts
+++ b/packages/ui-spec/__tests__/screens.test.ts
@@ -1,0 +1,119 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020';
+import { load as parseYaml } from 'js-yaml';
+import { describe, expect, it } from 'vitest';
+
+import { getRule } from '../grammar';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = resolve(HERE, '..');
+const SCREENS_DIR = join(PKG_ROOT, 'screens');
+const PATTERNS_DIR = join(PKG_ROOT, 'patterns');
+const UI_REACT_UI = resolve(PKG_ROOT, '../ui-react/src/components/ui');
+
+const ajv = new Ajv2020({ strict: false, allErrors: true });
+const validate = ajv.compile(
+  JSON.parse(readFileSync(join(PKG_ROOT, 'schema', 'screen.schema.json'), 'utf8'))
+);
+
+const toKebab = (s: string): string =>
+  s.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+
+interface Region {
+  rules?: string[];
+  components?: { component: string }[];
+  children?: Region[];
+}
+interface Screen {
+  name: string;
+  pattern?: string;
+  regions: Region[];
+  stateMachine: {
+    states: { name: string; initial?: boolean; rules?: string[] }[];
+    transitions: { from: string; to: string }[];
+  };
+}
+
+function listScreens(): string[] {
+  if (!existsSync(SCREENS_DIR)) return [];
+  return readdirSync(SCREENS_DIR)
+    .filter((e) => statSync(join(SCREENS_DIR, e)).isDirectory())
+    .sort();
+}
+
+function walkRegions(regions: Region[], visit: (r: Region) => void): void {
+  for (const r of regions) {
+    visit(r);
+    if (r.children) walkRegions(r.children, visit);
+  }
+}
+
+describe('every screen descriptor validates and references real things', () => {
+  for (const name of listScreens()) {
+    const screen = parseYaml(
+      readFileSync(join(SCREENS_DIR, name, 'screen.yaml'), 'utf8')
+    ) as Screen;
+
+    it(`${name}: schema + slug`, () => {
+      expect(validate(screen), ajv.errorsText(validate.errors, { separator: '\n' })).toBe(true);
+      expect(screen.name).toBe(name);
+    });
+
+    it(`${name}: referenced components exist in ui-react`, () => {
+      const components = new Set<string>();
+      walkRegions(screen.regions, (r) =>
+        r.components?.forEach((c) => components.add(c.component))
+      );
+      const missing = [...components].filter(
+        (c) => !existsSync(resolve(UI_REACT_UI, toKebab(c)))
+      );
+      expect(missing, `components not found in ui-react: ${missing.join(', ')}`).toEqual([]);
+    });
+
+    it(`${name}: referenced grammar rules resolve`, () => {
+      const ruleIds = new Set<string>();
+      walkRegions(screen.regions, (r) => r.rules?.forEach((id) => ruleIds.add(id)));
+      screen.stateMachine.states.forEach((s) => s.rules?.forEach((id) => ruleIds.add(id)));
+      const missing = [...ruleIds].filter((id) => !getRule(id));
+      expect(missing, `unknown grammar rules: ${missing.join(', ')}`).toEqual([]);
+    });
+
+    it(`${name}: pattern reference exists (if any)`, () => {
+      if (screen.pattern)
+        expect(
+          existsSync(join(PATTERNS_DIR, screen.pattern)),
+          `unknown pattern "${screen.pattern}"`
+        ).toBe(true);
+    });
+
+    it(`${name}: state machine has one initial, valid + reachable states`, () => {
+      const states = screen.stateMachine.states;
+      const names = new Set(states.map((s) => s.name));
+      expect(states.filter((s) => s.initial).length, 'exactly one initial state').toBe(1);
+      expect(new Set(states.map((s) => s.name)).size, 'unique state names').toBe(states.length);
+
+      for (const t of screen.stateMachine.transitions) {
+        expect(names.has(t.from), `transition from unknown state "${t.from}"`).toBe(true);
+        expect(names.has(t.to), `transition to unknown state "${t.to}"`).toBe(true);
+      }
+
+      // Every non-initial state is reachable from the initial state.
+      const initial = states.find((s) => s.initial)!.name;
+      const reached = new Set([initial]);
+      let grew = true;
+      while (grew) {
+        grew = false;
+        for (const t of screen.stateMachine.transitions) {
+          if (reached.has(t.from) && !reached.has(t.to)) {
+            reached.add(t.to);
+            grew = true;
+          }
+        }
+      }
+      const dead = states.map((s) => s.name).filter((n) => !reached.has(n));
+      expect(dead, `unreachable states: ${dead.join(', ')}`).toEqual([]);
+    });
+  }
+});

--- a/packages/ui-spec/schema/screen.schema.json
+++ b/packages/ui-spec/schema/screen.schema.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://acronis.com/ui-spec/screen.schema.json",
+  "title": "Screen descriptor — screen.yaml",
+  "description": "A machine-readable product screen: regions of real ui-react components, a state machine, and grammar/pattern references. The application layer above components, patterns, and grammar.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "spec_version",
+    "name",
+    "title",
+    "status",
+    "regions",
+    "stateMachine"
+  ],
+  "properties": {
+    "spec_version": { "type": "string" },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "description": "kebab slug; must equal the folder name."
+    },
+    "title": { "type": "string" },
+    "status": { "enum": ["draft", "ready", "stable", "deprecated"] },
+    "category": { "type": "string" },
+    "since": { "type": "string" },
+    "description": { "type": "string" },
+    "route": { "type": "string" },
+    "permissions": { "type": "array", "items": { "type": "string" } },
+    "pattern": {
+      "type": "string",
+      "description": "Optional usage-pattern slug (patterns/<name>) this screen assembles."
+    },
+    "figma": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "file": { "type": "string" },
+        "node": { "type": "string" }
+      }
+    },
+    "regions": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/region" }
+    },
+    "stateMachine": { "$ref": "#/$defs/stateMachine" }
+  },
+  "$defs": {
+    "region": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["regionId", "label", "layout"],
+      "properties": {
+        "regionId": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+        "label": { "type": "string" },
+        "ariaRole": { "type": "string" },
+        "visibleWhen": {
+          "type": "string",
+          "description": "Name of the state in which this region is shown."
+        },
+        "pattern": { "type": "string" },
+        "rules": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[a-z][a-z-]*/[a-z0-9-]+$" },
+          "description": "Grammar rule ids that govern this region. Each must exist in the registry."
+        },
+        "layout": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "enum": [
+                "fixed-width",
+                "flex-fill",
+                "overlay",
+                "sticky",
+                "dock-bottom"
+              ]
+            },
+            "position": { "enum": ["left", "right", "top", "bottom"] },
+            "width": { "type": "string" },
+            "scroll": { "enum": ["independent", "with-parent", "none"] }
+          }
+        },
+        "components": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/componentInstance" }
+        },
+        "children": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/region" }
+        }
+      }
+    },
+    "componentInstance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["instanceId", "component"],
+      "properties": {
+        "instanceId": { "type": "string" },
+        "component": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Za-z0-9]*$",
+          "description": "Root ui-react component name (PascalCase). Must exist."
+        },
+        "props": {
+          "type": "object",
+          "description": "Prop values: literals, { $bind: '<path>' }, or { $token: '--ui-*' }.",
+          "additionalProperties": true
+        },
+        "slots": { "type": "object", "additionalProperties": true },
+        "visibleWhen": { "type": "string" },
+        "disabledWhen": { "type": "string" },
+        "events": { "type": "object", "additionalProperties": true }
+      }
+    },
+    "stateMachine": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["states", "transitions"],
+      "properties": {
+        "states": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "category"],
+            "properties": {
+              "name": { "type": "string" },
+              "description": { "type": "string" },
+              "initial": { "type": "boolean" },
+              "category": {
+                "enum": [
+                  "idle",
+                  "loading",
+                  "loaded",
+                  "empty",
+                  "error",
+                  "custom"
+                ]
+              },
+              "rules": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^[a-z][a-z-]*/[a-z0-9-]+$"
+                }
+              }
+            }
+          }
+        },
+        "transitions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["from", "to", "trigger"],
+            "properties": {
+              "from": { "type": "string" },
+              "to": { "type": "string" },
+              "trigger": { "type": "string" },
+              "guard": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/ui-spec/screens/README.md
+++ b/packages/ui-spec/screens/README.md
@@ -1,0 +1,44 @@
+# `screens` — product screen descriptors
+
+The **application layer**: machine-readable descriptions of real product screens,
+assembled from real `@acronis-platform/ui-react` components. This is the layer
+above `components/` (one component), `patterns/` (a recipe), and `grammar/`
+(cross-component rules). A screen descriptor is the "screen spec" that the
+rendered **screen consistency audit** (Phase 3) will consume.
+
+Design and rationale: [`context/kit-consistency-audit-proposal.md`](../../../context/kit-consistency-audit-proposal.md).
+
+## Layout
+
+```
+screens/<slug>/screen.yaml     # one ScreenDescriptor per directory
+```
+
+Validated by `../__tests__/screens.test.ts` against `../schema/screen.schema.json`.
+
+## A `screen.yaml` contains
+
+- **identity** — `name` (= folder slug), `title`, `status`, optional `route`,
+  `permissions`, `figma` ({ file, node }), and a `pattern` slug it assembles.
+- **`regions[]`** — the spatial layout. Each region has a `layout`
+  (`fixed-width`/`flex-fill`/`overlay`/`sticky`/`dock-bottom` + position/scroll),
+  the real **`components[]`** it holds (root ui-react names, with `props` whose
+  values may be literals, `{ $bind: '<path>' }`, or `{ $token: '--ui-*' }`),
+  optional `rules` (grammar rule ids that govern the region), and nested
+  `children`.
+- **`stateMachine`** — `states` (each `idle`/`loading`/`loaded`/`empty`/`error`/
+  `custom`, exactly one `initial`) + `transitions` (`from`/`to`/`trigger`/`guard`).
+
+## What the test enforces
+
+- Schema validity; `name` equals the folder.
+- Every referenced **component** resolves to a real ui-react component directory.
+- Every referenced **grammar rule** id resolves in the registry.
+- The **pattern** slug (if set) exists under `../patterns/`.
+- The **state machine** has exactly one initial state, transitions reference real
+  states, and every non-initial state is reachable from the initial one.
+
+## Next
+
+A `ProductDescriptor` (screens + navigation `flows` + entry screen — the "app
+description") and the rendered screen audit follow in later phases.

--- a/packages/ui-spec/screens/protection-dashboard/screen.yaml
+++ b/packages/ui-spec/screens/protection-dashboard/screen.yaml
@@ -1,0 +1,101 @@
+spec_version: '1.0'
+name: protection-dashboard
+title: Protection Dashboard
+status: draft
+category: console
+description: >-
+  The Protection console dashboard: a full App Shell with a collapsed primary
+  rail, an expanded secondary section nav (Overview + Configuration with a
+  third-level Policies sub-menu), a centered global search header, and the main
+  content area. Worked example for the screen-spec format; mirrors the App Shell
+  "WithSecondary" story.
+route: /protection/dashboard
+permissions: [protection.view]
+pattern: app-shell
+figma:
+  file: lrU3ydIyvPYQNE6ixdsKtJ
+  node: 2782-1495
+
+regions:
+  - regionId: sidebar
+    label: Navigation rail
+    ariaRole: navigation
+    layout: { type: fixed-width, position: left, scroll: none }
+    # Sidebars scroll internally via ScrollArea — no reserved gutter may crop the
+    # full-bleed selected row, and the brand rail must use one token per role.
+    rules:
+      - composition/no-clipping
+      - tokens/one-token-per-role
+    components:
+      - instanceId: primary-nav
+        component: SidebarPrimary
+        props:
+          expanded: false
+          'aria-label': Primary
+      - instanceId: secondary-nav
+        component: SidebarSecondary
+        props:
+          expanded: true
+
+  - regionId: header
+    label: Top bar
+    ariaRole: banner
+    layout: { type: sticky, position: top, scroll: none }
+    # Search is centered; controls in the bar must share height and align.
+    rules:
+      - composition/edge-baseline-alignment
+      - spacing/control-height-parity
+    components:
+      - instanceId: global-search
+        component: SearchGlobal
+        props:
+          'aria-label': Search
+          placeholder: Search…
+        events:
+          input:
+            action: api-call
+            target: search
+            description: Debounced global search.
+
+  - regionId: main
+    label: Content area
+    ariaRole: main
+    layout: { type: flex-fill, scroll: independent }
+    # Sections on the page keep a consistent vertical rhythm.
+    rules:
+      - composition/vertical-rhythm
+    components:
+      - instanceId: page-header
+        component: PageHeader
+        props:
+          title: { $bind: section.title }
+        visibleWhen: loaded
+
+stateMachine:
+  states:
+    - name: idle
+      description: Before the dashboard requests data.
+      initial: true
+      category: idle
+    - name: loading
+      description: Fetching dashboard data; main area shows skeletons.
+      category: loading
+      rules: [anatomy/data-states-present]
+    - name: loaded
+      description: Dashboard populated.
+      category: loaded
+    - name: empty
+      description: No data for the current scope; shows an empty state.
+      category: empty
+      rules: [anatomy/empty-skeleton-parity]
+    - name: error
+      description: Fetch failed; shows an error with retry.
+      category: error
+  transitions:
+    - { from: idle, to: loading, trigger: mount }
+    - { from: loading, to: loaded, trigger: data-success, guard: 'count > 0' }
+    - { from: loading, to: empty, trigger: data-success, guard: 'count === 0' }
+    - { from: loading, to: error, trigger: data-error }
+    - { from: error, to: loading, trigger: retry }
+    - { from: empty, to: loading, trigger: scope-change }
+    - { from: loaded, to: loading, trigger: scope-change }


### PR DESCRIPTION
## Summary

**Phase 2** of the kit-consistency system (#482): the **screen-descriptor** format — machine-readable product screens assembled from real ui-react components. This is the application layer above `components/`, `patterns/`, and `grammar/`, and the input the rendered screen audit (Phase 3) will consume.

## What's here

- **`schema/screen.schema.json`** — the `ScreenDescriptor` schema (borrowed from the Vue `screens` shape, trimmed to what we render): identity (+ `route`/`permissions`/`figma`/`pattern`), `regions[]` (layout + real `components[]` with `props` as literals / `{ $bind }` / `{ $token }` + governing grammar `rules` + nested `children`), and a `stateMachine` (idle/loading/loaded/empty/error + transitions).
- **`screens/protection-dashboard/screen.yaml`** — the first real screen, modeling the App Shell `WithSecondary` story (collapsed primary rail + secondary nav + centered search + main), with a real Figma node, `$bind`/`$token` props, and grammar-rule refs per region (e.g. `composition/no-clipping` on the sidebar).
- **`__tests__/screens.test.ts`** — validates schema + slug, that every referenced **component** resolves to a ui-react dir, every **grammar-rule** id resolves, the **pattern** slug exists, and the **state machine** has one initial + all-reachable states (no dead states).
- `screens/README.md` + an AGENTS note.

## Result

typecheck / lint / **606 tests** green. `ui-spec` is private → no changeset.

> Next: a `ProductDescriptor` (navigation flows + entry = the "app description"), then Phase 3 — the rendered screen audit (generate a screen story from the descriptor, run structural detectors via the VR Playwright harness + an AI visual review).