### PR TITLE
feat(grammar): add rendered screen consistency audit (Phase 3)

### DIFF
--- a/.claude/skills/screen-audit/SKILL.md
+++ b/.claude/skills/screen-audit/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: screen-audit
+description: >
+  Render a real product screen from its ui-spec descriptor and run the
+  cross-component structural detectors over it — the "complete-screen
+  consistency audit". For each screen it loads screens/<slug>/screen.yaml,
+  opens the assembled-screen Storybook story (the descriptor's `story` id) in
+  light AND dark, captures a serializable snapshot with the screens/audit probe
+  (geometry, computed style, a11y, scrollbar gutters), then runs the pure
+  detectors via `pnpm --filter @acronis-platform/ui-spec screen-audit` — keyed to
+  the grammar's screen/* rules (control-height parity, accessible name, contrast,
+  edge alignment, reserved-gutter clipping, icon-size parity, vertical rhythm),
+  with `must` failing. Detectors first; an optional AI visual review covers the
+  judgment-only rows. Reports findings keyed by checklist id + severity; proposes
+  (never auto-applies) fixes + new grammar rules. Invoke with /screen-audit [screen-slug | all].
+argument-hint: '[screen-slug | all]'
+---
+
+# Skill: /screen-audit
+
+The rendered-screen half of the kit-consistency system (Phase 3 of
+[`context/kit-consistency-audit-proposal.md`](../../../context/kit-consistency-audit-proposal.md)).
+Where [`/kit-consistency`](../../../packages/ui-spec/scripts/kit-lint.ts) reads
+**source** statically, `/screen-audit` measures a **real assembled screen** and
+asks the questions only the rendered DOM can answer: do controls in a row share a
+height, do edges actually align, does a scrollbar gutter crop a full-bleed row,
+does text clear the contrast minimum.
+
+It **proposes**, it does not silently change anything. Findings are reported;
+`must` findings are CI-blocking defects; fixes and any new grammar rules are
+drafted for a human to ratify.
+
+## What it is built on
+
+- **Descriptors** — `packages/ui-spec/screens/<slug>/screen.yaml`: regions (each
+  opting into grammar `rules`), the components per region, a state machine, and a
+  `story` id (the assembled-screen Storybook story to capture).
+- **The engine** — `packages/ui-spec/screens/audit/`:
+  - `probe.ts` — `collectScreenSnapshot(opts)`, a self-contained browser function
+    (runs via `page.evaluate` / MCP `evaluate_script`) that returns a
+    `ScreenSnapshot` (no DOM handles).
+  - `detectors.ts` — pure detectors, one per `screen/*` grammar rule.
+  - `index.ts` — `runScreenAudit(snapshot, descriptor)` + `formatScreenReport`.
+- **The CLI** — `pnpm --filter @acronis-platform/ui-spec screen-audit <slug> <snapshot.json>`
+  (the Node half: detect + report + exit non-zero on `must`).
+
+The split is deliberate: **measurement** happens in the browser, **detection** is
+pure data-in/data-out (unit-tested in `__tests__/screen-audit.test.ts`). This
+skill is the glue that captures the snapshot and feeds it to the CLI.
+
+## Detectors implemented today
+
+| Rule id                               | Checklist | Severity |
+| ------------------------------------- | --------- | -------- |
+| `spacing/control-height-parity`       | Z2        | must     |
+| `accessibility/accessible-name`       | I1        | must     |
+| `accessibility/contrast`              | I5        | must     |
+| `composition/edge-baseline-alignment` | C2        | should   |
+| `composition/no-clipping`             | C8        | should   |
+| `spacing/icon-size-parity`            | Z6        | should   |
+| `composition/vertical-rhythm`         | C1        | should   |
+
+A region-scoped detector runs only on regions whose `rules[]` opt into it; the
+two a11y detectors run screen-wide. A `screen/*` rule with no detector here is
+simply not enforced yet (no false confidence) — add one by appending to
+`DETECTORS` and pointing the rule's `detector` field at it.
+
+## Steps
+
+1. **Resolve the target(s).** `all` → every `screens/*/screen.yaml`; otherwise the
+   named slug. Read each descriptor; note its `story` id. If a descriptor has no
+   `story`, report it as **un-capturable** and skip (it needs an assembled-screen
+   story first).
+
+2. **Serve Storybook.** Use a running instance if one is up, else start it with
+   `pnpm --filter @acronis-platform/ui-react storybook` (dev, port 6007), or build
+   then serve `storybook:build`. The story renders in isolation at
+   `http://localhost:6007/iframe.html?id=<story>&viewMode=story`.
+
+3. **Capture a snapshot per color mode.** For each of `light` and `dark`:
+   - Navigate to the iframe URL (chrome-devtools MCP `navigate_page`, or
+     Playwright). Set the theme the way the VR harness does:
+     ```js
+     document.documentElement.dataset.theme = mode;
+     document.documentElement.style.colorScheme = mode;
+     ```
+   - Wait for fonts/network idle.
+   - Inject the probe and capture: read `screens/audit/probe.ts`, strip the type
+     annotations, and `evaluate_script` calling
+     `collectScreenSnapshot({ screen: '<slug>', story: '<story>', colorMode: '<mode>', rootSelector: '#storybook-root' })`.
+   - Write the returned JSON to a temp file, e.g.
+     `packages/ui-react/test/screen-audit/<slug>.<mode>.snapshot.json` (gitignored).
+
+4. **Run the detectors.** For each snapshot:
+   `pnpm --filter @acronis-platform/ui-spec screen-audit <slug> <snapshot.json>`.
+   Collect the report; the command exits non-zero if any `must` finding is present.
+
+5. **(Optional) AI visual review — second pass.** Screenshot the story and, with
+   the screenshot + the descriptor + the grammar rules, judge the rows the
+   structural detectors cannot measure (`composition/single-solution-per-job`
+   C6, `composition/density-parity` C7, `typography/label-casing` Y4,
+   `anatomy/empty-skeleton-parity` A6, `composition/variant-parity` C4 across
+   screens). Report these as **advisory** findings — never auto-apply.
+
+6. **Report + propose.** Emit a per-screen report grouped by severity (must /
+   should / may), each line keyed by `[<checklist> <ruleId>] <region>: <ref> — <message>`.
+   Then, per the self-improving loop, for any finding **not** already covered by a
+   rule, **propose** a new `KitRule` + detector + `CHECKLIST.md` row for a human to
+   ratify (a person owns the `must` tier). Do not edit grammar or source unless
+   asked.
+
+## Output
+
+A consistency verdict per screen:
+
+- **CLEAN** — no findings.
+- **WARN** — `should`/`may` findings only.
+- **DEFECT** — one or more `must` findings (CI-blocking).
+
+## Not in scope (yet)
+
+Reference-implementation diffing (`ref/*`: legacy/Figma/Vue variant + token-value
+parity), the discrepancy **ledger**, and folding capture into the VR test-runner
+are **Phase 4**. This skill is detectors-first over a single rendered screen.

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ node_modules
 
 # Testing
 coverage
+# Screen-audit snapshots (captured by the /screen-audit skill; never committed)
+**/test/screen-audit/
 
 # Production
 build

--- a/packages/ui-react/.gitignore
+++ b/packages/ui-react/.gitignore
@@ -3,3 +3,4 @@ storybook-static
 node_modules
 *.tsbuildinfo
 test/__snapshots__/__diff_output__/
+test/screen-audit/

--- a/packages/ui-react/.gitignore
+++ b/packages/ui-react/.gitignore
@@ -3,4 +3,3 @@ storybook-static
 node_modules
 *.tsbuildinfo
 test/__snapshots__/__diff_output__/
-test/screen-audit/

--- a/packages/ui-spec/AGENTS.md
+++ b/packages/ui-spec/AGENTS.md
@@ -98,8 +98,25 @@ a `stateMachine`, and a `figma` node. Validated by `__tests__/screens.test.ts`
 against `schema/screen.schema.json`: schema, component refs resolve in ui-react,
 grammar-rule refs resolve, the `pattern` slug exists, and the state machine has
 one initial + all-reachable states. First example: `screens/protection-dashboard`
-(the App Shell with-secondary screen). **Phase 2** of the kit-consistency proposal;
-a `ProductDescriptor` (flows/entry) and the audit follow. See [`screens/README.md`](./screens/README.md).
+(the App Shell with-secondary screen, captured via its `story` id). **Phase 2** of
+the kit-consistency proposal. See [`screens/README.md`](./screens/README.md).
+
+**Phase 3 — the rendered screen audit** (`screens/audit/`,
+`pnpm --filter @acronis-platform/ui-spec screen-audit <slug> <snapshot.json>`):
+measure a real assembled screen, then run cross-component **structural detectors**
+keyed to the grammar's `screen/*` rules. Like `kit-lint`, measurement is split
+from detection: `screens/audit/probe.ts`'s `collectScreenSnapshot` runs in the
+browser (via the VR `page.evaluate` or the MCP `evaluate_script`) and returns a
+serializable `ScreenSnapshot`; `screens/audit/detectors.ts` are **pure** functions
+over that snapshot + descriptor, unit-tested in `__tests__/screen-audit.test.ts`
+without a browser. Findings map 1:1 to a `KitRule` (severity + checklist from the
+registry); `must` fails CI. Implemented: control-height-parity (Z2), accessible-name
+(I1), contrast (I5) — `must`; edge-baseline-alignment (C2), no-clipping (C8),
+icon-size-parity (Z6), vertical-rhythm (C1) — `should`. Region detectors run only
+on regions whose `rules[]` opt in; a11y detectors run screen-wide. Capture is
+driven by the [`/screen-audit`](../../.claude/skills/screen-audit/SKILL.md) skill.
+The AI visual-review pass, reference diffs, and the ledger are Phase 4. See
+[`screens/audit/README.md`](./screens/audit/README.md).
 
 ## Scripts
 

--- a/packages/ui-spec/__tests__/screen-audit.test.ts
+++ b/packages/ui-spec/__tests__/screen-audit.test.ts
@@ -1,0 +1,268 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { load as parseYaml } from 'js-yaml';
+import { describe, expect, it } from 'vitest';
+
+import { getRule } from '../grammar';
+import { formatScreenReport, runScreenAudit } from '../screens/audit';
+import { DETECTORS } from '../screens/audit/detectors';
+import type {
+  ScreenDescriptorLite,
+  ScreenSnapshot,
+  SnapshotNode,
+} from '../screens/audit/types';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCREENS_DIR = resolve(HERE, '../screens');
+
+// ── snapshot factory ─────────────────────────────────────────────────────────
+let seq = 0;
+function node(partial: Partial<SnapshotNode>): SnapshotNode {
+  seq += 1;
+  return {
+    ref: partial.ref ?? `node-${seq}`,
+    tag: partial.tag ?? 'div',
+    role: partial.role ?? null,
+    region: partial.region ?? null,
+    regionChild: partial.regionChild ?? false,
+    text: partial.text ?? '',
+    accessibleName: partial.accessibleName ?? null,
+    interactive: partial.interactive ?? false,
+    isIcon: partial.isIcon ?? false,
+    rect: partial.rect ?? { x: 0, y: 0, width: 100, height: 32 },
+    color: partial.color ?? 'rgb(20, 20, 20)',
+    backgroundColor: partial.backgroundColor ?? 'rgb(255, 255, 255)',
+    fontSize: partial.fontSize ?? 14,
+    fontWeight: partial.fontWeight ?? 400,
+    borderRadius: partial.borderRadius ?? 6,
+    gutterX: partial.gutterX ?? 0,
+    gutterY: partial.gutterY ?? 0,
+  };
+}
+
+function snapshot(nodes: SnapshotNode[]): ScreenSnapshot {
+  return {
+    screen: 'test',
+    colorMode: 'light',
+    viewport: { width: 1280, height: 800 },
+    nodes,
+  };
+}
+
+const run = (snap: ScreenSnapshot, descriptor: ScreenDescriptorLite) =>
+  runScreenAudit(snap, descriptor);
+
+const ids = (snap: ScreenSnapshot, descriptor: ScreenDescriptorLite) =>
+  run(snap, descriptor).map((f) => f.ruleId);
+
+// A descriptor with one region (banner) opting into every region-scoped rule, so
+// the region detectors all fire when their defect is present.
+const everyRule: ScreenDescriptorLite = {
+  name: 'test',
+  regions: [
+    {
+      regionId: 'bar',
+      ariaRole: 'banner',
+      rules: [
+        'spacing/control-height-parity',
+        'spacing/icon-size-parity',
+        'composition/edge-baseline-alignment',
+        'composition/vertical-rhythm',
+        'composition/no-clipping',
+      ],
+    },
+  ],
+};
+
+// ── registry integrity ───────────────────────────────────────────────────────
+describe('screen-audit detector registry', () => {
+  it('every detector enforces a real grammar rule flagged as screen-detected', () => {
+    for (const d of DETECTORS) {
+      const rule = getRule(d.ruleId);
+      expect(rule, `unknown rule ${d.ruleId}`).toBeTruthy();
+      // The rule's `detector` field must mark it as enforced by the screen audit.
+      expect(rule?.detector.startsWith('screen/'), `${d.ruleId} → ${rule?.detector}`).toBe(true);
+    }
+  });
+
+  it('detector rule ids are unique', () => {
+    const seen = new Set(DETECTORS.map((d) => d.ruleId));
+    expect(seen.size).toBe(DETECTORS.length);
+  });
+});
+
+// ── clean snapshot → no findings ─────────────────────────────────────────────
+describe('a coherent screen produces no findings', () => {
+  it('passes a clean banner', () => {
+    const clean = snapshot([
+      node({ region: 'banner', interactive: true, tag: 'button', text: 'Save', rect: { x: 16, y: 12, width: 80, height: 32 } }),
+      node({ region: 'banner', interactive: true, tag: 'button', text: 'Cancel', rect: { x: 104, y: 12, width: 80, height: 32 } }),
+      node({ region: 'banner', isIcon: true, tag: 'svg', rect: { x: 200, y: 18, width: 16, height: 16 } }),
+      node({ region: 'banner', isIcon: true, tag: 'svg', rect: { x: 224, y: 18, width: 16, height: 16 } }),
+    ]);
+    expect(ids(clean, everyRule)).toEqual([]);
+  });
+});
+
+// ── per-detector behavior ────────────────────────────────────────────────────
+describe('Z2 control-height-parity', () => {
+  it('flags mismatched control heights in one row', () => {
+    const snap = snapshot([
+      node({ region: 'banner', interactive: true, tag: 'button', text: 'A', rect: { x: 0, y: 10, width: 80, height: 32 } }),
+      node({ region: 'banner', interactive: true, tag: 'input', accessibleName: 'q', rect: { x: 90, y: 8, width: 200, height: 40 } }),
+    ]);
+    expect(ids(snap, everyRule)).toContain('spacing/control-height-parity');
+  });
+
+  it('ignores controls on different rows', () => {
+    const snap = snapshot([
+      node({ region: 'banner', interactive: true, tag: 'button', text: 'A', rect: { x: 0, y: 0, width: 80, height: 32 } }),
+      node({ region: 'banner', interactive: true, tag: 'input', accessibleName: 'q', rect: { x: 0, y: 100, width: 200, height: 40 } }),
+    ]);
+    expect(ids(snap, everyRule)).not.toContain('spacing/control-height-parity');
+  });
+});
+
+describe('Z6 icon-size-parity', () => {
+  it('flags mixed icon sizes in a cluster', () => {
+    const snap = snapshot([
+      node({ region: 'banner', isIcon: true, tag: 'svg', rect: { x: 0, y: 10, width: 16, height: 16 } }),
+      node({ region: 'banner', isIcon: true, tag: 'svg', rect: { x: 24, y: 8, width: 20, height: 20 } }),
+    ]);
+    expect(ids(snap, everyRule)).toContain('spacing/icon-size-parity');
+  });
+});
+
+describe('C2 edge-baseline-alignment', () => {
+  it('flags near-miss left edges', () => {
+    const snap = snapshot([
+      node({ region: 'banner', interactive: true, tag: 'button', text: 'A', rect: { x: 16, y: 0, width: 80, height: 32 } }),
+      node({ region: 'banner', role: 'heading', tag: 'h2', text: 'Title', rect: { x: 19, y: 40, width: 200, height: 24 } }),
+    ]);
+    expect(ids(snap, everyRule)).toContain('composition/edge-baseline-alignment');
+  });
+
+  it('does not flag exactly-aligned edges', () => {
+    const snap = snapshot([
+      node({ region: 'banner', interactive: true, tag: 'button', text: 'A', rect: { x: 16, y: 0, width: 80, height: 32 } }),
+      node({ region: 'banner', role: 'heading', tag: 'h2', text: 'Title', rect: { x: 16, y: 40, width: 200, height: 24 } }),
+    ]);
+    expect(ids(snap, everyRule)).not.toContain('composition/edge-baseline-alignment');
+  });
+});
+
+describe('C1 vertical-rhythm', () => {
+  it('flags an off-grid section gap', () => {
+    const snap = snapshot([
+      node({ region: 'banner', regionChild: true, rect: { x: 0, y: 0, width: 400, height: 50 } }),
+      node({ region: 'banner', regionChild: true, rect: { x: 0, y: 63, width: 400, height: 50 } }), // 13px gap
+    ]);
+    expect(ids(snap, everyRule)).toContain('composition/vertical-rhythm');
+  });
+
+  it('accepts a 4px-grid gap', () => {
+    const snap = snapshot([
+      node({ region: 'banner', regionChild: true, rect: { x: 0, y: 0, width: 400, height: 50 } }),
+      node({ region: 'banner', regionChild: true, rect: { x: 0, y: 66, width: 400, height: 50 } }), // 16px gap
+    ]);
+    expect(ids(snap, everyRule)).not.toContain('composition/vertical-rhythm');
+  });
+});
+
+describe('C8 no-clipping (reserved gutter)', () => {
+  it('flags a reserved scrollbar gutter', () => {
+    const snap = snapshot([
+      node({ region: 'banner', tag: 'div', gutterX: 11, rect: { x: 0, y: 0, width: 240, height: 600 } }),
+    ]);
+    expect(ids(snap, everyRule)).toContain('composition/no-clipping');
+  });
+});
+
+describe('I1 accessible-name (screen scope)', () => {
+  const noRules: ScreenDescriptorLite = { name: 'test', regions: [{ regionId: 'x', ariaRole: 'main' }] };
+
+  it('flags an interactive node with no name or text', () => {
+    const snap = snapshot([node({ interactive: true, tag: 'button', role: 'button' })]);
+    expect(ids(snap, noRules)).toContain('accessibility/accessible-name');
+  });
+
+  it('passes a labelled control even with no region opt-in', () => {
+    const snap = snapshot([node({ interactive: true, tag: 'button', accessibleName: 'Close' })]);
+    expect(ids(snap, noRules)).not.toContain('accessibility/accessible-name');
+  });
+});
+
+describe('I5 contrast (screen scope)', () => {
+  const noRules: ScreenDescriptorLite = { name: 'test', regions: [{ regionId: 'x', ariaRole: 'main' }] };
+
+  it('flags low-contrast body text', () => {
+    const snap = snapshot([
+      node({ text: 'Hard to read', color: 'rgb(180, 180, 180)', backgroundColor: 'rgb(255, 255, 255)', fontSize: 14 }),
+    ]);
+    expect(ids(snap, noRules)).toContain('accessibility/contrast');
+  });
+
+  it('passes high-contrast body text', () => {
+    const snap = snapshot([
+      node({ text: 'Readable', color: 'rgb(20, 20, 20)', backgroundColor: 'rgb(255, 255, 255)', fontSize: 14 }),
+    ]);
+    expect(ids(snap, noRules)).not.toContain('accessibility/contrast');
+  });
+
+  it('applies the relaxed large-text threshold', () => {
+    // 3.5:1 — fails for body (4.5) but passes for large bold (3).
+    const grey = 'rgb(130, 130, 130)';
+    const small = snapshot([node({ text: 'small', color: grey, fontSize: 14 })]);
+    const large = snapshot([node({ text: 'large', color: grey, fontSize: 28, fontWeight: 700 })]);
+    expect(ids(small, noRules)).toContain('accessibility/contrast');
+    expect(ids(large, noRules)).not.toContain('accessibility/contrast');
+  });
+});
+
+// ── findings carry registry severity + checklist ─────────────────────────────
+describe('findings resolve against the registry', () => {
+  it('every finding mirrors its rule severity + checklist row', () => {
+    const snap = snapshot([
+      node({ region: 'banner', interactive: true, tag: 'button', text: 'A', rect: { x: 0, y: 10, width: 80, height: 32 } }),
+      node({ region: 'banner', interactive: true, tag: 'input', accessibleName: 'q', rect: { x: 90, y: 8, width: 200, height: 40 } }),
+    ]);
+    const findings = run(snap, everyRule);
+    expect(findings.length).toBeGreaterThan(0);
+    for (const f of findings) {
+      const rule = getRule(f.ruleId)!;
+      expect(f.severity).toBe(rule.severity);
+      expect(f.checklist).toBe(rule.checklist);
+    }
+  });
+});
+
+// ── end-to-end against the real protection-dashboard descriptor ──────────────
+describe('runs against the shipped protection-dashboard descriptor', () => {
+  const descriptor = parseYaml(
+    readFileSync(join(SCREENS_DIR, 'protection-dashboard', 'screen.yaml'), 'utf8')
+  ) as ScreenDescriptorLite;
+
+  it('surfaces region-scoped defects only where that region opts in', () => {
+    // header opts into control-height-parity; sidebar opts into no-clipping.
+    const snap = snapshot([
+      // header: two mismatched controls in a row
+      node({ region: 'banner', interactive: true, tag: 'button', text: 'Go', rect: { x: 0, y: 10, width: 60, height: 28 } }),
+      node({ region: 'banner', interactive: true, tag: 'input', accessibleName: 'Search', rect: { x: 70, y: 8, width: 300, height: 40 } }),
+      // sidebar: a reserved scrollbar gutter
+      node({ region: 'navigation', tag: 'div', gutterX: 11, rect: { x: 0, y: 0, width: 240, height: 700 } }),
+    ]);
+    const found = ids(snap, descriptor);
+    expect(found).toContain('spacing/control-height-parity'); // header
+    expect(found).toContain('composition/no-clipping'); // sidebar
+  });
+
+  it('formats a readable report', () => {
+    const snap = snapshot([
+      node({ interactive: true, tag: 'button', role: 'button' }), // unnamed → must
+    ]);
+    const report = formatScreenReport(run(snap, descriptor), 'protection-dashboard');
+    expect(report).toContain('MUST');
+    expect(report).toContain('protection-dashboard');
+  });
+});

--- a/packages/ui-spec/__tests__/screens.test.ts
+++ b/packages/ui-spec/__tests__/screens.test.ts
@@ -39,7 +39,11 @@ interface Screen {
 function listScreens(): string[] {
   if (!existsSync(SCREENS_DIR)) return [];
   return readdirSync(SCREENS_DIR)
-    .filter((e) => statSync(join(SCREENS_DIR, e)).isDirectory())
+    .filter(
+      (e) =>
+        statSync(join(SCREENS_DIR, e)).isDirectory() &&
+        existsSync(join(SCREENS_DIR, e, 'screen.yaml'))
+    )
     .sort();
 }
 

--- a/packages/ui-spec/package.json
+++ b/packages/ui-spec/package.json
@@ -23,7 +23,8 @@
     "test:watch": "vitest",
     "validate": "vitest run",
     "generate:stories": "tsx scripts/generate-stories.ts",
-    "kit-lint": "tsx scripts/kit-lint.ts"
+    "kit-lint": "tsx scripts/kit-lint.ts",
+    "screen-audit": "tsx scripts/screen-audit.ts"
   },
   "keywords": [
     "ui-kit",

--- a/packages/ui-spec/schema/screen.schema.json
+++ b/packages/ui-spec/schema/screen.schema.json
@@ -26,6 +26,10 @@
     "since": { "type": "string" },
     "description": { "type": "string" },
     "route": { "type": "string" },
+    "story": {
+      "type": "string",
+      "description": "Storybook story id that renders this assembled screen; the screen audit (screens/audit) navigates here to capture a snapshot. e.g. `ui-appshell--with-secondary`."
+    },
     "permissions": { "type": "array", "items": { "type": "string" } },
     "pattern": {
       "type": "string",

--- a/packages/ui-spec/screens/README.md
+++ b/packages/ui-spec/screens/README.md
@@ -4,7 +4,8 @@ The **application layer**: machine-readable descriptions of real product screens
 assembled from real `@acronis-platform/ui-react` components. This is the layer
 above `components/` (one component), `patterns/` (a recipe), and `grammar/`
 (cross-component rules). A screen descriptor is the "screen spec" that the
-rendered **screen consistency audit** (Phase 3) will consume.
+rendered **screen consistency audit** ([`audit/`](./audit/README.md), Phase 3)
+consumes.
 
 Design and rationale: [`context/kit-consistency-audit-proposal.md`](../../../context/kit-consistency-audit-proposal.md).
 
@@ -19,7 +20,8 @@ Validated by `../__tests__/screens.test.ts` against `../schema/screen.schema.jso
 ## A `screen.yaml` contains
 
 - **identity** — `name` (= folder slug), `title`, `status`, optional `route`,
-  `permissions`, `figma` ({ file, node }), and a `pattern` slug it assembles.
+  `permissions`, `figma` ({ file, node }), a `pattern` slug it assembles, and a
+  `story` id (the assembled-screen Storybook story the audit captures).
 - **`regions[]`** — the spatial layout. Each region has a `layout`
   (`fixed-width`/`flex-fill`/`overlay`/`sticky`/`dock-bottom` + position/scroll),
   the real **`components[]`** it holds (root ui-react names, with `props` whose
@@ -38,7 +40,17 @@ Validated by `../__tests__/screens.test.ts` against `../schema/screen.schema.jso
 - The **state machine** has exactly one initial state, transitions reference real
   states, and every non-initial state is reachable from the initial one.
 
+## The audit
+
+[`audit/`](./audit/README.md) renders a descriptor's `story` and runs structural
+detectors (control-height parity, accessible name, contrast, edge alignment,
+reserved-gutter clipping, icon-size parity, vertical rhythm) over the measured DOM
+— keyed to the grammar's `screen/*` rules, `must` blocks CI. Driven by the
+[`/screen-audit`](../../../.claude/skills/screen-audit/SKILL.md) skill +
+`pnpm --filter @acronis-platform/ui-spec screen-audit <slug> <snapshot.json>`.
+
 ## Next
 
 A `ProductDescriptor` (screens + navigation `flows` + entry screen — the "app
-description") and the rendered screen audit follow in later phases.
+description"), the AI visual-review pass, reference-implementation diffing, and the
+discrepancy ledger follow in Phase 4.

--- a/packages/ui-spec/screens/audit/README.md
+++ b/packages/ui-spec/screens/audit/README.md
@@ -1,0 +1,66 @@
+# `screens/audit` — rendered screen consistency audit
+
+The **complete-screen audit** (Phase 3 of
+[`context/kit-consistency-audit-proposal.md`](../../../../context/kit-consistency-audit-proposal.md)):
+render a real assembled screen from its `../<slug>/screen.yaml` descriptor and run
+cross-component **structural detectors** over it, keyed to the grammar's
+`screen/*` rules. Where `kit-lint` reads source statically, this measures the
+rendered DOM — the questions only a real screen can answer.
+
+## The split: measurement vs detection
+
+```
+audit/
+├── types.ts       # ScreenSnapshot / SnapshotNode / ScreenFinding (the seam)
+├── probe.ts       # collectScreenSnapshot() — runs IN the browser, returns a snapshot
+├── detectors.ts   # pure detectors, one per screen/* rule (snapshot in, findings out)
+└── index.ts       # runScreenAudit() + formatScreenReport()
+```
+
+1. **Measure** — `probe.ts`'s `collectScreenSnapshot` runs inside the page (via
+   `page.evaluate` in the VR test-runner, or the chrome-devtools MCP
+   `evaluate_script` against a running Storybook). It walks the DOM and emits a
+   serializable `ScreenSnapshot` — geometry, computed color/background/radius/font,
+   accessible name, and net scrollbar gutters — with **no DOM handles**.
+2. **Detect** — `detectors.ts` runs over that snapshot + the descriptor. Pure
+   data-in/data-out, so it is unit-tested in Node without a browser
+   (`../../__tests__/screen-audit.test.ts`). Findings are keyed by grammar rule id;
+   the rule supplies severity + checklist row (defined once in the registry).
+
+This is the same shape as `kit-lint`: a finding maps 1:1 to a `KitRule`, and
+`must` findings fail CI.
+
+## Detectors implemented
+
+| Rule id                               | Checklist | Severity | Scope  |
+| ------------------------------------- | --------- | -------- | ------ |
+| `spacing/control-height-parity`       | Z2        | must     | region |
+| `accessibility/accessible-name`       | I1        | must     | screen |
+| `accessibility/contrast`              | I5        | must     | screen |
+| `composition/edge-baseline-alignment` | C2        | should   | region |
+| `composition/no-clipping`             | C8        | should   | region |
+| `spacing/icon-size-parity`            | Z6        | should   | region |
+| `composition/vertical-rhythm`         | C1        | should   | region |
+
+**Region** detectors run only on descriptor regions whose `rules[]` opt into the
+detector's rule (nodes matched to the region by landmark role ↔ `ariaRole`).
+**Screen** detectors run over every node. A `screen/*` rule with no detector here
+is simply not enforced yet — add one by appending to `DETECTORS` and pointing the
+rule's `detector` field at it.
+
+## Running
+
+Capture is driven by the [`/screen-audit`](../../../../.claude/skills/screen-audit/SKILL.md)
+skill (navigate the story → inject the probe → write a snapshot JSON), then:
+
+```bash
+pnpm --filter @acronis-platform/ui-spec screen-audit <screen-slug> <snapshot.json>
+```
+
+The CLI prints findings grouped by severity and exits non-zero on any `must`.
+
+## Not here yet (Phase 4)
+
+The judgment-only rows (`ai/*`: single-solution, density, label-casing) via an AI
+visual reviewer, reference-implementation diffing (`ref/*`), and the discrepancy
+ledger.

--- a/packages/ui-spec/screens/audit/detectors.ts
+++ b/packages/ui-spec/screens/audit/detectors.ts
@@ -1,0 +1,268 @@
+// Structural screen detectors (Phase 3).
+//
+// Each detector enforces one `screen/*` grammar rule over a `ScreenSnapshot`.
+// They are PURE — snapshot in, findings out — so they are unit-tested in Node
+// without a browser (the snapshot is the seam; see ./types.ts). Findings are
+// keyed by grammar rule id; the rule supplies severity + checklist row, so an
+// invariant is defined exactly once in the registry. `must` findings fail CI.
+//
+// Add a detector by appending to DETECTORS and pointing its grammar rule's
+// `detector` field at the matching `screen/<id>`. A rule whose detector is not
+// implemented here is simply not enforced (no false confidence) — mirrors kit-lint.
+import { getRule } from '../../grammar';
+import type { ScreenFinding, SnapshotNode } from './types';
+
+/** Detectors run either once over the whole screen, or per opted-in region. */
+export interface ScreenDetector {
+  ruleId: string;
+  scope: 'screen' | 'region';
+  /** `nodes` are pre-filtered to the region for `region` scope, else all nodes. */
+  run(nodes: SnapshotNode[]): Omit<ScreenFinding, 'severity' | 'checklist'>[];
+}
+
+function find(
+  ruleId: string,
+  node: { ref: string; region: string | null } | string,
+  message: string
+): Omit<ScreenFinding, 'severity' | 'checklist'> {
+  const ref = typeof node === 'string' ? node : node.ref;
+  const region = typeof node === 'string' ? null : node.region;
+  return { ruleId, region, ref, message };
+}
+
+/** Cluster nodes into visual rows by vertical overlap (sorted top-to-bottom). */
+function rows(nodes: SnapshotNode[]): SnapshotNode[][] {
+  const sorted = [...nodes].sort((a, b) => a.rect.y - b.rect.y);
+  const out: SnapshotNode[][] = [];
+  for (const n of sorted) {
+    const row = out.find((r) => {
+      const m = r[r.length - 1];
+      const aTop = n.rect.y;
+      const aBot = n.rect.y + n.rect.height;
+      const bTop = m.rect.y;
+      const bBot = m.rect.y + m.rect.height;
+      const overlap = Math.min(aBot, bBot) - Math.max(aTop, bTop);
+      return overlap > Math.min(n.rect.height, m.rect.height) / 2;
+    });
+    if (row) row.push(n);
+    else out.push([n]);
+  }
+  return out;
+}
+
+/** Group near-equal numbers into buckets within `tol`; returns the bucket count. */
+function distinct(values: number[], tol: number): number[] {
+  const reps: number[] = [];
+  for (const v of [...values].sort((a, b) => a - b)) {
+    if (!reps.some((r) => Math.abs(r - v) <= tol)) reps.push(v);
+  }
+  return reps;
+}
+
+function parseRgb(c: string): [number, number, number] | null {
+  const m = c.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+function relativeLuminance([r, g, b]: [number, number, number]): number {
+  const lin = (v: number) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+function contrastRatio(fg: string, bg: string): number | null {
+  const a = parseRgb(fg);
+  const b = parseRgb(bg);
+  if (!a || !b) return null;
+  const l1 = relativeLuminance(a);
+  const l2 = relativeLuminance(b);
+  const [hi, lo] = l1 >= l2 ? [l1, l2] : [l2, l1];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+const isHeading = (n: SnapshotNode): boolean =>
+  n.role === 'heading' || /^h[1-6]$/.test(n.tag);
+
+export const DETECTORS: ScreenDetector[] = [
+  // Z2 — controls placed in one row must share height within a size tier.
+  {
+    ruleId: 'spacing/control-height-parity',
+    scope: 'region',
+    run(nodes) {
+      const out: Omit<ScreenFinding, 'severity' | 'checklist'>[] = [];
+      for (const row of rows(nodes.filter((n) => n.interactive && n.rect.height > 0))) {
+        if (row.length < 2) continue;
+        const heights = distinct(row.map((n) => n.rect.height), 2);
+        if (heights.length > 1) {
+          const tallest = row.reduce((a, b) => (a.rect.height >= b.rect.height ? a : b));
+          out.push(
+            find(
+              'spacing/control-height-parity',
+              tallest,
+              `controls in one row have ${heights.length} different heights (${heights.join('/')}px) — align to a single size tier`
+            )
+          );
+        }
+      }
+      return out;
+    },
+  },
+
+  // Z6 — icons within a cluster (row) share one size.
+  {
+    ruleId: 'spacing/icon-size-parity',
+    scope: 'region',
+    run(nodes) {
+      const out: Omit<ScreenFinding, 'severity' | 'checklist'>[] = [];
+      for (const row of rows(nodes.filter((n) => n.isIcon))) {
+        if (row.length < 2) continue;
+        const sizes = distinct(
+          row.map((n) => Math.max(n.rect.width, n.rect.height)),
+          1
+        );
+        if (sizes.length > 1) {
+          out.push(
+            find(
+              'spacing/icon-size-parity',
+              row[0],
+              `icons in one cluster mix ${sizes.length} sizes (${sizes.join('/')}px) — use one icon size per cluster`
+            )
+          );
+        }
+      }
+      return out;
+    },
+  },
+
+  // C2 — adjacent components' left edges align, or are equal — never near-misses.
+  {
+    ruleId: 'composition/edge-baseline-alignment',
+    scope: 'region',
+    run(nodes) {
+      const out: Omit<ScreenFinding, 'severity' | 'checklist'>[] = [];
+      const candidates = nodes.filter((n) => n.interactive || isHeading(n));
+      const edges = distinct(candidates.map((n) => n.rect.x), 0).sort((a, b) => a - b);
+      for (let i = 1; i < edges.length; i += 1) {
+        const delta = edges[i] - edges[i - 1];
+        if (delta >= 1 && delta <= 6) {
+          const node = candidates.find((n) => n.rect.x === edges[i]) ?? candidates[0];
+          out.push(
+            find(
+              'composition/edge-baseline-alignment',
+              node,
+              `left edges nearly align (x=${edges[i - 1]} vs x=${edges[i]}, off by ${delta}px) — snap to the same edge`
+            )
+          );
+        }
+      }
+      return out;
+    },
+  },
+
+  // C1 — vertical gaps between a region's sections come from the 4px grid.
+  {
+    ruleId: 'composition/vertical-rhythm',
+    scope: 'region',
+    run(nodes) {
+      const out: Omit<ScreenFinding, 'severity' | 'checklist'>[] = [];
+      const sections = nodes
+        .filter((n) => n.regionChild && n.rect.height > 0)
+        .sort((a, b) => a.rect.y - b.rect.y);
+      for (let i = 1; i < sections.length; i += 1) {
+        const prev = sections[i - 1];
+        const gap = sections[i].rect.y - (prev.rect.y + prev.rect.height);
+        if (gap > 0 && gap % 4 !== 0) {
+          out.push(
+            find(
+              'composition/vertical-rhythm',
+              sections[i],
+              `section gap is ${gap}px — off the 4px vertical-rhythm grid`
+            )
+          );
+        }
+      }
+      return out;
+    },
+  },
+
+  // C8 — scroll containers must not reserve a gutter that can crop full-bleed content.
+  {
+    ruleId: 'composition/no-clipping',
+    scope: 'region',
+    run(nodes) {
+      const out: Omit<ScreenFinding, 'severity' | 'checklist'>[] = [];
+      for (const n of nodes) {
+        if (n.gutterX >= 1 || n.gutterY >= 1) {
+          const px = Math.max(n.gutterX, n.gutterY);
+          out.push(
+            find(
+              'composition/no-clipping',
+              n,
+              `scroll container reserves a ${px}px scrollbar gutter — use an overlay scrollbar so it cannot crop full-bleed content`
+            )
+          );
+        }
+      }
+      return out;
+    },
+  },
+
+  // I1 — every interactive element has an accessible name.
+  {
+    ruleId: 'accessibility/accessible-name',
+    scope: 'screen',
+    run(nodes) {
+      return nodes
+        .filter(
+          (n) =>
+            n.interactive &&
+            !(n.accessibleName && n.accessibleName.trim()) &&
+            !(n.text && n.text.trim())
+        )
+        .map((n) =>
+          find(
+            'accessibility/accessible-name',
+            n,
+            `interactive <${n.tag}>${n.role ? ` role="${n.role}"` : ''} has no accessible name`
+          )
+        );
+    },
+  },
+
+  // I5 — text meets the WCAG contrast minimum against its effective background.
+  {
+    ruleId: 'accessibility/contrast',
+    scope: 'screen',
+    run(nodes) {
+      const out: Omit<ScreenFinding, 'severity' | 'checklist'>[] = [];
+      for (const n of nodes) {
+        if (!n.text || !n.text.trim() || n.isIcon) continue;
+        const ratio = contrastRatio(n.color, n.backgroundColor);
+        if (ratio == null) continue;
+        const large = n.fontSize >= 24 || (n.fontSize >= 18.66 && n.fontWeight >= 700);
+        const min = large ? 3 : 4.5;
+        if (ratio < min) {
+          out.push(
+            find(
+              'accessibility/contrast',
+              n,
+              `text contrast ${ratio.toFixed(2)}:1 is below the ${min}:1 minimum (${n.color} on ${n.backgroundColor})`
+            )
+          );
+        }
+      }
+      return out;
+    },
+  },
+];
+
+/** Resolve severity + checklist row for a detector finding from the registry. */
+export function resolveFinding(
+  partial: Omit<ScreenFinding, 'severity' | 'checklist'>
+): ScreenFinding {
+  const rule = getRule(partial.ruleId);
+  if (!rule) throw new Error(`screen-audit references unknown rule "${partial.ruleId}"`);
+  return { ...partial, severity: rule.severity, checklist: rule.checklist };
+}

--- a/packages/ui-spec/screens/audit/index.ts
+++ b/packages/ui-spec/screens/audit/index.ts
@@ -1,0 +1,92 @@
+// Screen audit — run the structural detectors over a rendered-screen snapshot.
+//
+// `runScreenAudit(snapshot, descriptor)` scopes each detector:
+//   - `screen` detectors run once over every node (e.g. accessible-name, contrast);
+//   - `region` detectors run per descriptor region that opts into the detector's
+//     rule via `regions[].rules` — measured nodes are matched to that region by
+//     landmark role (`SnapshotNode.region` ↔ descriptor `ariaRole`).
+//
+// A region rule that no region opts into, or a `screen/*` rule with no detector
+// here, is simply not enforced — same "no false confidence" contract as kit-lint.
+// See context/kit-consistency-audit-proposal.md §7.
+import type { RuleSeverity } from '../../grammar';
+import { DETECTORS, resolveFinding } from './detectors';
+import type {
+  ScreenDescriptorLite,
+  ScreenFinding,
+  ScreenRegionLite,
+  ScreenSnapshot,
+  SnapshotNode,
+} from './types';
+
+export type { ScreenSnapshot, SnapshotNode, ScreenFinding } from './types';
+export { collectScreenSnapshot } from './probe';
+export { DETECTORS } from './detectors';
+
+function flattenRegions(regions: ScreenRegionLite[]): ScreenRegionLite[] {
+  const out: ScreenRegionLite[] = [];
+  for (const r of regions) {
+    out.push(r);
+    if (r.children) out.push(...flattenRegions(r.children));
+  }
+  return out;
+}
+
+export function runScreenAudit(
+  snapshot: ScreenSnapshot,
+  descriptor: ScreenDescriptorLite
+): ScreenFinding[] {
+  const regions = flattenRegions(descriptor.regions);
+  const findings: ScreenFinding[] = [];
+
+  for (const detector of DETECTORS) {
+    if (detector.scope === 'screen') {
+      for (const partial of detector.run(snapshot.nodes)) {
+        findings.push(resolveFinding(partial));
+      }
+      continue;
+    }
+    // region scope: run on every region whose `rules` opt into this detector.
+    for (const region of regions) {
+      if (!region.rules?.includes(detector.ruleId)) continue;
+      const nodes: SnapshotNode[] = region.ariaRole
+        ? snapshot.nodes.filter((n) => n.region === region.ariaRole)
+        : snapshot.nodes;
+      for (const partial of detector.run(nodes)) {
+        // Stamp the descriptor regionId (more meaningful than the landmark role).
+        findings.push(resolveFinding({ ...partial, region: region.regionId }));
+      }
+    }
+  }
+
+  // De-dupe identical findings (a node measured under overlapping scopes).
+  const seen = new Set<string>();
+  return findings.filter((f) => {
+    const key = `${f.ruleId}|${f.region}|${f.ref}|${f.message}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function formatScreenReport(
+  findings: ScreenFinding[],
+  screen?: string
+): string {
+  const head = screen ? `screen-audit (${screen})` : 'screen-audit';
+  if (findings.length === 0) return `${head}: no findings ✓`;
+  const order: RuleSeverity[] = ['must', 'should', 'may'];
+  const lines: string[] = [head];
+  for (const sev of order) {
+    const group = findings.filter((f) => f.severity === sev);
+    if (!group.length) continue;
+    lines.push(`\n${sev.toUpperCase()} (${group.length})`);
+    for (const f of group) {
+      const where = f.region ? `${f.region}: ${f.ref}` : f.ref;
+      lines.push(`  [${f.checklist} ${f.ruleId}] ${where} — ${f.message}`);
+    }
+  }
+  const must = findings.filter((f) => f.severity === 'must').length;
+  lines.push(`\n${findings.length} finding(s); ${must} must.`);
+  return lines.join('\n');
+}

--- a/packages/ui-spec/screens/audit/probe.ts
+++ b/packages/ui-spec/screens/audit/probe.ts
@@ -1,0 +1,224 @@
+/// <reference lib="dom" />
+// Browser probe for the screen audit.
+//
+// `collectScreenSnapshot` is meant to run **inside the page** — it is passed to
+// Playwright's `page.evaluate(...)` (the existing VR harness) or injected via the
+// chrome-devtools MCP `evaluate_script` against a running Storybook story. Because
+// the function is serialized and re-parsed in the browser, it MUST be fully
+// self-contained: every helper is declared inside it, and it references only DOM
+// globals and its single argument — no module-scope imports at runtime.
+//
+// It returns a plain `ScreenSnapshot` (see ./types.ts) with no DOM handles, so the
+// pure detectors can run over it in Node. See context/kit-consistency-audit-proposal.md §7.2.
+import type { ScreenSnapshot, SnapshotNode } from './types';
+
+export interface ProbeOptions {
+  screen: string;
+  story?: string;
+  colorMode: 'light' | 'dark';
+  /** Root to measure under (defaults to `#storybook-root`, then `body`). */
+  rootSelector?: string;
+  /** Cap on text length captured per node. */
+  maxText?: number;
+}
+
+export function collectScreenSnapshot(opts: ProbeOptions): ScreenSnapshot {
+  const maxText = opts.maxText ?? 80;
+  const root =
+    (opts.rootSelector && document.querySelector(opts.rootSelector)) ||
+    document.querySelector('#storybook-root') ||
+    document.body;
+
+  const LANDMARK_TAG: Record<string, string> = {
+    HEADER: 'banner',
+    NAV: 'navigation',
+    MAIN: 'main',
+    ASIDE: 'complementary',
+    FOOTER: 'contentinfo',
+  };
+  const LANDMARK_ROLE = new Set([
+    'banner',
+    'navigation',
+    'main',
+    'complementary',
+    'contentinfo',
+    'region',
+    'search',
+  ]);
+  const INTERACTIVE_TAG = new Set([
+    'BUTTON',
+    'A',
+    'INPUT',
+    'SELECT',
+    'TEXTAREA',
+  ]);
+  const INTERACTIVE_ROLE = new Set([
+    'button',
+    'link',
+    'checkbox',
+    'radio',
+    'switch',
+    'menuitem',
+    'tab',
+    'combobox',
+    'textbox',
+    'slider',
+    'option',
+    'searchbox',
+  ]);
+
+  const landmarkOf = (el: Element): { el: Element; role: string } | null => {
+    let cur: Element | null = el;
+    while (cur && cur !== document.documentElement) {
+      const role = cur.getAttribute('role');
+      if (role && LANDMARK_ROLE.has(role)) return { el: cur, role };
+      const tagRole = LANDMARK_TAG[cur.tagName];
+      if (tagRole) return { el: cur, role: tagRole };
+      cur = cur.parentElement;
+    }
+    return null;
+  };
+
+  const isTransparent = (c: string): boolean =>
+    c === 'transparent' ||
+    c === 'rgba(0, 0, 0, 0)' ||
+    /,\s*0\s*\)$/.test(c.replace(/\s/g, '').replace(/,0\)$/, ', 0)'));
+
+  const effectiveBg = (el: Element): string => {
+    let cur: Element | null = el;
+    while (cur) {
+      const bg = getComputedStyle(cur).backgroundColor;
+      if (bg && !isTransparent(bg)) return bg;
+      cur = cur.parentElement;
+    }
+    return 'rgb(255, 255, 255)';
+  };
+
+  const accessibleName = (el: Element): string | null => {
+    const label = el.getAttribute('aria-label');
+    if (label && label.trim()) return label.trim();
+    const labelledby = el.getAttribute('aria-labelledby');
+    if (labelledby) {
+      const text = labelledby
+        .split(/\s+/)
+        .map((id) => document.getElementById(id)?.textContent?.trim() ?? '')
+        .filter(Boolean)
+        .join(' ');
+      if (text) return text;
+    }
+    const title = el.getAttribute('title');
+    if (title && title.trim()) return title.trim();
+    if (el.tagName === 'IMG') {
+      const alt = el.getAttribute('alt');
+      if (alt && alt.trim()) return alt.trim();
+    }
+    const txt = (el.textContent ?? '').trim();
+    return txt || null;
+  };
+
+  // Short, reasonably-stable locator for reporting.
+  const refOf = (el: Element): string => {
+    const parts: string[] = [];
+    let cur: Element | null = el;
+    let depth = 0;
+    while (cur && cur !== root && cur !== document.body && depth < 4) {
+      const tag = cur.tagName.toLowerCase();
+      const parent = cur.parentElement;
+      if (parent) {
+        const sameTag = Array.prototype.filter.call(
+          parent.children,
+          (c: Element) => c.tagName === cur!.tagName
+        );
+        const idx = sameTag.indexOf(cur);
+        parts.unshift(sameTag.length > 1 ? `${tag}:nth-of-type(${idx + 1})` : tag);
+      } else {
+        parts.unshift(tag);
+      }
+      cur = cur.parentElement;
+      depth += 1;
+    }
+    return parts.join(' > ') || el.tagName.toLowerCase();
+  };
+
+  const num = (v: string): number => {
+    const n = parseFloat(v);
+    return Number.isFinite(n) ? n : 0;
+  };
+
+  const nodes: SnapshotNode[] = [];
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+  let el = walker.currentNode as Element | null;
+  // The TreeWalker starts on `root` itself; iterate over descendants.
+  for (el = walker.nextNode() as Element | null; el; el = walker.nextNode() as Element | null) {
+    const style = getComputedStyle(el);
+    if (style.display === 'none' || style.visibility === 'hidden') continue;
+    const rect = el.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) continue;
+
+    const role = el.getAttribute('role');
+    const lm = landmarkOf(el);
+    const tag = el.tagName.toLowerCase();
+    const isIcon =
+      el.tagName === 'svg' || el.getAttribute('data-slot') === 'icon';
+    const disabled =
+      el.hasAttribute('disabled') ||
+      el.getAttribute('aria-disabled') === 'true';
+    const interactive =
+      !disabled &&
+      (INTERACTIVE_TAG.has(el.tagName) ||
+        (role != null && INTERACTIVE_ROLE.has(role)));
+
+    const borderX =
+      num(style.borderLeftWidth) + num(style.borderRightWidth);
+    const borderY =
+      num(style.borderTopWidth) + num(style.borderBottomWidth);
+    const he = el as HTMLElement;
+    const overflowY = style.overflowY;
+    const overflowX = style.overflowX;
+    const scrollsY =
+      (overflowY === 'auto' || overflowY === 'scroll') &&
+      he.scrollHeight > he.clientHeight + 1;
+    const scrollsX =
+      (overflowX === 'auto' || overflowX === 'scroll') &&
+      he.scrollWidth > he.clientWidth + 1;
+    const gutterX = scrollsY
+      ? Math.max(0, Math.round(he.offsetWidth - he.clientWidth - borderX))
+      : 0;
+    const gutterY = scrollsX
+      ? Math.max(0, Math.round(he.offsetHeight - he.clientHeight - borderY))
+      : 0;
+
+    nodes.push({
+      ref: refOf(el),
+      tag,
+      role,
+      region: lm?.role ?? null,
+      regionChild: lm ? el.parentElement === lm.el : false,
+      text: (el.textContent ?? '').trim().slice(0, maxText),
+      accessibleName: interactive || el.tagName === 'IMG' ? accessibleName(el) : null,
+      interactive,
+      isIcon,
+      rect: {
+        x: Math.round(rect.x),
+        y: Math.round(rect.y),
+        width: Math.round(rect.width),
+        height: Math.round(rect.height),
+      },
+      color: style.color,
+      backgroundColor: effectiveBg(el),
+      fontSize: Math.round(num(style.fontSize) * 100) / 100,
+      fontWeight: num(style.fontWeight) || 400,
+      borderRadius: Math.round(num(style.borderTopLeftRadius)),
+      gutterX,
+      gutterY,
+    });
+  }
+
+  return {
+    screen: opts.screen,
+    story: opts.story,
+    colorMode: opts.colorMode,
+    viewport: { width: window.innerWidth, height: window.innerHeight },
+    nodes,
+  };
+}

--- a/packages/ui-spec/screens/audit/types.ts
+++ b/packages/ui-spec/screens/audit/types.ts
@@ -1,0 +1,94 @@
+// Screen-audit data model (Phase 3 of the kit-consistency proposal).
+//
+// The audit splits *measurement* from *detection*, exactly like `kit-lint`:
+//   1. a browser probe (./probe.ts, run via `page.evaluate`) renders a real
+//      screen and emits a serializable `ScreenSnapshot` (geometry, computed
+//      style, a11y, scrollbar gutters — no DOM handles);
+//   2. pure detectors (./detectors.ts) run over that snapshot + the screen
+//      descriptor and emit findings keyed by grammar rule id + severity.
+//
+// Step 2 is plain data-in/data-out, so it is unit-testable in Node without a
+// browser — the snapshot is the seam. See context/kit-consistency-audit-proposal.md §7.
+import type { RuleSeverity } from '../../grammar';
+
+export interface NodeRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** One measured DOM element in a rendered screen. */
+export interface SnapshotNode {
+  /** Short CSS-ish locator for reporting (e.g. `header > button:nth-of-type(2)`). */
+  ref: string;
+  /** Lowercased tag name. */
+  tag: string;
+  /** Explicit or implicit ARIA role, if any. */
+  role: string | null;
+  /**
+   * Landmark role of the nearest landmark ancestor — `banner` | `navigation` |
+   * `main` | `complementary` | `contentinfo` | `region` | `search` — or null.
+   * Detectors scope region-level rules by matching this to a descriptor
+   * region's `ariaRole`.
+   */
+  region: string | null;
+  /** True when this element is a direct child of its region's landmark element. */
+  regionChild: boolean;
+  /** Trimmed, truncated text content. */
+  text: string;
+  /** Computed accessible name (aria-label / labelledby / alt / title / text). */
+  accessibleName: string | null;
+  /** A control the user operates (button, link, input, select, textarea, …). */
+  interactive: boolean;
+  /** An icon glyph (svg / `[data-slot="icon"]`). */
+  isIcon: boolean;
+  rect: NodeRect;
+  /** Computed `color`, normalized `rgb(...)`/`rgba(...)`. */
+  color: string;
+  /** First non-transparent background found walking ancestors (the effective bg). */
+  backgroundColor: string;
+  fontSize: number;
+  fontWeight: number;
+  borderRadius: number;
+  /** Reserved vertical-scrollbar gutter (px), net of borders — 0 if none/overlay. */
+  gutterX: number;
+  /** Reserved horizontal-scrollbar gutter (px), net of borders. */
+  gutterY: number;
+}
+
+export interface ScreenSnapshot {
+  /** Screen slug (`screens/<slug>`). */
+  screen: string;
+  /** Storybook story id the snapshot was captured from, if any. */
+  story?: string;
+  colorMode: 'light' | 'dark';
+  viewport: { width: number; height: number };
+  nodes: SnapshotNode[];
+}
+
+/** A single audit finding — same shape contract as `kit-lint`'s `Finding`. */
+export interface ScreenFinding {
+  ruleId: string;
+  checklist: string;
+  severity: RuleSeverity;
+  /** Descriptor region the finding belongs to (regionId), or null for screen-wide. */
+  region: string | null;
+  /** Node locator (or a synthetic cluster description). */
+  ref: string;
+  message: string;
+}
+
+/** Minimal view of a screen descriptor the audit needs (loaded from screen.yaml). */
+export interface ScreenRegionLite {
+  regionId: string;
+  ariaRole?: string;
+  rules?: string[];
+  children?: ScreenRegionLite[];
+}
+
+export interface ScreenDescriptorLite {
+  name: string;
+  story?: string;
+  regions: ScreenRegionLite[];
+}

--- a/packages/ui-spec/screens/protection-dashboard/screen.yaml
+++ b/packages/ui-spec/screens/protection-dashboard/screen.yaml
@@ -10,6 +10,9 @@ description: >-
   content area. Worked example for the screen-spec format; mirrors the App Shell
   "WithSecondary" story.
 route: /protection/dashboard
+# The assembled-screen render the screen audit captures (App Shell with-secondary
+# is the de-facto Protection dashboard). See screens/audit + the /screen-audit skill.
+story: ui-appshell--with-secondary
 permissions: [protection.view]
 pattern: app-shell
 figma:

--- a/packages/ui-spec/scripts/screen-audit.ts
+++ b/packages/ui-spec/scripts/screen-audit.ts
@@ -1,0 +1,46 @@
+/**
+ * screen-audit — run the structural screen detectors over a captured snapshot.
+ *
+ * Capture (a `ScreenSnapshot` JSON) is produced in the browser by the probe in
+ * `screens/audit/probe.ts` — driven by the `/screen-audit` skill against a
+ * running Storybook story (the descriptor's `story` id), or by the VR
+ * test-runner. This CLI is the Node half: load the snapshot + the screen
+ * descriptor, run the detectors, print findings keyed by checklist id +
+ * severity, and exit non-zero on any `must`.
+ *
+ * Run:   pnpm --filter @acronis-platform/ui-spec screen-audit <screen-slug> <snapshot.json>
+ * Design: context/kit-consistency-audit-proposal.md §7  ·  rules: ../grammar
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { load as parseYaml } from 'js-yaml';
+
+import { formatScreenReport, runScreenAudit } from '../screens/audit';
+import type { ScreenDescriptorLite, ScreenSnapshot } from '../screens/audit/types';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCREENS_DIR = resolve(HERE, '../screens');
+
+function loadDescriptor(slug: string): ScreenDescriptorLite {
+  const path = join(SCREENS_DIR, slug, 'screen.yaml');
+  return parseYaml(readFileSync(path, 'utf8')) as ScreenDescriptorLite;
+}
+
+function loadSnapshot(path: string): ScreenSnapshot {
+  return JSON.parse(readFileSync(resolve(path), 'utf8')) as ScreenSnapshot;
+}
+
+const [slug, snapshotPath] = process.argv.slice(2);
+if (!slug || !snapshotPath) {
+  process.stderr.write(
+    'usage: screen-audit <screen-slug> <snapshot.json>\n'
+  );
+  process.exit(2);
+}
+
+const descriptor = loadDescriptor(slug);
+const snapshot = loadSnapshot(snapshotPath);
+const findings = runScreenAudit(snapshot, descriptor);
+process.stdout.write(formatScreenReport(findings, slug) + '\n');
+process.exit(findings.some((f) => f.severity === 'must') ? 1 : 0);

--- a/packages/ui-spec/tsconfig.json
+++ b/packages/ui-spec/tsconfig.json
@@ -15,6 +15,7 @@
     "lib/**/*.ts",
     "scripts/**/*.ts",
     "grammar/**/*.ts",
+    "screens/**/*.ts",
     "__tests__/**/*.ts"
   ]
 }


### PR DESCRIPTION
## Phase 3 — rendered screen consistency audit

Completes the kit-consistency rollout's centerpiece (proposal §7, §11): render a **real assembled screen** and run **cross-component structural detectors** over the measured DOM, keyed to the grammar's `screen/*` rules. Where Phase 1 `kit-lint` reads source statically, this answers the questions only a rendered screen can — do controls in a row share a height, do edges actually align, does a scrollbar gutter crop a full-bleed row, does text clear the contrast minimum.

Builds on Phase 0 (#483 grammar registry), Phase 1 (#485 kit-lint), Phase 2 (#486 screen descriptors).

### Architecture — measurement vs detection (mirrors kit-lint)
- **`screens/audit/probe.ts`** — `collectScreenSnapshot`, a self-contained browser probe (run via `page.evaluate` / MCP `evaluate_script`) that returns a serializable `ScreenSnapshot` (geometry, computed color/bg/radius/font, accessible name, net scrollbar gutters) — no DOM handles.
- **`screens/audit/detectors.ts`** — **pure** detectors over snapshot + descriptor, so they are unit-tested in Node without a browser. A finding maps 1:1 to a `KitRule` (severity + checklist from the registry); `must` fails CI.
- **`screens/audit/index.ts`** — `runScreenAudit` + `formatScreenReport`. Region detectors scope to regions whose `rules[]` opt in (nodes matched by landmark role ↔ `ariaRole`); a11y detectors run screen-wide.
- **`scripts/screen-audit.ts`** + `screen-audit` npm script — the Node CLI half (detect → report → exit non-zero on `must`).

### Detectors implemented
| Rule | Checklist | Severity |
|------|-----------|----------|
| `spacing/control-height-parity` | Z2 | must |
| `accessibility/accessible-name` | I1 | must |
| `accessibility/contrast` | I5 | must |
| `composition/edge-baseline-alignment` | C2 | should |
| `composition/no-clipping` | C8 | should |
| `spacing/icon-size-parity` | Z6 | should |
| `composition/vertical-rhythm` | C1 | should |

### Capture wiring
- Added an optional `story` field to `screen.schema.json` (the assembled-screen Storybook story id); wired `protection-dashboard` → `ui-appshell--with-secondary`.
- New **`/screen-audit`** skill drives capture: navigate the story (light + dark) → inject the probe → run the CLI. Detectors first; an optional AI visual review covers judgment-only rows.

### Tests
`__tests__/screen-audit.test.ts` (625 ui-spec tests total, all green): registry integrity, a clean snapshot → 0 findings, per-detector positive/negative cases, findings carry registry severity/checklist, and an end-to-end run against the shipped `protection-dashboard` descriptor proving region scoping. Also fixed `screens.test.ts` to list only dirs containing a `screen.yaml` (so the new `audit/` engine dir isn't mistaken for a screen).

### Deferred to Phase 4
AI visual-review detectors (`ai/*`), reference-implementation diffing (`ref/*`), the discrepancy ledger, and folding capture into the VR test-runner.

ui-spec is private — no changeset.