### PR TITLE
feat(grammar): add radius/disabled/tab-order screen detectors (Phase 4 step 1a)

### DIFF
--- a/.claude/skills/screen-audit/SKILL.md
+++ b/.claude/skills/screen-audit/SKILL.md
@@ -50,20 +50,27 @@ skill is the glue that captures the snapshot and feeds it to the CLI.
 
 ## Detectors implemented today
 
-| Rule id                               | Checklist | Severity |
-| ------------------------------------- | --------- | -------- |
-| `spacing/control-height-parity`       | Z2        | must     |
-| `accessibility/accessible-name`       | I1        | must     |
-| `accessibility/contrast`              | I5        | must     |
-| `composition/edge-baseline-alignment` | C2        | should   |
-| `composition/no-clipping`             | C8        | should   |
-| `spacing/icon-size-parity`            | Z6        | should   |
-| `composition/vertical-rhythm`         | C1        | should   |
+| Rule id                               | Checklist | Severity | Scope  |
+| ------------------------------------- | --------- | -------- | ------ |
+| `spacing/control-height-parity`       | Z2        | must     | region |
+| `accessibility/accessible-name`       | I1        | must     | screen |
+| `accessibility/contrast`              | I5        | must     | screen |
+| `composition/edge-baseline-alignment` | C2        | should   | region |
+| `composition/no-clipping`             | C8        | should   | region |
+| `spacing/icon-size-parity`            | Z6        | should   | region |
+| `spacing/radius-parity`               | Z3        | should   | region |
+| `composition/vertical-rhythm`         | C1        | should   | region |
+| `anatomy/disabled-parity`             | A2        | should   | screen |
+| `accessibility/tab-order`             | I4        | should   | region |
 
-A region-scoped detector runs only on regions whose `rules[]` opt into it; the
-two a11y detectors run screen-wide. A `screen/*` rule with no detector here is
-simply not enforced yet (no false confidence) — add one by appending to
-`DETECTORS` and pointing the rule's `detector` field at it.
+A region-scoped detector runs only on regions whose `rules[]` opt into it;
+screen-scoped detectors run over every node. A `screen/*` rule with no detector
+here is simply not enforced yet (no false confidence) — add one by appending to
+`DETECTORS` and pointing the rule's `detector` field at it. Four screen rules
+remain deferred because a single static snapshot can't judge them
+(`tokens/one-token-per-role`, `accessibility/overlay-dismiss`,
+`spacing/padding-tier`, `composition/shared-grid`) — see
+[`screens/audit/README.md`](../../../packages/ui-spec/screens/audit/README.md).
 
 ## Steps
 

--- a/packages/ui-spec/AGENTS.md
+++ b/packages/ui-spec/AGENTS.md
@@ -112,9 +112,14 @@ over that snapshot + descriptor, unit-tested in `__tests__/screen-audit.test.ts`
 without a browser. Findings map 1:1 to a `KitRule` (severity + checklist from the
 registry); `must` fails CI. Implemented: control-height-parity (Z2), accessible-name
 (I1), contrast (I5) — `must`; edge-baseline-alignment (C2), no-clipping (C8),
-icon-size-parity (Z6), vertical-rhythm (C1) — `should`. Region detectors run only
-on regions whose `rules[]` opt in; a11y detectors run screen-wide. Capture is
-driven by the [`/screen-audit`](../../.claude/skills/screen-audit/SKILL.md) skill.
+icon-size-parity (Z6), radius-parity (Z3), vertical-rhythm (C1), disabled-parity
+(A2), tab-order (I4) — `should`. Region detectors run only on regions whose
+`rules[]` opt in; screen detectors (accessible-name, contrast, disabled-parity)
+run screen-wide. Four `screen/*` rules stay deferred (one-token-per-role T5,
+overlay-dismiss I2, padding-tier Z4, shared-grid C3) — they need a role taxonomy,
+an interactive capture, or a column-grid model a single static snapshot lacks; see
+`screens/audit/README.md`. Capture is driven by the
+[`/screen-audit`](../../.claude/skills/screen-audit/SKILL.md) skill.
 The AI visual-review pass, reference diffs, and the ledger are Phase 4. See
 [`screens/audit/README.md`](./screens/audit/README.md).
 

--- a/packages/ui-spec/__tests__/screen-audit.test.ts
+++ b/packages/ui-spec/__tests__/screen-audit.test.ts
@@ -29,8 +29,10 @@ function node(partial: Partial<SnapshotNode>): SnapshotNode {
     text: partial.text ?? '',
     accessibleName: partial.accessibleName ?? null,
     interactive: partial.interactive ?? false,
+    disabled: partial.disabled ?? false,
     isIcon: partial.isIcon ?? false,
     rect: partial.rect ?? { x: 0, y: 0, width: 100, height: 32 },
+    opacity: partial.opacity ?? 1,
     color: partial.color ?? 'rgb(20, 20, 20)',
     backgroundColor: partial.backgroundColor ?? 'rgb(255, 255, 255)',
     fontSize: partial.fontSize ?? 14,
@@ -67,6 +69,8 @@ const everyRule: ScreenDescriptorLite = {
       rules: [
         'spacing/control-height-parity',
         'spacing/icon-size-parity',
+        'spacing/radius-parity',
+        'accessibility/tab-order',
         'composition/edge-baseline-alignment',
         'composition/vertical-rhythm',
         'composition/no-clipping',
@@ -131,6 +135,63 @@ describe('Z6 icon-size-parity', () => {
       node({ region: 'banner', isIcon: true, tag: 'svg', rect: { x: 24, y: 8, width: 20, height: 20 } }),
     ]);
     expect(ids(snap, everyRule)).toContain('spacing/icon-size-parity');
+  });
+});
+
+describe('Z3 radius-parity', () => {
+  it('flags sibling controls with mismatched radii in a row', () => {
+    const snap = snapshot([
+      node({ region: 'banner', interactive: true, tag: 'button', text: 'A', rect: { x: 0, y: 10, width: 80, height: 32 }, borderRadius: 6 }),
+      node({ region: 'banner', interactive: true, tag: 'button', text: 'B', rect: { x: 90, y: 10, width: 80, height: 32 }, borderRadius: 16 }),
+    ]);
+    expect(ids(snap, everyRule)).toContain('spacing/radius-parity');
+  });
+
+  it('passes equal radii', () => {
+    const snap = snapshot([
+      node({ region: 'banner', interactive: true, tag: 'button', text: 'A', rect: { x: 0, y: 10, width: 80, height: 32 }, borderRadius: 6 }),
+      node({ region: 'banner', interactive: true, tag: 'button', text: 'B', rect: { x: 90, y: 10, width: 80, height: 32 }, borderRadius: 6 }),
+    ]);
+    expect(ids(snap, everyRule)).not.toContain('spacing/radius-parity');
+  });
+});
+
+describe('A2 disabled-treatment (screen scope)', () => {
+  const noRules: ScreenDescriptorLite = { name: 'test', regions: [{ regionId: 'x', ariaRole: 'main' }] };
+
+  it('flags a mix of opacity-dimmed and token-dimmed disabled controls', () => {
+    const snap = snapshot([
+      node({ disabled: true, tag: 'button', accessibleName: 'A', opacity: 0.5 }),
+      node({ disabled: true, tag: 'button', accessibleName: 'B', opacity: 1 }),
+    ]);
+    expect(ids(snap, noRules)).toContain('anatomy/disabled-parity');
+  });
+
+  it('passes when all disabled controls share one treatment', () => {
+    const snap = snapshot([
+      node({ disabled: true, tag: 'button', accessibleName: 'A', opacity: 0.5 }),
+      node({ disabled: true, tag: 'button', accessibleName: 'B', opacity: 0.5 }),
+    ]);
+    expect(ids(snap, noRules)).not.toContain('anatomy/disabled-parity');
+  });
+});
+
+describe('I4 tab-order', () => {
+  it('flags a focusable element visually above one earlier in the tab order', () => {
+    // DOM order: A then B; but B sits entirely above A.
+    const snap = snapshot([
+      node({ region: 'banner', interactive: true, tag: 'a', text: 'A', rect: { x: 0, y: 100, width: 80, height: 32 } }),
+      node({ region: 'banner', interactive: true, tag: 'a', text: 'B', rect: { x: 0, y: 0, width: 80, height: 32 } }),
+    ]);
+    expect(ids(snap, everyRule)).toContain('accessibility/tab-order');
+  });
+
+  it('accepts DOM order matching top-to-bottom visual order', () => {
+    const snap = snapshot([
+      node({ region: 'banner', interactive: true, tag: 'a', text: 'A', rect: { x: 0, y: 0, width: 80, height: 32 } }),
+      node({ region: 'banner', interactive: true, tag: 'a', text: 'B', rect: { x: 0, y: 100, width: 80, height: 32 } }),
+    ]);
+    expect(ids(snap, everyRule)).not.toContain('accessibility/tab-order');
   });
 });
 

--- a/packages/ui-spec/screens/audit/README.md
+++ b/packages/ui-spec/screens/audit/README.md
@@ -40,13 +40,25 @@ This is the same shape as `kit-lint`: a finding maps 1:1 to a `KitRule`, and
 | `composition/edge-baseline-alignment` | C2        | should   | region |
 | `composition/no-clipping`             | C8        | should   | region |
 | `spacing/icon-size-parity`            | Z6        | should   | region |
+| `spacing/radius-parity`               | Z3        | should   | region |
 | `composition/vertical-rhythm`         | C1        | should   | region |
+| `anatomy/disabled-parity`             | A2        | should   | screen |
+| `accessibility/tab-order`             | I4        | should   | region |
 
 **Region** detectors run only on descriptor regions whose `rules[]` opt into the
 detector's rule (nodes matched to the region by landmark role ↔ `ariaRole`).
 **Screen** detectors run over every node. A `screen/*` rule with no detector here
 is simply not enforced yet — add one by appending to `DETECTORS` and pointing the
 rule's `detector` field at it.
+
+### Deferred `screen/*` detectors (need a capability a single snapshot lacks)
+
+| Rule id                         | Checklist | Why it is not a snapshot detector                                                     |
+| ------------------------------- | --------- | ------------------------------------------------------------------------------------- |
+| `tokens/one-token-per-role`     | T5 (must) | needs a semantic-role taxonomy per node; better as a static role→token map + ref diff |
+| `accessibility/overlay-dismiss` | I2 (must) | needs an interactive before/after-Escape capture; the probe is one static snapshot    |
+| `spacing/padding-tier`          | Z4        | "same role/size → same padding"; without a role model it is pure noise                |
+| `composition/shared-grid`       | C3        | overlaps `edge-baseline-alignment` (C2); needs a column-grid model to add signal      |
 
 ## Running
 

--- a/packages/ui-spec/screens/audit/detectors.ts
+++ b/packages/ui-spec/screens/audit/detectors.ts
@@ -136,6 +136,84 @@ export const DETECTORS: ScreenDetector[] = [
     },
   },
 
+  // Z3 — sibling controls in a row share a border-radius.
+  {
+    ruleId: 'spacing/radius-parity',
+    scope: 'region',
+    run(nodes) {
+      const out: Omit<ScreenFinding, 'severity' | 'checklist'>[] = [];
+      const controls = nodes.filter(
+        (n) => (n.interactive || n.disabled) && n.rect.height > 0
+      );
+      for (const row of rows(controls)) {
+        if (row.length < 2) continue;
+        const radii = distinct(row.map((n) => n.borderRadius), 1);
+        if (radii.length > 1) {
+          out.push(
+            find(
+              'spacing/radius-parity',
+              row[0],
+              `sibling controls in one row use ${radii.length} different border-radii (${radii.join('/')}px) — share one radius`
+            )
+          );
+        }
+      }
+      return out;
+    },
+  },
+
+  // A2 — disabled controls across the screen use ONE treatment, not a mix
+  // (some dimmed via opacity, some via a token color).
+  {
+    ruleId: 'anatomy/disabled-parity',
+    scope: 'screen',
+    run(nodes) {
+      const disabled = nodes.filter((n) => n.disabled);
+      if (disabled.length < 2) return [];
+      const viaOpacity = disabled.filter((n) => n.opacity < 0.99);
+      if (viaOpacity.length === 0 || viaOpacity.length === disabled.length) {
+        return [];
+      }
+      return [
+        find(
+          'anatomy/disabled-parity',
+          viaOpacity[0],
+          `disabled controls use mixed treatments (${viaOpacity.length} dim via opacity, ${disabled.length - viaOpacity.length} via a token) — pick one disabled treatment`
+        ),
+      ];
+    },
+  },
+
+  // I4 — tab (DOM) order follows visual order: no focusable element sits visually
+  // above another it comes after in source.
+  {
+    ruleId: 'accessibility/tab-order',
+    scope: 'region',
+    run(nodes) {
+      const out: Omit<ScreenFinding, 'severity' | 'checklist'>[] = [];
+      // `nodes` preserve DOM (document) order from the probe's tree walk.
+      const focusable = nodes.filter((n) => n.interactive);
+      for (let i = 0; i < focusable.length; i += 1) {
+        const a = focusable[i];
+        for (let j = i + 1; j < focusable.length; j += 1) {
+          const b = focusable[j];
+          // b comes later in the tab order but sits entirely above a.
+          if (b.rect.y + b.rect.height <= a.rect.y) {
+            out.push(
+              find(
+                'accessibility/tab-order',
+                b,
+                `tab order does not match visual order — this control is above an earlier-focused one (y=${b.rect.y} vs y=${a.rect.y})`
+              )
+            );
+            break;
+          }
+        }
+      }
+      return out;
+    },
+  },
+
   // C2 — adjacent components' left edges align, or are equal — never near-misses.
   {
     ruleId: 'composition/edge-baseline-alignment',

--- a/packages/ui-spec/screens/audit/probe.ts
+++ b/packages/ui-spec/screens/audit/probe.ts
@@ -160,13 +160,14 @@ export function collectScreenSnapshot(opts: ProbeOptions): ScreenSnapshot {
     const tag = el.tagName.toLowerCase();
     const isIcon =
       el.tagName === 'svg' || el.getAttribute('data-slot') === 'icon';
-    const disabled =
+    const isControl =
+      INTERACTIVE_TAG.has(el.tagName) ||
+      (role != null && INTERACTIVE_ROLE.has(role));
+    const isDisabled =
       el.hasAttribute('disabled') ||
       el.getAttribute('aria-disabled') === 'true';
-    const interactive =
-      !disabled &&
-      (INTERACTIVE_TAG.has(el.tagName) ||
-        (role != null && INTERACTIVE_ROLE.has(role)));
+    const interactive = isControl && !isDisabled;
+    const disabled = isControl && isDisabled;
 
     const borderX =
       num(style.borderLeftWidth) + num(style.borderRightWidth);
@@ -195,8 +196,12 @@ export function collectScreenSnapshot(opts: ProbeOptions): ScreenSnapshot {
       region: lm?.role ?? null,
       regionChild: lm ? el.parentElement === lm.el : false,
       text: (el.textContent ?? '').trim().slice(0, maxText),
-      accessibleName: interactive || el.tagName === 'IMG' ? accessibleName(el) : null,
+      accessibleName:
+        interactive || disabled || el.tagName === 'IMG'
+          ? accessibleName(el)
+          : null,
       interactive,
+      disabled,
       isIcon,
       rect: {
         x: Math.round(rect.x),
@@ -204,6 +209,7 @@ export function collectScreenSnapshot(opts: ProbeOptions): ScreenSnapshot {
         width: Math.round(rect.width),
         height: Math.round(rect.height),
       },
+      opacity: style.opacity === '' ? 1 : num(style.opacity),
       color: style.color,
       backgroundColor: effectiveBg(el),
       fontSize: Math.round(num(style.fontSize) * 100) / 100,

--- a/packages/ui-spec/screens/audit/types.ts
+++ b/packages/ui-spec/screens/audit/types.ts
@@ -39,11 +39,15 @@ export interface SnapshotNode {
   text: string;
   /** Computed accessible name (aria-label / labelledby / alt / title / text). */
   accessibleName: string | null;
-  /** A control the user operates (button, link, input, select, textarea, …). */
+  /** An enabled control the user operates (button, link, input, select, …). */
   interactive: boolean;
+  /** A control that is present but disabled (`disabled` / `aria-disabled`). */
+  disabled: boolean;
   /** An icon glyph (svg / `[data-slot="icon"]`). */
   isIcon: boolean;
   rect: NodeRect;
+  /** Computed opacity (0–1) — used to tell apart disabled treatments. */
+  opacity: number;
   /** Computed `color`, normalized `rgb(...)`/`rgba(...)`. */
   color: string;
   /** First non-transparent background found walking ancestors (the effective bg). */


### PR DESCRIPTION
## Phase 4 — step 1a: complete the dormant `screen/*` detectors

Fills three more screen-audit detectors over the Phase 3 (#487) harness — pure, snapshot-based, unit-tested without a browser. All `should`-level (won't block CI), and the screen detectors only run over synthetic snapshots in the vitest suite, so this is fully regression-safe.

### Added detectors
| Rule | Checklist | Severity | Scope | What it catches |
|------|-----------|----------|-------|-----------------|
| `spacing/radius-parity` | Z3 | should | region | sibling controls in a row using different border-radii |
| `anatomy/disabled-parity` | A2 | should | screen | disabled controls split between opacity-dim and token-dim treatments |
| `accessibility/tab-order` | I4 | should | region | a focusable element sitting visually above one earlier in the tab (DOM) order |

Probe now captures `disabled` (a present-but-disabled control) and `opacity` to support these.

### Deferred (a single static snapshot can't judge them) — documented in `screens/audit/README.md`
| Rule | Why |
|------|-----|
| `tokens/one-token-per-role` (T5, must) | needs a semantic-role taxonomy per node; better as a static role→token map + ref diff |
| `accessibility/overlay-dismiss` (I2, must) | needs an interactive before/after-Escape capture; the probe is one static snapshot |
| `spacing/padding-tier` (Z4) | "same role/size → same padding"; without a role model it's pure noise |
| `composition/shared-grid` (C3) | overlaps `edge-baseline-alignment` (C2); needs a column-grid model to add signal |

### Tests
`__tests__/screen-audit.test.ts` — +6 cases (positive/negative per detector); 631 ui-spec tests green. Docs updated: audit README, AGENTS.md, `/screen-audit` skill.

ui-spec is private — no changeset. Next: step 1b (complete the dormant `kit-lint/*` static detectors).