### PR TITLE
feat(grammar): complete safe kit-lint static detectors (Phase 4 step 1b)

### DIFF
--- a/packages/ui-spec/AGENTS.md
+++ b/packages/ui-spec/AGENTS.md
@@ -82,11 +82,18 @@ screen specs and the rendered audit follow. See [`grammar/README.md`](./grammar/
 
 **Phase 1 — `kit-lint`** (`scripts/kit-lint.ts`, `pnpm --filter @acronis-platform/ui-spec kit-lint`):
 static detectors over shipped ui-react component source for the `kit-lint` checklist
-rows (T1 no-hardcoded-color, T2 unbridged-name as `must`; T3 opacity-hack, Z1
-off-grid-spacing as `should`). It reads severities from the grammar registry and is
-**enforced via `__tests__/kit-lint.test.ts`** (which is part of `test`), so a
-`must` finding fails CI. Add a detector by appending to the `DETECTORS` array and
-its grammar rule's `detector` id.
+rows. `must`: T1 no-hardcoded-color, T2 unbridged-name. `should`: T3 opacity-hack,
+T4 state-token-wiring, Z1 off-grid-spacing, Y1 type-scale, Y2 line-height, Y3
+font-weight. `may`: I3 timing-parity. It reads severities from the grammar registry
+and is **enforced via `__tests__/kit-lint.test.ts`** (part of `test`), so a `must`
+finding fails CI; that test also exercises each detector over synthetic source via
+the exported `lintSource()`. Add a detector by appending to the `DETECTORS` array
+and pointing its grammar rule's `detector` id at it. Three static rows stay
+deferred: A1 focus-ring and C5 z-index (`must`) — a static "parity"/"layer-scale"
+detector would block CI on real, possibly-intentional variation, so they need a
+ratified canonical (and the overrides/ledger) first; Z5 touch-target (`must`) is
+not reliably detectable from source. A3 border-border is held pending a focused
+audit of the ~80 bare-`border` usages.
 
 ## Screens (application layer)
 

--- a/packages/ui-spec/__tests__/kit-lint.test.ts
+++ b/packages/ui-spec/__tests__/kit-lint.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { getRule } from '../grammar';
-import { formatReport, runKitLint } from '../scripts/kit-lint';
+import { formatReport, lintSource, runKitLint } from '../scripts/kit-lint';
 
 const findings = runKitLint();
 
@@ -18,5 +18,63 @@ describe('kit-lint static detectors', () => {
       expect(f.severity).toBe(rule?.severity);
       expect(f.checklist).toBe(rule?.checklist);
     }
+  });
+});
+
+// Focused detector tests over synthetic source (no dependence on shipped code).
+const ruleIds = (src: string): string[] =>
+  lintSource('x.tsx', src).map((f) => f.ruleId);
+
+describe('T4 tokens/state-token-wiring', () => {
+  it('flags a state variant wired to a base token', () => {
+    expect(ruleIds('className="hover:bg-[var(--ui-x-idle)]"')).toContain(
+      'tokens/state-token-wiring'
+    );
+  });
+  it('flags a state variant wired to a different state token', () => {
+    expect(ruleIds('className="hover:border-[var(--ui-x-active)]"')).toContain(
+      'tokens/state-token-wiring'
+    );
+  });
+  it('accepts a matching state token', () => {
+    expect(ruleIds('className="hover:bg-[var(--ui-x-hover)]"')).not.toContain(
+      'tokens/state-token-wiring'
+    );
+  });
+  it('ignores a state variant on a semantic token with no state suffix', () => {
+    expect(
+      ruleIds('className="hover:text-[var(--ui-text-on-surface-primary)]"')
+    ).not.toContain('tokens/state-token-wiring');
+  });
+});
+
+describe('Y1/Y2/Y3 typography', () => {
+  it('flags off-scale font size', () => {
+    expect(ruleIds('className="text-[13px]"')).toContain('typography/type-scale');
+  });
+  it('flags off-ramp line-height', () => {
+    expect(ruleIds('className="leading-[1.15]"')).toContain('typography/line-height');
+  });
+  it('flags arbitrary numeric font-weight', () => {
+    expect(ruleIds('className="font-[550]"')).toContain('typography/font-weight');
+  });
+  it('accepts token/utility typography', () => {
+    const out = ruleIds('className="text-sm leading-6 font-medium"');
+    expect(out).not.toContain('typography/type-scale');
+    expect(out).not.toContain('typography/line-height');
+    expect(out).not.toContain('typography/font-weight');
+  });
+});
+
+describe('I3 interaction/timing-parity', () => {
+  it('flags an arbitrary transition duration', () => {
+    expect(ruleIds('className="duration-[120ms]"')).toContain(
+      'interaction/timing-parity'
+    );
+  });
+  it('accepts a duration scale step', () => {
+    expect(ruleIds('className="duration-200"')).not.toContain(
+      'interaction/timing-parity'
+    );
   });
 });

--- a/packages/ui-spec/scripts/kit-lint.ts
+++ b/packages/ui-spec/scripts/kit-lint.ts
@@ -11,6 +11,11 @@
  *
  * Detectors are added over the rollout; a grammar rule whose `detector` is not
  * implemented here yet is simply not enforced (no false confidence).
+ *
+ * Implemented: T1/T2 (must), T3/T4/Z1/Y1/Y2/Y3 (should), I3 (may). Deferred:
+ * A1 focus-ring + C5 z-index (must — need a ratified canonical / layer scale +
+ * overrides before they can block CI on real variation), Z5 touch-target (not
+ * reliably static), A3 border-border (pending a bare-`border` audit).
  */
 import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
@@ -148,15 +153,97 @@ const DETECTORS: Detector[] = [
     });
     return out;
   },
+
+  // T4 — interaction state wired to the wrong token. A `hover:`/`active:`/
+  // `focus:`/`disabled:` color utility must reference a token whose trailing
+  // suffix matches that state. Flag a base token (`-idle`/`-default`/`-base`/
+  // `-normal`) or a *different* state's token under a state variant. Tokens with
+  // no state suffix (e.g. a semantic `-primary`) are left alone.
+  ({ file, lines }) => {
+    const out: Finding[] = [];
+    const re = new RegExp(
+      `\\b(hover|active|focus|disabled):(?:${COLOR_PREFIXES})-\\[var\\((--ui-[a-z0-9-]+)\\)\\]`,
+      'g'
+    );
+    const STATES = ['hover', 'active', 'focus', 'disabled'];
+    const BASE = ['idle', 'default', 'base', 'normal'];
+    lines.forEach((raw, i) => {
+      for (const m of raw.matchAll(re)) {
+        const state = m[1];
+        const token = m[2];
+        const suffix = [...BASE, ...STATES].find((s) => token.endsWith(`-${s}`));
+        if (!suffix) continue; // no state semantics in the token name → fine
+        if (BASE.includes(suffix) || suffix !== state)
+          out.push(finding('tokens/state-token-wiring', file, i + 1, `"${state}:" wired to "${token}" — reference the matching *-${state} token`));
+      }
+    });
+    return out;
+  },
+
+  // Y1 — off-scale arbitrary font size (text-[<number><unit>], not a token).
+  ({ file, lines }) => {
+    const out: Finding[] = [];
+    const re = /\btext-\[(\d+(?:\.\d+)?)(px|rem|em)\]/g;
+    lines.forEach((raw, i) => {
+      for (const m of raw.matchAll(re))
+        out.push(finding('typography/type-scale', file, i + 1, `off-scale font size "${m[0]}" — use a type-scale token/utility`));
+    });
+    return out;
+  },
+
+  // Y2 — line-height off the ramp (arbitrary leading-[<number>], not a token).
+  ({ file, lines }) => {
+    const out: Finding[] = [];
+    const re = /\bleading-\[(\d+(?:\.\d+)?)\]/g;
+    lines.forEach((raw, i) => {
+      for (const m of raw.matchAll(re))
+        out.push(finding('typography/line-height', file, i + 1, `off-ramp line-height "${m[0]}" — use a line-height token/utility`));
+    });
+    return out;
+  },
+
+  // Y3 — font-weight outside the allowed set (arbitrary numeric font-[NNN]).
+  ({ file, lines }) => {
+    const out: Finding[] = [];
+    const re = /\bfont-\[(\d{2,3})\]/g;
+    lines.forEach((raw, i) => {
+      for (const m of raw.matchAll(re))
+        out.push(finding('typography/font-weight', file, i + 1, `arbitrary font-weight "${m[0]}" — use a named weight (font-normal/medium/semibold)`));
+    });
+    return out;
+  },
+
+  // I3 — hover/transition timing drift (arbitrary duration-[<n>ms], not a scale step).
+  ({ file, lines }) => {
+    const out: Finding[] = [];
+    const re = /\bduration-\[(\d+)m?s\]/g;
+    lines.forEach((raw, i) => {
+      for (const m of raw.matchAll(re))
+        out.push(finding('interaction/timing-parity', file, i + 1, `arbitrary transition duration "${m[0]}" — use a duration scale step (duration-150/200/300)`));
+    });
+    return out;
+  },
 ];
+
+/** Run every detector over one source string. Exposed for focused tests. */
+export function lintSource(
+  file: string,
+  src: string,
+  bridged: Set<string> = new Set()
+): Finding[] {
+  const lines = stripComments(src).split('\n');
+  const out: Finding[] = [];
+  for (const detect of DETECTORS) out.push(...detect({ file, lines, bridged }));
+  return out;
+}
 
 export function runKitLint(): Finding[] {
   const bridged = bridgedColorNames();
   const findings: Finding[] = [];
   for (const file of componentFiles(UI_DIR)) {
-    const rel = relative(REPO, file);
-    const lines = stripComments(readFileSync(file, 'utf8')).split('\n');
-    for (const detect of DETECTORS) findings.push(...detect({ file: rel, lines, bridged }));
+    findings.push(
+      ...lintSource(relative(REPO, file), readFileSync(file, 'utf8'), bridged)
+    );
   }
   return findings;
 }


### PR DESCRIPTION
## Phase 4 — step 1b: complete the dormant `kit-lint/*` static detectors

Adds five static detectors over real ui-react source. All `should`/`may` (cannot block CI), and the test asserts `must === []`, so this is regression-safe. Follows step 1a (#488).

### Added detectors
| Rule | Checklist | Severity | What it catches |
|------|-----------|----------|-----------------|
| `tokens/state-token-wiring` | T4 | should | a `hover:`/`active:`/`focus:`/`disabled:` color utility referencing a base or *other-state* token instead of the matching `*-<state>` one |
| `typography/type-scale` | Y1 | should | off-scale arbitrary font sizes (`text-[Npx]`) |
| `typography/line-height` | Y2 | should | off-ramp arbitrary `leading-[N]` |
| `typography/font-weight` | Y3 | should | arbitrary numeric `font-[NNN]` |
| `interaction/timing-parity` | I3 | may | arbitrary transition `duration-[Nms]` |

**T4 immediately caught a real mis-wiring:** `scroll-area.tsx:35` has a `hover:` variant pointing at an `-active` token. Surfaced as a `should` warning (not CI-blocking).

Real-source `kit-lint` run: **0 must**, 4 should (1 pre-existing T3, 2 Y1, 1 T4).

### Deferred (cannot ship safely as static detectors yet)
| Rule | Why |
|------|-----|
| `anatomy/focus-ring-parity` (A1, must) | genuine ring/border/outline variation across 34 files — needs a *ratified canonical* focus ring (+ overrides) before it can block CI |
| `composition/z-index-layers` (C5, must) | a real `z-[100]` exists; needs a defined layer scale + an override/source fix first |
| `spacing/touch-target` (Z5, must) | not reliably detectable from static source (sizes come from tokens) |
| `anatomy/explicit-border-color` (A3, should) | ~80 bare-`border` usages — needs a focused audit (does the project set a default border color?) + likely a codemod, not a blind detector |

### Tests
Exposed `lintSource()` so each detector is unit-tested over synthetic source — +10 cases; **641 ui-spec tests green**. Docs updated (AGENTS.md, script header).

ui-spec is private — no changeset. This completes step 1; the deferred `must` rows roll into Phase 4 proper (overrides + ledger).