### PR TITLE
feat(grammar): add overrides mechanism (Phase 4)

### DIFF
--- a/packages/ui-spec/AGENTS.md
+++ b/packages/ui-spec/AGENTS.md
@@ -80,6 +80,18 @@ and the checklist in sync. This is **Phase 0** of
 [`context/kit-consistency-audit-proposal.md`](../../context/kit-consistency-audit-proposal.md);
 screen specs and the rendered audit follow. See [`grammar/README.md`](./grammar/README.md).
 
+**Overrides** (`grammar/overrides/`, Phase 4): approved, scoped, dated waivers for
+_intentional_ deviations — the third resolution for a finding (fix / new rule /
+override). A `KitOverride` names the `rule` it waives, a `scope` (component / screen
+/ region / file / ref), a `reason`, `approvedBy`, `date`, and optional `expires`.
+Both `kit-lint` and the screen audit pass findings through `applyOverrides`, so an
+approved waiver is removed from what gates CI yet stays auditable (the CLIs print an
+`N suppressed by approved override(s)` line). The registry ships **empty**; only a
+human adds an entry. `validateOverrides()` (run by `__tests__/overrides.test.ts`)
+keeps entries well-formed. This unblocks the deferred `must` detectors — a rule can
+block CI broadly while genuine exceptions carry a scoped waiver. See
+[`grammar/overrides/README.md`](./grammar/overrides/README.md).
+
 **Phase 1 — `kit-lint`** (`scripts/kit-lint.ts`, `pnpm --filter @acronis-platform/ui-spec kit-lint`):
 static detectors over shipped ui-react component source for the `kit-lint` checklist
 rows. `must`: T1 no-hardcoded-color, T2 unbridged-name. `should`: T3 opacity-hack,

--- a/packages/ui-spec/__tests__/kit-lint.test.ts
+++ b/packages/ui-spec/__tests__/kit-lint.test.ts
@@ -78,3 +78,24 @@ describe('I3 interaction/timing-parity', () => {
     );
   });
 });
+
+describe('overrides wiring', () => {
+  it('runKitLint suppresses a finding a scoped override covers', () => {
+    const ruleId = 'tokens/state-token-wiring';
+    const covered = (f: { ruleId: string; file: string }) =>
+      f.ruleId === ruleId && f.file.includes('scroll-area');
+    const active = runKitLint({
+      overrides: [
+        {
+          id: 'sa-state',
+          rule: ruleId,
+          scope: { component: 'scroll-area' },
+          reason: 'no -hover token exists for this border tier yet',
+          approvedBy: 'tester',
+          date: '2026-06-28',
+        },
+      ],
+    });
+    expect(active.some(covered)).toBe(false);
+  });
+});

--- a/packages/ui-spec/__tests__/overrides.test.ts
+++ b/packages/ui-spec/__tests__/overrides.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyOverrides,
+  isOverridden,
+  matchesOverride,
+  overrides,
+  validateOverrides,
+} from '../grammar/overrides';
+import type { KitOverride } from '../grammar/overrides';
+
+const base: KitOverride = {
+  id: 'compact-device-table',
+  rule: 'spacing/control-height-parity',
+  scope: { screen: 'devices', region: 'table' },
+  reason: 'The device table is intentionally compact per design.',
+  approvedBy: 'Leonid Romanov',
+  date: '2026-06-28',
+};
+
+describe('the shipped override registry', () => {
+  it('is empty until a human ratifies a deviation', () => {
+    expect(overrides).toEqual([]);
+  });
+
+  it('validates clean (no entries, no errors)', () => {
+    expect(validateOverrides()).toEqual([]);
+  });
+});
+
+describe('validateOverrides', () => {
+  it('accepts a well-formed entry', () => {
+    expect(validateOverrides([base])).toEqual([]);
+  });
+
+  it('flags an unknown rule', () => {
+    const errs = validateOverrides([{ ...base, rule: 'nope/not-a-rule' }]);
+    expect(errs.join(' ')).toMatch(/unknown rule/);
+  });
+
+  it('flags an empty scope, missing reason/approver, and bad dates', () => {
+    const errs = validateOverrides([
+      { ...base, scope: {} },
+      { ...base, id: 'b', reason: '' },
+      { ...base, id: 'c', approvedBy: '' },
+      { ...base, id: 'd', date: '2026/06/28' },
+      { ...base, id: 'e', expires: 'soon' },
+    ]);
+    expect(errs.join(' ')).toMatch(/no scope/);
+    expect(errs.join(' ')).toMatch(/missing a reason/);
+    expect(errs.join(' ')).toMatch(/missing approvedBy/);
+    expect(errs.join(' ')).toMatch(/invalid date/);
+    expect(errs.join(' ')).toMatch(/invalid expires/);
+  });
+
+  it('flags duplicate ids', () => {
+    const errs = validateOverrides([base, { ...base }]);
+    expect(errs.join(' ')).toMatch(/duplicate override id/);
+  });
+});
+
+describe('matchesOverride', () => {
+  it('matches the same rule + all specified scope selectors', () => {
+    expect(
+      matchesOverride(base, {
+        ruleId: 'spacing/control-height-parity',
+        screen: 'devices',
+        region: 'table',
+      })
+    ).toBe(true);
+  });
+
+  it('does not match a different rule', () => {
+    expect(
+      matchesOverride(base, { ruleId: 'accessibility/contrast', screen: 'devices', region: 'table' })
+    ).toBe(false);
+  });
+
+  it('does not match when a scope selector differs', () => {
+    expect(
+      matchesOverride(base, { ruleId: 'spacing/control-height-parity', screen: 'devices', region: 'header' })
+    ).toBe(false);
+  });
+
+  it('matches a component scope case/style-insensitively', () => {
+    const o: KitOverride = { ...base, scope: { component: 'ScrollArea' } };
+    expect(matchesOverride(o, { ruleId: base.rule, component: 'scroll-area' })).toBe(true);
+  });
+
+  it('matches a file fragment for kit-lint findings', () => {
+    const o: KitOverride = { ...base, scope: { file: 'scroll-area/scroll-area.tsx' } };
+    expect(
+      matchesOverride(o, {
+        ruleId: base.rule,
+        file: 'packages/ui-react/src/components/ui/scroll-area/scroll-area.tsx',
+      })
+    ).toBe(true);
+  });
+
+  it('never matches an empty scope', () => {
+    expect(matchesOverride({ ...base, scope: {} }, { ruleId: base.rule })).toBe(false);
+  });
+
+  it('does not suppress once expired', () => {
+    const o: KitOverride = { ...base, expires: '2026-01-01' };
+    const t = { ruleId: base.rule, screen: 'devices', region: 'table' };
+    expect(matchesOverride(o, t, '2025-12-31')).toBe(true); // before expiry
+    expect(matchesOverride(o, t, '2026-06-28')).toBe(false); // after expiry
+  });
+});
+
+describe('applyOverrides / isOverridden', () => {
+  type F = { ruleId: string; screen: string; region: string };
+  const findings: F[] = [
+    { ruleId: 'spacing/control-height-parity', screen: 'devices', region: 'table' },
+    { ruleId: 'spacing/control-height-parity', screen: 'devices', region: 'header' },
+  ];
+
+  it('splits suppressed from active', () => {
+    const { active, suppressed } = applyOverrides(
+      findings,
+      (f) => ({ ruleId: f.ruleId, screen: f.screen, region: f.region }),
+      { overrides: [base] }
+    );
+    expect(suppressed).toHaveLength(1);
+    expect(suppressed[0].region).toBe('table');
+    expect(active).toHaveLength(1);
+    expect(active[0].region).toBe('header');
+  });
+
+  it('isOverridden honors an injected registry', () => {
+    expect(
+      isOverridden(
+        { ruleId: base.rule, screen: 'devices', region: 'table' },
+        { overrides: [base] }
+      )
+    ).toBe(true);
+    expect(
+      isOverridden({ ruleId: base.rule, screen: 'devices', region: 'table' })
+    ).toBe(false); // real (empty) registry
+  });
+});

--- a/packages/ui-spec/__tests__/screen-audit.test.ts
+++ b/packages/ui-spec/__tests__/screen-audit.test.ts
@@ -298,6 +298,31 @@ describe('findings resolve against the registry', () => {
   });
 });
 
+// ── overrides suppress findings end-to-end ───────────────────────────────────
+describe('an approved override suppresses a screen finding', () => {
+  const snap = snapshot([
+    node({ region: 'banner', interactive: true, tag: 'button', text: 'A', rect: { x: 0, y: 10, width: 80, height: 28 } }),
+    node({ region: 'banner', interactive: true, tag: 'input', accessibleName: 'q', rect: { x: 90, y: 8, width: 200, height: 40 } }),
+  ]);
+
+  it('drops the finding the override covers, keeps the rest', () => {
+    expect(ids(snap, everyRule)).toContain('spacing/control-height-parity');
+    const active = runScreenAudit(snap, everyRule, {
+      overrides: [
+        {
+          id: 'compact-bar',
+          rule: 'spacing/control-height-parity',
+          scope: { screen: 'test', region: 'bar' },
+          reason: 'intentionally compact toolbar',
+          approvedBy: 'tester',
+          date: '2026-06-28',
+        },
+      ],
+    });
+    expect(active.map((f) => f.ruleId)).not.toContain('spacing/control-height-parity');
+  });
+});
+
 // ── end-to-end against the real protection-dashboard descriptor ──────────────
 describe('runs against the shipped protection-dashboard descriptor', () => {
   const descriptor = parseYaml(

--- a/packages/ui-spec/grammar/README.md
+++ b/packages/ui-spec/grammar/README.md
@@ -15,12 +15,24 @@ Design and rationale: [`context/kit-consistency-audit-proposal.md`](../../../con
 grammar/
 ├── types.ts            # KitRule, RuleCategory, RuleSeverity
 ├── rules/              # one file per category + index (registry + lookups)
+├── overrides/          # approved, scoped, dated rule deviations (see README)
 ├── CHECKLIST.md        # human mirror of the registry (1:1 by row id)
 └── index.ts            # public surface
 ```
 
 The test (`../__tests__/grammar.test.ts`) enforces registry integrity and that
-the registry and `CHECKLIST.md` stay in sync.
+the registry and `CHECKLIST.md` stay in sync;
+`../__tests__/overrides.test.ts` validates the [overrides](./overrides/README.md)
+registry.
+
+## Overrides
+
+[`overrides/`](./overrides/README.md) is how an _intentional_ deviation stays
+legal: an approved, scoped, dated entry that the audits treat as a pass instead of
+a defect (the third resolution for a finding — fix / new rule / **override**).
+Both `kit-lint` and the screen audit run findings through `applyOverrides`, so an
+approved waiver removes a finding from what gates CI while keeping it auditable.
+The registry ships empty until a human ratifies one.
 
 ## Usage
 

--- a/packages/ui-spec/grammar/index.ts
+++ b/packages/ui-spec/grammar/index.ts
@@ -7,3 +7,11 @@ export {
   getRulesByCategory,
   getMandatoryRules,
 } from './rules';
+export type { KitOverride, OverrideScope, OverrideTarget } from './overrides';
+export {
+  overrides,
+  validateOverrides,
+  matchesOverride,
+  isOverridden,
+  applyOverrides,
+} from './overrides';

--- a/packages/ui-spec/grammar/overrides/README.md
+++ b/packages/ui-spec/grammar/overrides/README.md
@@ -1,0 +1,67 @@
+# `grammar/overrides` — approved rule deviations
+
+An **override** is how an _intentional_ deviation from a grammar rule stays legal.
+Instead of a defect, the audits (`kit-lint`, the screen audit) treat a matching
+finding as a **pass** — and record that it was waived, never silently dropped.
+
+This is the third resolution for an audit finding (proposal §9): fix it, write a
+new rule for it, or — when the deviation is intended — **override** it. It is also
+what unblocks shipping the deferred `must` detectors: a rule can block CI broadly
+while genuine exceptions carry a scoped, dated, human-approved waiver.
+
+## Shape
+
+```ts
+interface KitOverride {
+  id: string; // unique kebab slug
+  rule: string; // grammar rule id it waives (must resolve)
+  scope: {
+    // at least one selector required
+    component?: string; // ui-react component (dir or PascalCase)
+    screen?: string; // screen slug
+    region?: string; // region id within a screen
+    file?: string; // repo-relative path / fragment (kit-lint findings)
+    ref?: string; // node locator (screen-audit findings)
+  };
+  reason: string; // why the deviation is intentional
+  approvedBy: string; // the human who approved it
+  date: string; // YYYY-MM-DD approved
+  expires?: string; // optional YYYY-MM-DD; after this it no longer applies
+}
+```
+
+A finding is suppressed when an override has the **same rule** and **every
+specified scope selector matches** the finding's location (and the override is not
+expired). An empty scope never matches.
+
+## Adding one (a human owns this)
+
+The registry in [`index.ts`](./index.ts) ships **empty** — there are no approved
+deviations yet. To add one, append a typed entry with a real `reason` and your
+name in `approvedBy`. `validateOverrides()` (run by `__tests__/overrides.test.ts`,
+part of `test`) enforces a resolvable rule, a non-empty scope, a reason, an
+approver, and well-formed dates — so a malformed waiver fails CI.
+
+```ts
+export const overrides: KitOverride[] = [
+  {
+    id: 'compact-device-table',
+    rule: 'spacing/control-height-parity',
+    scope: { screen: 'devices', region: 'table' },
+    reason:
+      'The device table is intentionally compact per the approved design.',
+    approvedBy: 'Jane Doe',
+    date: '2026-06-28',
+  },
+];
+```
+
+## API
+
+- `validateOverrides(list?, ruleExists?)` → `string[]` of errors (empty = valid).
+- `matchesOverride(o, target, today?)` → does this override cover that finding?
+- `isOverridden(target, { overrides?, today? })` → boolean.
+- `applyOverrides(findings, toTarget, { overrides?, today? })` →
+  `{ active, suppressed }`. Both `kit-lint` and the screen audit run their findings
+  through this; the CLIs print active findings and an `N suppressed by approved
+override(s)` line, and gate CI on the **active** `must` findings only.

--- a/packages/ui-spec/grammar/overrides/index.ts
+++ b/packages/ui-spec/grammar/overrides/index.ts
@@ -1,0 +1,98 @@
+// Grammar overrides — registry + validation + matching/suppression.
+//
+// The registry starts empty: there are no approved deviations yet. When a real
+// one is needed (e.g. an intentionally compact device table), a human adds a
+// typed entry here; the audits (kit-lint, screen-audit) then treat the matching
+// finding as a pass instead of a defect. See ./types.ts and README.md.
+import { getRule } from '../rules';
+import type { KitOverride, OverrideTarget } from './types';
+
+export type { KitOverride, OverrideScope, OverrideTarget } from './types';
+
+/** Approved deviations. Empty until a human ratifies one. */
+export const overrides: KitOverride[] = [];
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+const toKebab = (s: string): string =>
+  s.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+
+/**
+ * Validate override entries: unique id, resolvable rule, non-empty scope/reason/
+ * approver, and well-formed dates. Returns a list of human-readable errors
+ * (empty = valid). `ruleExists` is injectable for tests.
+ */
+export function validateOverrides(
+  list: KitOverride[] = overrides,
+  ruleExists: (id: string) => boolean = (id) => Boolean(getRule(id))
+): string[] {
+  const errors: string[] = [];
+  const ids = new Set<string>();
+  for (const o of list) {
+    const label = o.id ? `override "${o.id}"` : 'override (missing id)';
+    if (!o.id) errors.push('an override is missing an id');
+    else if (ids.has(o.id)) errors.push(`duplicate override id "${o.id}"`);
+    if (o.id) ids.add(o.id);
+    if (!ruleExists(o.rule)) errors.push(`${label} references unknown rule "${o.rule}"`);
+    if (!o.scope || Object.keys(o.scope).length === 0)
+      errors.push(`${label} has no scope (needs at least one selector)`);
+    if (!o.reason?.trim()) errors.push(`${label} is missing a reason`);
+    if (!o.approvedBy?.trim()) errors.push(`${label} is missing approvedBy`);
+    if (!DATE_RE.test(o.date ?? '')) errors.push(`${label} has an invalid date "${o.date}"`);
+    if (o.expires && !DATE_RE.test(o.expires))
+      errors.push(`${label} has an invalid expires "${o.expires}"`);
+  }
+  return errors;
+}
+
+/**
+ * Does this override apply to the target finding? Requires the same rule, every
+ * specified scope selector to match, and (if `today` is given) a non-expired
+ * override. An override with an empty scope never matches.
+ */
+export function matchesOverride(
+  o: KitOverride,
+  t: OverrideTarget,
+  today?: string
+): boolean {
+  if (o.rule !== t.ruleId) return false;
+  if (!o.scope || Object.keys(o.scope).length === 0) return false;
+  if (today && o.expires && o.expires < today) return false;
+  const s = o.scope;
+  if (s.component && (!t.component || toKebab(s.component) !== toKebab(t.component)))
+    return false;
+  if (s.screen && s.screen !== t.screen) return false;
+  if (s.region && s.region !== t.region) return false;
+  if (s.file && !(t.file && t.file.includes(s.file))) return false;
+  if (s.ref && s.ref !== t.ref) return false;
+  return true;
+}
+
+export function isOverridden(
+  t: OverrideTarget,
+  opts: { overrides?: KitOverride[]; today?: string } = {}
+): boolean {
+  const list = opts.overrides ?? overrides;
+  return list.some((o) => matchesOverride(o, t, opts.today));
+}
+
+/**
+ * Split findings into those still active and those suppressed by an override.
+ * `toTarget` maps a finding to its location. Generic over the finding shape so
+ * both kit-lint and screen-audit reuse it.
+ */
+export function applyOverrides<T>(
+  findings: T[],
+  toTarget: (f: T) => OverrideTarget,
+  opts: { overrides?: KitOverride[]; today?: string } = {}
+): { active: T[]; suppressed: T[] } {
+  const list = opts.overrides ?? overrides;
+  const active: T[] = [];
+  const suppressed: T[] = [];
+  for (const f of findings) {
+    if (list.some((o) => matchesOverride(o, toTarget(f), opts.today)))
+      suppressed.push(f);
+    else active.push(f);
+  }
+  return { active, suppressed };
+}

--- a/packages/ui-spec/grammar/overrides/types.ts
+++ b/packages/ui-spec/grammar/overrides/types.ts
@@ -1,0 +1,47 @@
+// Grammar overrides — approved, scoped, dated deviations from a grammar rule.
+//
+// An override is how an *intentional* deviation stays legal: instead of a defect,
+// the audit treats a matching finding as a pass. Every override names the rule it
+// waives, a scope (where it applies), a human-readable reason, who approved it,
+// and the date — so a waiver is auditable and never silent. A person owns this:
+// only a human adds an override entry. See context/kit-consistency-audit-proposal.md §5/§9.
+
+/** Where an override applies. At least one selector is required (validated). */
+export interface OverrideScope {
+  /** ui-react component (dir or PascalCase name; matched case-insensitively kebab). */
+  component?: string;
+  /** Screen slug (screens/<slug>). */
+  screen?: string;
+  /** Region id within a screen. */
+  region?: string;
+  /** Repo-relative path or path fragment (substring match) — for kit-lint findings. */
+  file?: string;
+  /** Node locator (exact) — for screen-audit findings. */
+  ref?: string;
+}
+
+export interface KitOverride {
+  /** Unique kebab slug. */
+  id: string;
+  /** Grammar rule id this waives (must resolve in the registry). */
+  rule: string;
+  scope: OverrideScope;
+  /** Why this deviation is intentional. */
+  reason: string;
+  /** The human who approved it (a person owns waivers). */
+  approvedBy: string;
+  /** ISO date approved (YYYY-MM-DD). */
+  date: string;
+  /** Optional ISO expiry (YYYY-MM-DD); after this the override no longer applies. */
+  expires?: string;
+}
+
+/** A finding's location, normalized so an override can be matched against it. */
+export interface OverrideTarget {
+  ruleId: string;
+  component?: string;
+  screen?: string;
+  region?: string;
+  file?: string;
+  ref?: string;
+}

--- a/packages/ui-spec/screens/audit/index.ts
+++ b/packages/ui-spec/screens/audit/index.ts
@@ -10,6 +10,8 @@
 // here, is simply not enforced — same "no false confidence" contract as kit-lint.
 // See context/kit-consistency-audit-proposal.md §7.
 import type { RuleSeverity } from '../../grammar';
+import { applyOverrides } from '../../grammar/overrides';
+import type { KitOverride } from '../../grammar/overrides';
 import { DETECTORS, resolveFinding } from './detectors';
 import type {
   ScreenDescriptorLite,
@@ -32,7 +34,8 @@ function flattenRegions(regions: ScreenRegionLite[]): ScreenRegionLite[] {
   return out;
 }
 
-export function runScreenAudit(
+/** All raw findings for a screen, before approved overrides are applied. */
+export function collectScreenFindings(
   snapshot: ScreenSnapshot,
   descriptor: ScreenDescriptorLite
 ): ScreenFinding[] {
@@ -67,6 +70,33 @@ export function runScreenAudit(
     seen.add(key);
     return true;
   });
+}
+
+/** Findings split into active vs. suppressed by an approved override. */
+export function auditScreen(
+  snapshot: ScreenSnapshot,
+  descriptor: ScreenDescriptorLite,
+  opts: { overrides?: KitOverride[]; today?: string } = {}
+): { active: ScreenFinding[]; suppressed: ScreenFinding[] } {
+  return applyOverrides(
+    collectScreenFindings(snapshot, descriptor),
+    (f) => ({
+      ruleId: f.ruleId,
+      screen: descriptor.name,
+      region: f.region ?? undefined,
+      ref: f.ref,
+    }),
+    opts
+  );
+}
+
+/** The active findings (approved overrides removed) — what gates CI. */
+export function runScreenAudit(
+  snapshot: ScreenSnapshot,
+  descriptor: ScreenDescriptorLite,
+  opts: { overrides?: KitOverride[]; today?: string } = {}
+): ScreenFinding[] {
+  return auditScreen(snapshot, descriptor, opts).active;
 }
 
 export function formatScreenReport(

--- a/packages/ui-spec/scripts/kit-lint.ts
+++ b/packages/ui-spec/scripts/kit-lint.ts
@@ -23,6 +23,8 @@ import { fileURLToPath } from 'node:url';
 
 import { getRule } from '../grammar';
 import type { RuleSeverity } from '../grammar';
+import { applyOverrides } from '../grammar/overrides';
+import type { KitOverride, OverrideTarget } from '../grammar/overrides';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = resolve(HERE, '../../..');
@@ -237,7 +239,19 @@ export function lintSource(
   return out;
 }
 
-export function runKitLint(): Finding[] {
+/** Component dir name from a repo-relative source path (the override scope key). */
+function componentOf(file: string): string | undefined {
+  return file.match(/components\/ui\/([^/]+)\//)?.[1];
+}
+
+const kitTarget = (f: Finding): OverrideTarget => ({
+  ruleId: f.ruleId,
+  file: f.file,
+  component: componentOf(f.file),
+});
+
+/** All raw findings, before approved overrides are applied. */
+export function collectFindings(): Finding[] {
   const bridged = bridgedColorNames();
   const findings: Finding[] = [];
   for (const file of componentFiles(UI_DIR)) {
@@ -246,6 +260,20 @@ export function runKitLint(): Finding[] {
     );
   }
   return findings;
+}
+
+/** Findings split into active vs. suppressed by an approved override. */
+export function auditKitLint(
+  opts: { overrides?: KitOverride[]; today?: string } = {}
+): { active: Finding[]; suppressed: Finding[] } {
+  return applyOverrides(collectFindings(), kitTarget, opts);
+}
+
+/** The active findings (approved overrides removed) — what gates CI. */
+export function runKitLint(
+  opts: { overrides?: KitOverride[]; today?: string } = {}
+): Finding[] {
+  return auditKitLint(opts).active;
 }
 
 export function formatReport(findings: Finding[]): string {
@@ -267,7 +295,11 @@ export function formatReport(findings: Finding[]): string {
 // CLI: print the report; exit non-zero on any `must` finding.
 const isMain = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
 if (isMain) {
-  const findings = runKitLint();
-  process.stdout.write(formatReport(findings) + '\n');
-  process.exit(findings.some((f) => f.severity === 'must') ? 1 : 0);
+  const today = new Date().toISOString().slice(0, 10);
+  const { active, suppressed } = auditKitLint({ today });
+  let report = formatReport(active);
+  if (suppressed.length)
+    report += `\n${suppressed.length} suppressed by approved override(s).`;
+  process.stdout.write(report + '\n');
+  process.exit(active.some((f) => f.severity === 'must') ? 1 : 0);
 }

--- a/packages/ui-spec/scripts/screen-audit.ts
+++ b/packages/ui-spec/scripts/screen-audit.ts
@@ -16,7 +16,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { load as parseYaml } from 'js-yaml';
 
-import { formatScreenReport, runScreenAudit } from '../screens/audit';
+import { auditScreen, formatScreenReport } from '../screens/audit';
 import type { ScreenDescriptorLite, ScreenSnapshot } from '../screens/audit/types';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -41,6 +41,10 @@ if (!slug || !snapshotPath) {
 
 const descriptor = loadDescriptor(slug);
 const snapshot = loadSnapshot(snapshotPath);
-const findings = runScreenAudit(snapshot, descriptor);
-process.stdout.write(formatScreenReport(findings, slug) + '\n');
-process.exit(findings.some((f) => f.severity === 'must') ? 1 : 0);
+const today = new Date().toISOString().slice(0, 10);
+const { active, suppressed } = auditScreen(snapshot, descriptor, { today });
+let report = formatScreenReport(active, slug);
+if (suppressed.length)
+  report += `\n${suppressed.length} suppressed by approved override(s).`;
+process.stdout.write(report + '\n');
+process.exit(active.some((f) => f.severity === 'must') ? 1 : 0);


### PR DESCRIPTION
## Phase 4 — overrides mechanism

The first piece of Phase 4 proper (proposal §5/§9): **approved, scoped, dated waivers** for intentional rule deviations. An override is the third resolution for an audit finding — *fix it*, *write a new rule*, or, when the deviation is intended, *override it*. The audits then treat a matching finding as a **pass** (and report it as waived), never silently dropped.

This is also what **unblocks the deferred `must` detectors**: a rule can block CI broadly while genuine exceptions carry a scoped, human-approved waiver.

### What's added — `grammar/overrides/`
- `KitOverride` type: `rule` + `scope` (component / screen / region / file / ref) + `reason` + `approvedBy` + `date` + optional `expires`.
- Registry **ships empty** — only a human ratifies a deviation.
- `validateOverrides()` — resolvable rule, non-empty scope, reason, approver, well-formed dates. Run by `__tests__/overrides.test.ts`, so a malformed waiver fails CI.
- `matchesOverride()` / `isOverridden()` — same rule + every specified scope selector matches, expiry-aware.
- Generic `applyOverrides(findings, toTarget)` → `{ active, suppressed }`.

### Wiring
Both `kit-lint` and the screen audit now run findings through `applyOverrides`: an approved waiver is removed from what gates CI (active `must` only) yet stays auditable — both CLIs print `N suppressed by approved override(s)`. With the empty registry **behavior is unchanged** (kit-lint still 4 should / 0 must). Exposed `lintSource`/`collectFindings` and `collectScreenFindings`/`auditScreen` for raw-vs-active access.

### Tests
`__tests__/overrides.test.ts` (validation, rule/scope/expiry matching, component case-insensitivity, file-fragment match, suppression split) + e2e suppression through `runScreenAudit`/`runKitLint`. **658 ui-spec tests green** (+17). Docs: `grammar/overrides/README.md`, `grammar/README.md`, AGENTS.md.

ui-spec is private — no changeset. Next in Phase 4: the discrepancy **ledger** + `/grammar-rule` (the self-improving loop), then `kit-diff`.