### PR TITLE
feat(grammar): add discrepancy ledger + /grammar-rule (Phase 4)

### DIFF
--- a/.claude/skills/grammar-rule/SKILL.md
+++ b/.claude/skills/grammar-rule/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: grammar-rule
+description: >
+  Curate a cross-component grammar rule in packages/ui-spec/grammar — usually born
+  from a discrepancy-ledger finding whose resolution is "new-rule". Drives the full
+  addition: a typed KitRule in grammar/rules/<category>.ts, a 1:1 CHECKLIST.md row,
+  a detector (kit-lint static, screen-audit structural, or an honest stub), a test,
+  and the ledger cross-link. A human ratifies severity — only a person may set
+  `must` (it blocks CI). Invoke with /grammar-rule <ledger-id | description>.
+argument-hint: '<ledger-id | short description>'
+---
+
+# Skill: /grammar-rule
+
+The curation half of the self-improving loop (Phase 4 of
+[`context/kit-consistency-audit-proposal.md`](../../../context/kit-consistency-audit-proposal.md)).
+When an audit finding isn't already covered by a rule and isn't an intentional
+deviation, it becomes a **new permanent check** so it can never recur. This skill
+adds that rule end-to-end and keeps every mirror in sync.
+
+It **proposes**; a human **ratifies severity**. Only a person may set a rule to
+`must` (that blocks CI) — default a fresh rule to `should` unless told otherwise.
+
+## Inputs
+
+- A **ledger id** (preferred): an entry in `packages/ui-spec/grammar/ledger/`
+  whose `status` is `open` and whose intended `resolution.kind` is `new-rule`; or
+- a **short description** of the discrepancy (then also add the ledger entry).
+
+## Steps
+
+1. **Locate the finding.** Read the ledger entry (or capture the description).
+   Confirm it's genuinely uncovered: search `grammar/rules/*` — if an existing rule
+   already fits, the resolution is `detector`, not a new rule (stop and say so).
+
+2. **Pick category + id + checklist row.** Category is one of `tokens` `spacing`
+   `typography` `anatomy` `interaction` `accessibility` `composition` `cross-impl`.
+   The rule `id` is `<category>/<kebab>` (the prefix MUST equal the category).
+   The `checklist` row id is the next free in that section (e.g. `C9`) — both must
+   be unique (enforced by `__tests__/grammar.test.ts`).
+
+3. **Draft the `KitRule`.** Append to `grammar/rules/<category>.ts` with all
+   required fields: `id`, `title`, `category`, `severity`, `rule` (imperative,
+   1–2 sentences), `rationale`, `checklist`, `detector` (the id of the check that
+   enforces it — see step 5), and optional `tokens`/`wcag`/`relatedRules`.
+   **Severity:** propose `should`/`may`; flag explicitly if you believe it warrants
+   `must` and ask the human to ratify.
+
+4. **Add the CHECKLIST.md row.** A matching `| <row> | … | <detect> | <sev> |`
+   row under the right section — `grammar.test.ts` enforces the registry ↔
+   CHECKLIST 1:1 mapping.
+
+5. **Add the detector** (or an honest stub). Match the detector id to the kind:
+   - `kit-lint/<name>` — a static detector: append to `DETECTORS` in
+     `scripts/kit-lint.ts` (AST/string over component source). Add a focused test
+     in `__tests__/kit-lint.test.ts` via `lintSource()`.
+   - `screen/<name>` — a structural detector: append to `DETECTORS` in
+     `screens/audit/detectors.ts` (pure over a `ScreenSnapshot`), declare its
+     `scope`, and test it in `__tests__/screen-audit.test.ts`.
+   - `ref/<name>` / `ai/<name>` / `spec/<name>` — if no detector can be implemented
+     yet, the rule still ships with the intended `detector` id (it's documented as
+     not-yet-enforced — no false confidence). Note the deferral.
+     **Never relax `must` to make a flaky static check pass.** If a `must` detector
+     would fire on real, intentional variation, it needs a ratified canonical and an
+     [override](../../../packages/ui-spec/grammar/overrides/README.md) path first —
+     keep it deferred and say so.
+
+6. **Close the loop in the ledger.** Set the entry's `resolution` to
+   `{ kind: 'new-rule', rule: '<new id>', date }` and `status: 'resolved'`; update
+   the `LEDGER.md` row. `__tests__/ledger.test.ts` checks the rule exists.
+
+7. **Verify.** `pnpm --filter @acronis-platform/ui-spec test` (grammar + ledger +
+   detector tests) and `pnpm --filter @acronis-platform/ui-spec kit-lint`. Report
+   the new rule, its severity, the detector, and what now fires.
+
+## Output
+
+A summary: the new rule id + severity (flagging any `must` for human ratification),
+the CHECKLIST row, the detector (implemented or deferred + why), the ledger entry
+it closes, and the test/lint result. Open a PR — ui-spec is private (no changeset).

--- a/packages/ui-spec/AGENTS.md
+++ b/packages/ui-spec/AGENTS.md
@@ -92,6 +92,19 @@ keeps entries well-formed. This unblocks the deferred `must` detectors — a rul
 block CI broadly while genuine exceptions carry a scoped waiver. See
 [`grammar/overrides/README.md`](./grammar/overrides/README.md).
 
+**Ledger** (`grammar/ledger/` + `grammar/LEDGER.md`, Phase 4): the self-improving
+loop. Every real consistency finding is logged with **how it was resolved** —
+because a finding is done only when a permanent check exists so it can never recur.
+A `LedgerEntry` resolves into a **detector** (existing/new guard), a ratified
+**new-rule**, or an **accepted** deviation (an override). `validateLedger()` (run
+by `__tests__/ledger.test.ts`) checks each entry and that its resolution target
+actually exists (a declared detector / a real rule / an existing override), and the
+LEDGER.md table mirrors the registry 1:1. It is seeded with the App Shell review
+findings plus the scroll-area T4 mis-wiring. The
+[`/grammar-rule`](../../.claude/skills/grammar-rule/SKILL.md) skill curates a new
+rule from a finding; only a human may ratify `must`. See
+[`grammar/LEDGER.md`](./grammar/LEDGER.md).
+
 **Phase 1 — `kit-lint`** (`scripts/kit-lint.ts`, `pnpm --filter @acronis-platform/ui-spec kit-lint`):
 static detectors over shipped ui-react component source for the `kit-lint` checklist
 rows. `must`: T1 no-hardcoded-color, T2 unbridged-name. `should`: T3 opacity-hack,

--- a/packages/ui-spec/__tests__/ledger.test.ts
+++ b/packages/ui-spec/__tests__/ledger.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+  getLedgerEntry,
+  ledger,
+  ledgerByStatus,
+  validateLedger,
+} from '../grammar';
+import type { LedgerEntry } from '../grammar';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const LEDGER_MD = readFileSync(resolve(HERE, '../grammar/LEDGER.md'), 'utf8');
+
+const valid: LedgerEntry = {
+  id: 'sample',
+  title: 'A sample discrepancy',
+  checklist: 'C2',
+  rule: 'composition/edge-baseline-alignment',
+  severity: 'should',
+  source: { screen: 'x', ref: 'header' },
+  discovered: '2026-06-28',
+  status: 'resolved',
+  resolution: { kind: 'detector', detector: 'screen/alignment-grid' },
+};
+
+describe('the shipped ledger', () => {
+  it('validates clean', () => {
+    expect(validateLedger()).toEqual([]);
+  });
+
+  it('has entries with unique ids', () => {
+    expect(ledger.length).toBeGreaterThan(0);
+    expect(new Set(ledger.map((e) => e.id)).size).toBe(ledger.length);
+  });
+
+  it('lookups work', () => {
+    expect(getLedgerEntry('scroll-area-hover-active-token')?.status).toBe('open');
+    expect(getLedgerEntry('nope')).toBeUndefined();
+    expect(ledgerByStatus('resolved').every((e) => e.status === 'resolved')).toBe(true);
+  });
+});
+
+describe('LEDGER.md mirrors the registry 1:1', () => {
+  const mdIds = new Set(
+    LEDGER_MD.split('\n')
+      .map((line) => /^\|\s*([a-z][a-z0-9-]+)\s*\|/.exec(line)?.[1])
+      .filter((id): id is string => Boolean(id))
+  );
+  const regIds = new Set(ledger.map((e) => e.id));
+
+  it('every registry entry has a LEDGER.md row', () => {
+    const missing = [...regIds].filter((id) => !mdIds.has(id));
+    expect(missing, `entries without a row: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('every LEDGER.md row has a registry entry', () => {
+    const missing = [...mdIds].filter((id) => !regIds.has(id));
+    expect(missing, `rows without an entry: ${missing.join(', ')}`).toEqual([]);
+  });
+});
+
+describe('validateLedger', () => {
+  it('accepts a well-formed entry', () => {
+    expect(validateLedger([valid])).toEqual([]);
+  });
+
+  it('flags an unknown rule / mismatched checklist row', () => {
+    expect(validateLedger([{ ...valid, rule: 'no/such-rule' }]).join(' ')).toMatch(/unknown rule/);
+    expect(
+      validateLedger([{ ...valid, checklist: 'C8' }]).join(' ')
+    ).toMatch(/disagrees with checklist/);
+  });
+
+  it('requires a resolution once resolved/accepted', () => {
+    const { resolution, ...noRes } = valid;
+    void resolution;
+    expect(validateLedger([noRes]).join(' ')).toMatch(/has no resolution/);
+  });
+
+  it('checks the resolution target exists', () => {
+    expect(
+      validateLedger([
+        { ...valid, resolution: { kind: 'detector', detector: 'screen/not-real' } },
+      ]).join(' ')
+    ).toMatch(/not a declared rule detector/);
+    expect(
+      validateLedger([
+        { ...valid, resolution: { kind: 'new-rule', rule: 'no/such-rule' } },
+      ]).join(' ')
+    ).toMatch(/does not exist/);
+  });
+
+  it('an accepted entry must point at a real override', () => {
+    const errs = validateLedger([
+      { ...valid, status: 'accepted', resolution: { kind: 'override', override: 'ghost' } },
+    ]);
+    expect(errs.join(' ')).toMatch(/override "ghost" does not exist/);
+  });
+
+  it('flags an invalid status / discovered date / empty source', () => {
+    expect(
+      validateLedger([{ ...valid, status: 'wat' as LedgerEntry['status'] }]).join(' ')
+    ).toMatch(/invalid status/);
+    expect(validateLedger([{ ...valid, discovered: 'nope' }]).join(' ')).toMatch(/invalid discovered/);
+    expect(validateLedger([{ ...valid, source: {} }]).join(' ')).toMatch(/no source/);
+  });
+});

--- a/packages/ui-spec/grammar/LEDGER.md
+++ b/packages/ui-spec/grammar/LEDGER.md
@@ -1,0 +1,37 @@
+# Discrepancy ledger
+
+The record that makes the kit **ratchet**. Every real consistency finding is
+logged here with **how it was resolved** — because a finding is not done when the
+pixel is fixed, it's done when a permanent check exists so it can never recur
+(proposal §9).
+
+Each row is **mirrored 1:1 by an entry** in [`ledger/`](./ledger/index.ts) (the
+TS registry is the source of truth; `__tests__/ledger.test.ts` keeps the two in
+sync and validates every entry).
+
+A finding resolves into one of three kinds:
+
+- **detector** — an existing or newly-added detector now guards this class of
+  defect (the ratchet).
+- **new-rule** — a new `KitRule` was ratified for it (a human owns the `must`
+  tier). Use [`/grammar-rule`](../../../.claude/skills/grammar-rule/SKILL.md).
+- **override** — it's an intentional deviation, waived by an approved
+  [override](./overrides/README.md) (`status: accepted`).
+
+Columns: **Entry** (stable id) · **Discrepancy** · **Where** · **Rule (row)** ·
+**Sev** · **Status** · **Resolution**.
+
+| Entry                              | Discrepancy                                                     | Where                          | Rule (row)                               | Sev    | Status   | Resolution                                                               |
+| ---------------------------------- | --------------------------------------------------------------- | ------------------------------ | ---------------------------------------- | ------ | -------- | ------------------------------------------------------------------------ |
+| app-shell-search-offcenter         | Header search left-aligned / off the header center axis         | protection-dashboard · header  | composition/edge-baseline-alignment (C2) | should | resolved | detector `screen/alignment-grid` now catches near-miss edges             |
+| app-shell-collapsed-rail-crops-row | Collapsed rail reserved a scrollbar gutter that cropped the row | protection-dashboard · sidebar | composition/no-clipping (C8)             | should | resolved | fixed by overlay scrollbar (PR #479); `screen/reserved-gutter` guards it |
+| scroll-area-hover-active-token     | `hover:` wired to an `-active` border token instead of `-hover` | scroll-area                    | tokens/state-token-wiring (T4)           | should | open     | surfaced by `kit-lint/state-token-wiring`; awaiting fix or override      |
+
+## Adding an entry
+
+Append a typed entry to [`ledger/index.ts`](./ledger/index.ts) and a matching row
+here. `validateLedger()` (run by `__tests__/ledger.test.ts`) enforces: unique id,
+a resolvable rule/checklist row, valid severity/status/dates, a non-empty source,
+and — once `status` is `resolved`/`accepted` — a resolution whose target exists
+(a declared detector, a real rule, or an existing override). An `accepted` entry
+must point at a real override.

--- a/packages/ui-spec/grammar/README.md
+++ b/packages/ui-spec/grammar/README.md
@@ -16,7 +16,9 @@ grammar/
 ├── types.ts            # KitRule, RuleCategory, RuleSeverity
 ├── rules/              # one file per category + index (registry + lookups)
 ├── overrides/          # approved, scoped, dated rule deviations (see README)
+├── ledger/             # discrepancy ledger registry (the self-improving loop)
 ├── CHECKLIST.md        # human mirror of the registry (1:1 by row id)
+├── LEDGER.md           # human mirror of the ledger (1:1 by entry id)
 └── index.ts            # public surface
 ```
 
@@ -33,6 +35,19 @@ a defect (the third resolution for a finding — fix / new rule / **override**).
 Both `kit-lint` and the screen audit run findings through `applyOverrides`, so an
 approved waiver removes a finding from what gates CI while keeping it auditable.
 The registry ships empty until a human ratifies one.
+
+## Ledger (the self-improving loop)
+
+[`ledger/`](./ledger/index.ts) + [`LEDGER.md`](./LEDGER.md) record every real
+consistency finding and **how it was resolved** — because a finding is done only
+when a permanent check exists so it can never recur (proposal §9). Each entry
+resolves into one of: an existing/new **detector** guards it, a ratified
+**new-rule**, or an **accepted** intentional deviation (an override). The
+[`/grammar-rule`](../../../.claude/skills/grammar-rule/SKILL.md) skill curates a
+new rule from a finding (a human ratifies `must`). Seeded with the App Shell review
+findings + the T4 mis-wiring; `validateLedger()` (run by
+`../__tests__/ledger.test.ts`) checks each entry and that its resolution target
+(detector / rule / override) actually exists.
 
 ## Usage
 

--- a/packages/ui-spec/grammar/index.ts
+++ b/packages/ui-spec/grammar/index.ts
@@ -15,3 +15,16 @@ export {
   isOverridden,
   applyOverrides,
 } from './overrides';
+export type {
+  LedgerEntry,
+  LedgerStatus,
+  LedgerResolution,
+  LedgerSource,
+  ResolutionKind,
+} from './ledger';
+export {
+  ledger,
+  validateLedger,
+  getLedgerEntry,
+  ledgerByStatus,
+} from './ledger';

--- a/packages/ui-spec/grammar/ledger/index.ts
+++ b/packages/ui-spec/grammar/ledger/index.ts
@@ -1,0 +1,150 @@
+// Discrepancy ledger — registry + validation. Human mirror: ../LEDGER.md.
+//
+// Seeded with the real findings that motivated this whole system (the App Shell
+// review cited in the proposal, plus the hover→active token mis-wiring the new
+// kit-lint T4 detector surfaced). Each carries how the loop closed it. See
+// ./types.ts and context/kit-consistency-audit-proposal.md §9.
+import { allRules, getRule } from '../rules';
+import { overrides } from '../overrides';
+import type { LedgerEntry } from './types';
+
+export type {
+  LedgerEntry,
+  LedgerStatus,
+  LedgerResolution,
+  LedgerSource,
+  ResolutionKind,
+} from './types';
+
+const STATUSES = ['open', 'resolved', 'accepted'] as const;
+const KINDS = ['detector', 'new-rule', 'override'] as const;
+const SEVERITIES = ['must', 'should', 'may'] as const;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export const ledger: LedgerEntry[] = [
+  {
+    id: 'app-shell-search-offcenter',
+    title:
+      'App Shell header search is left-aligned / off the header center axis',
+    checklist: 'C2',
+    rule: 'composition/edge-baseline-alignment',
+    severity: 'should',
+    source: { screen: 'protection-dashboard', ref: 'header' },
+    discovered: '2026-06-28',
+    status: 'resolved',
+    resolution: {
+      kind: 'detector',
+      detector: 'screen/alignment-grid',
+      note: 'Found by eyeballing the assembled screen; now caught structurally by the alignment-grid detector (near-miss edges) so it cannot silently recur.',
+      date: '2026-06-28',
+    },
+  },
+  {
+    id: 'app-shell-collapsed-rail-crops-row',
+    title:
+      'Collapsed sidebar rail reserved a scrollbar gutter that cropped the selected row',
+    checklist: 'C8',
+    rule: 'composition/no-clipping',
+    severity: 'should',
+    source: { screen: 'protection-dashboard', ref: 'sidebar' },
+    discovered: '2026-06-28',
+    status: 'resolved',
+    resolution: {
+      kind: 'detector',
+      detector: 'screen/reserved-gutter',
+      note: 'Fixed by the ScrollArea overlay scrollbar (PR #479, zero reserved gutter); the reserved-gutter detector guards against regression.',
+      date: '2026-06-28',
+    },
+  },
+  {
+    id: 'scroll-area-hover-active-token',
+    title:
+      'ScrollArea wires a hover: state to an -active border token instead of a -hover one',
+    checklist: 'T4',
+    rule: 'tokens/state-token-wiring',
+    severity: 'should',
+    source: {
+      component: 'scroll-area',
+      file: 'packages/ui-react/src/components/ui/scroll-area/scroll-area.tsx',
+    },
+    discovered: '2026-06-28',
+    status: 'open',
+    resolution: {
+      kind: 'detector',
+      detector: 'kit-lint/state-token-wiring',
+      note: 'The new T4 detector surfaces it as a should-warning. Awaiting a dedicated -hover border token, a code fix, or an approved override — the loop working as intended.',
+    },
+  },
+];
+
+const declaredDetectors = new Set(allRules.map((r) => r.detector));
+
+/**
+ * Validate ledger entries: unique id, resolvable rule/checklist, valid severity/
+ * status/dates, a non-empty source, and a consistent resolution whose target
+ * exists (a declared detector, a real rule, or an existing override). Returns
+ * human-readable errors (empty = valid).
+ */
+export function validateLedger(list: LedgerEntry[] = ledger): string[] {
+  const errors: string[] = [];
+  const ids = new Set<string>();
+  const checklistRows = new Set(allRules.map((r) => r.checklist));
+
+  for (const e of list) {
+    const label = e.id ? `ledger "${e.id}"` : 'ledger entry (missing id)';
+    if (!e.id) errors.push('a ledger entry is missing an id');
+    else if (ids.has(e.id)) errors.push(`duplicate ledger id "${e.id}"`);
+    if (e.id) ids.add(e.id);
+    if (!e.title?.trim()) errors.push(`${label} is missing a title`);
+    if (!SEVERITIES.includes(e.severity))
+      errors.push(`${label} has an invalid severity "${e.severity}"`);
+    if (!STATUSES.includes(e.status))
+      errors.push(`${label} has an invalid status "${e.status}"`);
+    if (!DATE_RE.test(e.discovered ?? ''))
+      errors.push(`${label} has an invalid discovered date "${e.discovered}"`);
+    if (!e.source || Object.keys(e.source).length === 0)
+      errors.push(`${label} has no source (needs at least one selector)`);
+    if (e.checklist && !checklistRows.has(e.checklist))
+      errors.push(`${label} references unknown checklist row "${e.checklist}"`);
+    if (e.rule) {
+      const rule = getRule(e.rule);
+      if (!rule) errors.push(`${label} references unknown rule "${e.rule}"`);
+      else if (e.checklist && rule.checklist !== e.checklist)
+        errors.push(
+          `${label} rule "${e.rule}" (row ${rule.checklist}) disagrees with checklist "${e.checklist}"`
+        );
+    }
+
+    const r = e.resolution;
+    if (e.status === 'open') {
+      if (r && !KINDS.includes(r.kind))
+        errors.push(`${label} has an invalid resolution kind "${r.kind}"`);
+    } else {
+      if (!r) {
+        errors.push(`${label} is "${e.status}" but has no resolution`);
+        continue;
+      }
+      if (!KINDS.includes(r.kind))
+        errors.push(`${label} has an invalid resolution kind "${r.kind}"`);
+      if (r.date && !DATE_RE.test(r.date))
+        errors.push(`${label} has an invalid resolution date "${r.date}"`);
+      if (e.status === 'accepted' && r.kind !== 'override')
+        errors.push(`${label} is "accepted" but its resolution is not an override`);
+      if (r.kind === 'detector' && !declaredDetectors.has(r.detector ?? ''))
+        errors.push(`${label} resolution detector "${r.detector}" is not a declared rule detector`);
+      if (r.kind === 'new-rule' && !getRule(r.rule ?? ''))
+        errors.push(`${label} resolution rule "${r.rule}" does not exist`);
+      if (r.kind === 'override' && !overrides.some((o) => o.id === r.override))
+        errors.push(`${label} resolution override "${r.override}" does not exist`);
+    }
+  }
+  return errors;
+}
+
+export function getLedgerEntry(id: string): LedgerEntry | undefined {
+  return ledger.find((e) => e.id === id);
+}
+
+export function ledgerByStatus(status: LedgerEntry['status']): LedgerEntry[] {
+  return ledger.filter((e) => e.status === status);
+}

--- a/packages/ui-spec/grammar/ledger/types.ts
+++ b/packages/ui-spec/grammar/ledger/types.ts
@@ -1,0 +1,53 @@
+// Discrepancy ledger — the record that makes the kit ratchet.
+//
+// Every real audit finding is logged here with how it was resolved. The rule
+// (proposal §9): a finding is not "done" when the pixel is fixed — it's done when
+// a permanent check exists so it can never recur. So each entry resolves into one
+// of three kinds: an existing/new **detector** guards it, a **new rule** is
+// ratified for it, or it's an intentional deviation **accepted** via an override.
+// AI may propose entries + rules; a human owns the `must` tier.
+import type { RuleSeverity } from '../types';
+
+export type LedgerStatus = 'open' | 'resolved' | 'accepted';
+
+/** How a finding was put to rest. */
+export type ResolutionKind = 'detector' | 'new-rule' | 'override';
+
+export interface LedgerResolution {
+  kind: ResolutionKind;
+  /** kind=detector — the detector id that now guards this (a declared rule detector). */
+  detector?: string;
+  /** kind=new-rule — the grammar rule id created for it. */
+  rule?: string;
+  /** kind=override / accepted — the override id that waives it. */
+  override?: string;
+  note?: string;
+  /** ISO date resolved (YYYY-MM-DD). */
+  date?: string;
+}
+
+/** Where the discrepancy was found. At least one selector is required. */
+export interface LedgerSource {
+  screen?: string;
+  component?: string;
+  file?: string;
+  ref?: string;
+}
+
+export interface LedgerEntry {
+  /** Unique kebab slug. */
+  id: string;
+  /** One-line description of the discrepancy. */
+  title: string;
+  /** Checklist row id it maps to (e.g. `C2`), if catalogued. */
+  checklist?: string;
+  /** Grammar rule id it maps to, if any. */
+  rule?: string;
+  severity: RuleSeverity;
+  source: LedgerSource;
+  /** ISO date discovered / logged (YYYY-MM-DD). */
+  discovered: string;
+  status: LedgerStatus;
+  /** Required once `status` is `resolved` or `accepted`. */
+  resolution?: LedgerResolution;
+}


### PR DESCRIPTION
## Phase 4 — discrepancy ledger + the self-improving loop

The record that makes the kit **ratchet** (proposal §9): a finding is done not when the pixel is fixed, but when a permanent check exists so it can never recur. Builds on the overrides mechanism (#491).

### What's added
- **`grammar/ledger/`** — `LedgerEntry` registry + `validateLedger()`. Every real consistency finding is logged with **how it was resolved**, into one of three kinds:
  - **detector** — an existing/new detector now guards this class;
  - **new-rule** — a ratified `KitRule` was added for it;
  - **override** — an intentional deviation, waived (`status: accepted`).
  Validation cross-checks the resolution target **actually exists** (a declared rule detector / a real rule / an existing override), plus unique id, resolvable rule + checklist row, valid severity/status/dates, and a non-empty source.
- **`grammar/LEDGER.md`** — human mirror, kept **1:1** with the registry by `ledger.test.ts` (same pattern as `CHECKLIST.md`).
- **`/grammar-rule` skill** — curate a new rule from a finding end-to-end (registry entry + CHECKLIST row + detector or an honest stub + test + ledger cross-link). **Only a human ratifies `must`.**

### Seeded with the real findings that motivated this system
| Entry | Rule (row) | Status | Resolution |
|-------|-----------|--------|------------|
| `app-shell-search-offcenter` | edge-baseline-alignment (C2) | resolved | `screen/alignment-grid` detector |
| `app-shell-collapsed-rail-crops-row` | no-clipping (C8) | resolved | overlay scrollbar (PR #479) + `screen/reserved-gutter` |
| `scroll-area-hover-active-token` | state-token-wiring (T4) | **open** | surfaced by `kit-lint/state-token-wiring`; awaiting fix or override |

That last one is the loop working live: a detector added two PRs ago caught a real mis-wiring, and it's now tracked until fixed or waived.

### Tests
`__tests__/ledger.test.ts` — validation (rule/checklist/detector/override resolution, status/date/source), LEDGER.md↔registry 1:1 sync, lookups. **669 ui-spec tests green** (+11). Docs: `grammar/README.md`, AGENTS.md.

ui-spec is private — no changeset. Next in Phase 4: `kit-diff` + `/kit-consistency` (reference-implementation parity), then the AI visual-review pass + the ui-kit-pipeline screen-audit gate.