### PR TITLE
fix(ui-react): apply font-smoothing reset to all elements

### DIFF
--- a/.changeset/font-smoothing-reset.md
+++ b/.changeset/font-smoothing-reset.md
@@ -1,0 +1,6 @@
+---
+'@acronis-platform/ui-react': patch
+---
+
+Apply font-smoothing reset (`-webkit-font-smoothing: antialiased`,
+`-moz-osx-font-smoothing: grayscale`) to all elements via `@layer base`.

--- a/packages/ui-react/src/styles/index.css
+++ b/packages/ui-react/src/styles/index.css
@@ -32,6 +32,15 @@
 @import '@acronis-platform/tokens-pd/css/SidebarSecondary/acronis.css';
 @import '@acronis-platform/tokens-pd/css/Table/acronis.css';
 
+@layer base {
+  *,
+  *::before,
+  *::after {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+}
+
 /* Theme switches via the `[data-theme]` attribute (set by the consumer /
    next-themes), which drives the tokens' `light-dark()` + `color-scheme` — mirror
    that for the `dark:` variant. */


### PR DESCRIPTION
**Type of change**
Bug fix (a non-breaking change that fixes an issue)

**Description**
Adds a font-smoothing reset (-webkit-font-smoothing: antialiased, -moz-osx-font-smoothing: grayscale) to all elements via @layer base in index.css, as requested by design.

**Related issue**
Fixes https://pmc.acronis.work/browse/PLTFRM-91807

**Checklist**
- I have linked an issue or discussion
- I have performed a self-review of my code
- My code follows the style guidelines of this project
- My changes generate no new warnings