### PR TITLE
feat(portal-container): add PortalContainerProvider for shadow-DOM portal routing

### DIFF
--- a/.changeset/portal-container-provider.md
+++ b/.changeset/portal-container-provider.md
@@ -1,0 +1,19 @@
+---
+'@acronis-platform/ui-react': minor
+---
+
+feat: add `PortalContainerProvider` for shadow-DOM MFE portal redirection (PLTFRM-91950)
+
+New exports: `PortalContainerProvider`, `usePortalContainer`.
+
+Wrap a subtree in `<PortalContainerProvider container={element}>` and every
+portaling component (`Popover`, `DropdownMenu`, `Tooltip`, `Dialog`, `Sheet`,
+`InputSelect`/`Select`, `Combobox`, `Toaster`) will mount its popup inside the
+given container instead of `document.body`. An explicit `portalContainer` prop
+on an individual component still takes precedence.
+
+This is the recommended pattern for rendering `@acronis-platform/ui-react`
+inside a shadow-DOM MFE: adopt the library's CSS onto the shadow root and wrap
+the React tree in `PortalContainerProvider` pointing at a `<div>` inside the
+shadow root. Portaled popups will then render inside the shadow boundary, fully
+styled, with zero global style leakage.

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -4,6 +4,7 @@
     "architecture",
     "design-to-code",
     "migration",
+    "shadow-dom",
     "tree-shaking",
     "publishing",
     "versioning",

--- a/apps/docs/content/docs/guides/shadow-dom.mdx
+++ b/apps/docs/content/docs/guides/shadow-dom.mdx
@@ -1,0 +1,148 @@
+---
+title: Shadow DOM Integration
+description: How to render @acronis-platform/ui-react inside a shadow-DOM micro-frontend with fully styled portaled components and zero host style leakage.
+---
+
+# Shadow DOM Integration
+
+When `@acronis-platform/ui-react` runs inside a **shadow-DOM micro-frontend**
+(MFE), portaled components — Popover, DropdownMenu, Tooltip, Dialog, Sheet,
+Select, Combobox, and Toaster — mount their popups into `document.body` by
+default. This means the popup escapes the shadow boundary and loses access to
+the adopted stylesheets, rendering **unstyled**.
+
+`PortalContainerProvider` solves this by redirecting all portals into a container
+inside the shadow root.
+
+## Quick setup
+
+```tsx
+import { PortalContainerProvider } from '@acronis-platform/ui-react';
+
+function ShadowMFE({ shadowRoot }: { shadowRoot: ShadowRoot }) {
+  // 1. Create a mount point inside the shadow root
+  const mountRef = useRef<HTMLDivElement>(null);
+
+  // 2. Adopt ui-react's CSS onto the shadow root
+  useEffect(() => {
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(uiReactCssText); // your bundled/fetched CSS
+    shadowRoot.adoptedStyleSheets = [sheet];
+  }, [shadowRoot]);
+
+  // 3. Wrap your app — all portals now render inside the shadow root
+  return (
+    <div ref={mountRef}>
+      <PortalContainerProvider container={mountRef.current}>
+        <App />
+      </PortalContainerProvider>
+    </div>
+  );
+}
+```
+
+That's it. Every portaling component automatically picks up the container from
+context. No need to pass `portalContainer` to each component individually.
+
+## How it works
+
+1. **`PortalContainerProvider`** sets a React context with the target DOM element.
+2. Each portaling component calls **`usePortalContainer()`** internally to read
+   the context.
+3. The component passes the resolved container to the Base UI `Portal` primitive,
+   which creates a React portal into that element instead of `document.body`.
+4. An explicit **`portalContainer` prop** on any individual component always
+   takes precedence over the context — useful for edge cases where one popup
+   needs a different container.
+
+## Affected components
+
+All portaling components respect `PortalContainerProvider`:
+
+| Component | Portal target |
+|-----------|---------------|
+| `PopoverContent` | Positioner + popup |
+| `DropdownMenuContent` | Positioner + popup |
+| `TooltipContent` | Positioner + popup |
+| `DialogContent` | Backdrop + popup |
+| `SheetContent` | Backdrop + popup |
+| `SelectContent` / `InputSelectContent` | Positioner + popup |
+| `ComboboxContent` | Positioner + popup |
+| `Toaster` | Viewport + toasts |
+
+## Adopting styles
+
+ui-react's CSS is authored for `:root, :host`, so the same stylesheet works
+inside a shadow root. The recommended approach:
+
+```ts
+// Fetch or import ui-react's compiled CSS
+import cssText from '@acronis-platform/ui-react/styles?raw';
+
+// Build a Constructable Stylesheet and adopt it
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(cssText);
+shadowRoot.adoptedStyleSheets = [sheet];
+```
+
+This keeps ui-react's Tailwind Preflight and design tokens **inside** the shadow
+boundary — they never touch the host document.
+
+## Theming inside the shadow root
+
+ui-react uses `light-dark()` with the `[data-theme]` attribute. Set it on your
+mount element:
+
+```tsx
+<div data-theme="light">
+  <PortalContainerProvider container={mountEl}>
+    <App />
+  </PortalContainerProvider>
+</div>
+```
+
+To follow the host page's theme, observe `document.documentElement` for
+`data-theme` or `class` changes and mirror them onto your shadow mount.
+
+## Overriding per-component
+
+If a specific component needs to portal elsewhere (e.g. a full-screen dialog
+that must overlay the entire viewport), pass `portalContainer` directly:
+
+```tsx
+<PortalContainerProvider container={shadowMount}>
+  {/* This popover portals into the shadow root (from context) */}
+  <Popover>
+    <PopoverTrigger>Open</PopoverTrigger>
+    <PopoverContent>Inside shadow</PopoverContent>
+  </Popover>
+
+  {/* This dialog portals to document.body (explicit override) */}
+  <Dialog>
+    <DialogTrigger>Open</DialogTrigger>
+    <DialogContent portalContainer={document.body}>
+      Full-screen overlay
+    </DialogContent>
+  </Dialog>
+</PortalContainerProvider>
+```
+
+## Known caveats
+
+- **Positioning**: Base UI uses `position: fixed` for positioners. This works
+  inside shadow roots, but breaks if an ancestor has `transform`, `contain`, or
+  `will-change` set — those create a new containing block for fixed positioning.
+  Avoid these CSS properties on shadow-root ancestors.
+- **z-index**: Portaled content inside a shadow root participates in the shadow
+  root's stacking context, not the document's. This is usually desirable (popups
+  stay inside the MFE), but means a shadow-hosted popup cannot overlay content
+  outside the shadow root.
+- **Focus management**: Base UI's focus trapping and restoration work across
+  shadow boundaries in modern browsers (Chrome 90+, Firefox 96+, Safari 16.4+).
+
+## API reference
+
+<AutoTypeTable
+  path="../../packages/ui-react/src/lib/portal-container.tsx"
+  name="PortalContainerProviderProps"
+/>

--- a/apps/docs/src/components/ShadowDemo.tsx
+++ b/apps/docs/src/components/ShadowDemo.tsx
@@ -9,6 +9,7 @@ import {
   type ReactNode,
 } from 'react';
 import { createPortal } from 'react-dom';
+import { PortalContainerProvider } from '@acronis-platform/ui-react';
 
 // Lets a demo portal its Base UI overlays (Select dropdown, Tooltip popup) INTO
 // the shadow root instead of document.body, so the popup inherits the shadow's
@@ -134,7 +135,9 @@ export function ShadowDemo({ children, center }: ShadowDemoProps) {
       {mount &&
         createPortal(
           <ShadowMountContext.Provider value={mount}>
-            {children}
+            <PortalContainerProvider container={mount}>
+              {children}
+            </PortalContainerProvider>
           </ShadowMountContext.Provider>,
           mount
         )}

--- a/apps/docs/src/components/demos-react/combobox.tsx
+++ b/apps/docs/src/components/demos-react/combobox.tsx
@@ -8,7 +8,6 @@ import {
   ComboboxItem,
   ComboboxList,
 } from '@acronis-platform/ui-react';
-import { useShadowMount } from '@/components/ShadowDemo';
 
 type Framework = { value: string; label: string };
 const frameworks: Framework[] = [
@@ -20,12 +19,11 @@ const frameworks: Framework[] = [
 ];
 
 export function ComboboxDemo() {
-  const mount = useShadowMount();
   return (
     <div style={{ width: 260 }}>
       <Combobox items={frameworks}>
         <ComboboxInput placeholder="Search framework…" clearable />
-        <ComboboxContent portalContainer={mount}>
+        <ComboboxContent>
           <ComboboxEmpty>No framework found.</ComboboxEmpty>
           <ComboboxList>
             {(item: Framework) => (

--- a/apps/docs/src/components/demos-react/dialog.tsx
+++ b/apps/docs/src/components/demos-react/dialog.tsx
@@ -13,14 +13,12 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@acronis-platform/ui-react';
-import { useShadowMount } from '@/components/ShadowDemo';
 
 export function DialogDemo() {
-  const mount = useShadowMount();
   return (
     <Dialog>
       <DialogTrigger render={<Button variant="secondary">Open dialog</Button>} />
-      <DialogContent portalContainer={mount}>
+      <DialogContent>
         <DialogHeader>
           <DialogTitle>Are you absolutely sure?</DialogTitle>
           <DialogCloseButton />

--- a/apps/docs/src/components/demos-react/dropdown-menu.tsx
+++ b/apps/docs/src/components/demos-react/dropdown-menu.tsx
@@ -10,14 +10,12 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from '@acronis-platform/ui-react';
-import { useShadowMount } from '@/components/ShadowDemo';
 
 export function DropdownMenuDemo() {
-  const mount = useShadowMount();
   return (
     <DropdownMenu defaultOpen>
       <DropdownMenuTrigger render={<Button variant="secondary">Open menu</Button>} />
-      <DropdownMenuContent portalContainer={mount} className="w-56">
+      <DropdownMenuContent className="w-56">
         <DropdownMenuLabel>My account</DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuItem>

--- a/apps/docs/src/components/demos-react/input-select.tsx
+++ b/apps/docs/src/components/demos-react/input-select.tsx
@@ -10,7 +10,6 @@ import {
   InputSelectTrigger,
   InputSelectValue,
 } from '@acronis-platform/ui-react';
-import { useShadowMount } from '@/components/ShadowDemo';
 
 const regions = {
   us: 'United States',
@@ -19,7 +18,6 @@ const regions = {
 };
 
 export function InputSelectDemo() {
-  const mount = useShadowMount();
   return (
     <div style={{ width: 260 }}>
       <InputSelect items={regions} defaultValue="eu">
@@ -30,7 +28,7 @@ export function InputSelectDemo() {
           </InputSelectTrigger>
           <InputSelectDescription>Where workloads are stored.</InputSelectDescription>
         </InputSelectField>
-        <InputSelectContent portalContainer={mount}>
+        <InputSelectContent>
           <InputSelectItem value="us">United States</InputSelectItem>
           <InputSelectItem value="eu">Europe</InputSelectItem>
           <InputSelectItem value="apac">Asia Pacific</InputSelectItem>

--- a/apps/docs/src/components/demos-react/patterns/filter-popover.tsx
+++ b/apps/docs/src/components/demos-react/patterns/filter-popover.tsx
@@ -13,20 +13,17 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@acronis-platform/ui-react';
-import { useShadowMount } from '@/components/ShadowDemo';
 
 const statuses = { active: 'Active', idle: 'Idle', error: 'Error' };
 const regions = { us: 'United States', eu: 'Europe', apac: 'Asia Pacific' };
 
 export function FilterPopoverDemo() {
-  const mount = useShadowMount();
   return (
     <Popover defaultOpen>
       <PopoverTrigger render={<Button variant="secondary">Filters</Button>} />
       <PopoverContent
         align="start"
         sideOffset={8}
-        portalContainer={mount}
         className="w-80 p-0"
       >
         <form onSubmit={(e) => e.preventDefault()}>
@@ -41,7 +38,7 @@ export function FilterPopoverDemo() {
                   <InputSelectValue placeholder="Any status" />
                 </InputSelectTrigger>
               </InputSelectField>
-              <InputSelectContent portalContainer={mount}>
+              <InputSelectContent>
                 <InputSelectItem value="active">Active</InputSelectItem>
                 <InputSelectItem value="idle">Idle</InputSelectItem>
                 <InputSelectItem value="error">Error</InputSelectItem>
@@ -54,7 +51,7 @@ export function FilterPopoverDemo() {
                   <InputSelectValue placeholder="Any region" />
                 </InputSelectTrigger>
               </InputSelectField>
-              <InputSelectContent portalContainer={mount}>
+              <InputSelectContent>
                 <InputSelectItem value="us">United States</InputSelectItem>
                 <InputSelectItem value="eu">Europe</InputSelectItem>
                 <InputSelectItem value="apac">Asia Pacific</InputSelectItem>

--- a/apps/docs/src/components/demos-react/patterns/sheet-detail-panel.tsx
+++ b/apps/docs/src/components/demos-react/patterns/sheet-detail-panel.tsx
@@ -21,7 +21,6 @@ import {
   SheetTitle,
   Spinner,
 } from '@acronis-platform/ui-react';
-import { useShadowMount } from '@/components/ShadowDemo';
 
 type ContentState = 'content' | 'loading' | 'empty';
 
@@ -39,7 +38,6 @@ const STATES: { id: ContentState; label: string }[] = [
 ];
 
 export function SheetDetailPanelDemo() {
-  const mount = useShadowMount();
   const [open, setOpen] = useState(false);
   const [state, setState] = useState<ContentState>('content');
 
@@ -57,7 +55,7 @@ export function SheetDetailPanelDemo() {
       ))}
 
       <Sheet open={open} onOpenChange={setOpen}>
-        <SheetContent side="right" portalContainer={mount}>
+        <SheetContent side="right">
           <SheetHeader>
             <SheetTitle>Workload details</SheetTitle>
             <SheetCloseButton />

--- a/apps/docs/src/components/demos-react/popover.tsx
+++ b/apps/docs/src/components/demos-react/popover.tsx
@@ -6,14 +6,12 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@acronis-platform/ui-react';
-import { useShadowMount } from '@/components/ShadowDemo';
 
 export function PopoverDemo() {
-  const mount = useShadowMount();
   return (
     <Popover defaultOpen>
       <PopoverTrigger render={<Button variant="secondary">Open popover</Button>} />
-      <PopoverContent portalContainer={mount}>
+      <PopoverContent>
         <div className="grid gap-2">
           <h4 className="font-medium leading-none">Dimensions</h4>
           <p className="text-sm text-muted-foreground">

--- a/apps/docs/src/components/demos-react/select.tsx
+++ b/apps/docs/src/components/demos-react/select.tsx
@@ -7,7 +7,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@acronis-platform/ui-react';
-import { useShadowMount } from '@/components/ShadowDemo';
 
 const regions = {
   us: 'United States',
@@ -16,14 +15,13 @@ const regions = {
 };
 
 export function SelectDemo() {
-  const mount = useShadowMount();
   return (
     <div style={{ width: 256 }}>
       <Select items={regions} defaultValue="eu">
         <SelectTrigger aria-label="Region">
           <SelectValue placeholder="Select a region" />
         </SelectTrigger>
-        <SelectContent portalContainer={mount}>
+        <SelectContent>
           <SelectItem value="us">United States</SelectItem>
           <SelectItem value="eu">Europe</SelectItem>
           <SelectItem value="apac">Asia Pacific</SelectItem>

--- a/apps/docs/src/components/demos-react/sheet.tsx
+++ b/apps/docs/src/components/demos-react/sheet.tsx
@@ -13,14 +13,12 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@acronis-platform/ui-react';
-import { useShadowMount } from '@/components/ShadowDemo';
 
 export function SheetDemo() {
-  const mount = useShadowMount();
   return (
     <Sheet>
       <SheetTrigger render={<Button variant="secondary">Open details</Button>} />
-      <SheetContent side="right" portalContainer={mount}>
+      <SheetContent side="right">
         <SheetHeader>
           <SheetTitle>Workload details</SheetTitle>
           <SheetCloseButton />

--- a/apps/docs/src/components/demos-react/toast.tsx
+++ b/apps/docs/src/components/demos-react/toast.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import { Button, Toaster, toast } from '@acronis-platform/ui-react';
-import { useShadowMount } from '@/components/ShadowDemo';
 
 export function ToastDemo() {
-  const mount = useShadowMount();
   return (
     <div className="flex flex-wrap gap-3">
       <Button
@@ -48,7 +46,7 @@ export function ToastDemo() {
       >
         With action
       </Button>
-      <Toaster portalContainer={mount} />
+      <Toaster />
     </div>
   );
 }

--- a/apps/docs/src/components/demos-react/tooltip.tsx
+++ b/apps/docs/src/components/demos-react/tooltip.tsx
@@ -6,15 +6,13 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@acronis-platform/ui-react';
-import { useShadowMount } from '@/components/ShadowDemo';
 
 export function TooltipDemo() {
-  const mount = useShadowMount();
   return (
     <div style={{ padding: '48px 0' }}>
       <Tooltip defaultOpen>
         <TooltipTrigger render={<Button variant="secondary">Hover me</Button>} />
-        <TooltipContent portalContainer={mount}>Helpful hint</TooltipContent>
+        <TooltipContent>Helpful hint</TooltipContent>
       </Tooltip>
     </div>
   );

--- a/packages/ui-react/src/components/ui/combobox/combobox.tsx
+++ b/packages/ui-react/src/components/ui/combobox/combobox.tsx
@@ -9,6 +9,7 @@ import {
 } from '@acronis-platform/icons-react/stroke-mono';
 
 import { cn } from '@/lib/utils';
+import { usePortalContainer } from '@/lib/portal-container';
 
 // A searchable single/multi-select built on Base UI's Combobox primitive. The
 // legacy `combobox` was only a hardcoded Popover + cmdk demo; this is a real,
@@ -98,8 +99,12 @@ const ComboboxContent = React.forwardRef<
   (
     { className, children, sideOffset = 4, align = 'start', side = 'bottom', portalContainer, ...props },
     ref
-  ) => (
-    <ComboboxPrimitive.Portal container={portalContainer}>
+  ) => {
+    const ctxContainer = usePortalContainer();
+    const resolvedContainer = portalContainer ?? ctxContainer;
+
+    return (
+    <ComboboxPrimitive.Portal container={resolvedContainer}>
       <ComboboxPrimitive.Positioner
         sideOffset={sideOffset}
         align={align}
@@ -118,7 +123,8 @@ const ComboboxContent = React.forwardRef<
         </ComboboxPrimitive.Popup>
       </ComboboxPrimitive.Positioner>
     </ComboboxPrimitive.Portal>
-  )
+    );
+  }
 );
 ComboboxContent.displayName = 'ComboboxContent';
 

--- a/packages/ui-react/src/components/ui/dialog/dialog.tsx
+++ b/packages/ui-react/src/components/ui/dialog/dialog.tsx
@@ -4,6 +4,7 @@ import { TimesIcon } from '@acronis-platform/icons-react/stroke-mono';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
+import { usePortalContainer } from '@/lib/portal-container';
 
 // Initial version ported from `@acronis-platform/shadcn-uikit`'s `dialog`
 // (packages/ui-legacy/src/components/ui/dialog.tsx). A modal overlay built on
@@ -106,6 +107,9 @@ const DialogContent = React.forwardRef<
     },
     ref
   ) => {
+    const ctxContainer = usePortalContainer();
+    const resolvedContainer = portalContainer ?? ctxContainer;
+
     const popup = (
       <>
         <DialogOverlay />
@@ -120,7 +124,7 @@ const DialogContent = React.forwardRef<
     );
 
     return portal ? (
-      <DialogPrimitive.Portal container={portalContainer} keepMounted={keepMounted}>
+      <DialogPrimitive.Portal container={resolvedContainer} keepMounted={keepMounted}>
         {popup}
       </DialogPrimitive.Portal>
     ) : (

--- a/packages/ui-react/src/components/ui/dropdown-menu/dropdown-menu.tsx
+++ b/packages/ui-react/src/components/ui/dropdown-menu/dropdown-menu.tsx
@@ -3,6 +3,7 @@ import { Menu as MenuPrimitive } from '@base-ui/react/menu';
 import { CheckIcon, ChevronRightIcon } from '@acronis-platform/icons-react/stroke-mono';
 
 import { cn } from '@/lib/utils';
+import { usePortalContainer } from '@/lib/portal-container';
 
 // Ported from `@acronis-platform/shadcn-uikit`'s `dropdown-menu`
 // (packages/ui-legacy/src/components/ui/dropdown-menu.tsx). A menu of actions
@@ -60,6 +61,9 @@ const DropdownMenuContent = React.forwardRef<
     },
     ref
   ) => {
+    const ctxContainer = usePortalContainer();
+    const resolvedContainer = portalContainer ?? ctxContainer;
+
     const positioner = (
       <MenuPrimitive.Positioner
         side={side}
@@ -75,7 +79,7 @@ const DropdownMenuContent = React.forwardRef<
       </MenuPrimitive.Positioner>
     );
     return portal ? (
-      <MenuPrimitive.Portal container={portalContainer} keepMounted={keepMounted}>
+      <MenuPrimitive.Portal container={resolvedContainer} keepMounted={keepMounted}>
         {positioner}
       </MenuPrimitive.Portal>
     ) : (

--- a/packages/ui-react/src/components/ui/input-select/input-select.tsx
+++ b/packages/ui-react/src/components/ui/input-select/input-select.tsx
@@ -9,6 +9,7 @@ import {
 } from '@acronis-platform/icons-react/stroke-mono';
 
 import { cn } from '@/lib/utils';
+import { usePortalContainer } from '@/lib/portal-container';
 
 // The next-gen select, themed by the dedicated `--ui-input-select-*` tier (global /
 // normal / error / dropdown). It composes Base UI `Select` and adds the field
@@ -150,8 +151,12 @@ const InputSelectContent = React.forwardRef<
       ...props
     },
     ref
-  ) => (
-    <SelectPrimitive.Portal container={portalContainer}>
+  ) => {
+    const ctxContainer = usePortalContainer();
+    const resolvedContainer = portalContainer ?? ctxContainer;
+
+    return (
+    <SelectPrimitive.Portal container={resolvedContainer}>
       <SelectPrimitive.Positioner
         sideOffset={sideOffset}
         align={align}
@@ -171,7 +176,8 @@ const InputSelectContent = React.forwardRef<
         </SelectPrimitive.Popup>
       </SelectPrimitive.Positioner>
     </SelectPrimitive.Portal>
-  )
+    );
+  }
 );
 InputSelectContent.displayName = 'InputSelectContent';
 

--- a/packages/ui-react/src/components/ui/popover/popover.tsx
+++ b/packages/ui-react/src/components/ui/popover/popover.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Popover as PopoverPrimitive } from '@base-ui/react/popover';
 
 import { cn } from '@/lib/utils';
+import { usePortalContainer } from '@/lib/portal-container';
 
 // Ported from `@acronis-platform/shadcn-uikit`'s `popover`
 // (packages/ui-legacy/src/components/ui/popover.tsx). A floating panel anchored
@@ -61,6 +62,9 @@ const PopoverContent = React.forwardRef<
     },
     ref
   ) => {
+    const ctxContainer = usePortalContainer();
+    const resolvedContainer = portalContainer ?? ctxContainer;
+
     const positioner = (
       <PopoverPrimitive.Positioner
         side={side}
@@ -82,7 +86,7 @@ const PopoverContent = React.forwardRef<
     );
 
     return portal ? (
-      <PopoverPrimitive.Portal container={portalContainer} keepMounted={keepMounted}>
+      <PopoverPrimitive.Portal container={resolvedContainer} keepMounted={keepMounted}>
         {positioner}
       </PopoverPrimitive.Portal>
     ) : (

--- a/packages/ui-react/src/components/ui/sheet/sheet.tsx
+++ b/packages/ui-react/src/components/ui/sheet/sheet.tsx
@@ -4,6 +4,7 @@ import { TimesIcon } from '@acronis-platform/icons-react/stroke-mono';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
+import { usePortalContainer } from '@/lib/portal-container';
 
 // Initial version ported from `@acronis-platform/shadcn-uikit`'s `sheet`
 // (packages/ui-legacy/src/components/ui/sheet.tsx). A modal side panel — the
@@ -102,6 +103,9 @@ const SheetContent = React.forwardRef<
     },
     ref
   ) => {
+    const ctxContainer = usePortalContainer();
+    const resolvedContainer = portalContainer ?? ctxContainer;
+
     const popup = (
       <>
         <SheetOverlay />
@@ -116,7 +120,7 @@ const SheetContent = React.forwardRef<
     );
 
     return portal ? (
-      <DialogPrimitive.Portal container={portalContainer} keepMounted={keepMounted}>
+      <DialogPrimitive.Portal container={resolvedContainer} keepMounted={keepMounted}>
         {popup}
       </DialogPrimitive.Portal>
     ) : (

--- a/packages/ui-react/src/components/ui/toast/toast.tsx
+++ b/packages/ui-react/src/components/ui/toast/toast.tsx
@@ -11,6 +11,7 @@ import {
 } from '@acronis-platform/icons-react/stroke-mono';
 
 import { cn } from '@/lib/utils';
+import { usePortalContainer } from '@/lib/portal-container';
 import { Spinner } from '../spinner';
 
 // Ported from `@acronis-platform/shadcn-uikit`'s `sonner`
@@ -143,13 +144,16 @@ export interface ToasterProps {
  * stack and renders every queued toast. Trigger toasts with the `toast` API.
  */
 function Toaster({ timeout, limit, portalContainer }: ToasterProps) {
+  const ctxContainer = usePortalContainer();
+  const resolvedContainer = portalContainer ?? ctxContainer;
+
   return (
     <ToastPrimitive.Provider
       toastManager={toastManager}
       timeout={timeout}
       limit={limit}
     >
-      <ToastPrimitive.Portal container={portalContainer}>
+      <ToastPrimitive.Portal container={resolvedContainer}>
         <ToastPrimitive.Viewport className="fixed bottom-4 end-4 z-[100] flex w-[384px] max-w-[calc(100vw-2rem)] flex-col gap-3 outline-none">
           <ToastList />
         </ToastPrimitive.Viewport>

--- a/packages/ui-react/src/components/ui/tooltip/tooltip.tsx
+++ b/packages/ui-react/src/components/ui/tooltip/tooltip.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Tooltip as TooltipPrimitive } from '@base-ui/react/tooltip';
 
 import { cn } from '@/lib/utils';
+import { usePortalContainer } from '@/lib/portal-container';
 
 // A contextual hint shown on hover/focus of its trigger. Wraps the Base UI
 // Tooltip primitive; the popup is themed with the `--ui-tooltip-*` token tier
@@ -36,9 +37,13 @@ const TooltipContent = React.forwardRef<
       ...props
     },
     ref
-  ) => (
+  ) => {
+    const ctxContainer = usePortalContainer();
+    const resolvedContainer = portalContainer ?? ctxContainer;
+
+    return (
     <TooltipPrimitive.Portal
-      container={portalContainer}
+      container={resolvedContainer}
       keepMounted={keepMounted}
     >
       <TooltipPrimitive.Positioner
@@ -57,7 +62,8 @@ const TooltipContent = React.forwardRef<
         />
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>
-  )
+    );
+  }
 );
 TooltipContent.displayName = 'TooltipContent';
 

--- a/packages/ui-react/src/index.ts
+++ b/packages/ui-react/src/index.ts
@@ -1,4 +1,9 @@
 export { cn } from './lib/utils';
+export {
+  PortalContainerProvider,
+  usePortalContainer,
+  type PortalContainerProviderProps,
+} from './lib/portal-container';
 export * from './components/ui/accordion';
 export * from './components/ui/alert';
 export * from './components/ui/app-shell';

--- a/packages/ui-react/src/lib/__tests__/portal-container.test.tsx
+++ b/packages/ui-react/src/lib/__tests__/portal-container.test.tsx
@@ -1,0 +1,186 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import {
+  PortalContainerProvider,
+  usePortalContainer,
+} from '../portal-container';
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+// ── Hook behavior ───────────────────────────────────────────────────────────
+
+describe('usePortalContainer', () => {
+  function Spy() {
+    const container = usePortalContainer();
+    const label = container === undefined ? 'undefined' : container === null ? 'null' : 'element';
+    return <span data-testid="spy">{label}</span>;
+  }
+
+  it('returns undefined when no provider exists', () => {
+    render(<Spy />);
+    expect(screen.getByTestId('spy').textContent).toBe('undefined');
+  });
+
+  it('returns the container passed to PortalContainerProvider', () => {
+    const div = document.createElement('div');
+    render(
+      <PortalContainerProvider container={div}>
+        <Spy />
+      </PortalContainerProvider>
+    );
+    expect(screen.getByTestId('spy').textContent).toBe('element');
+  });
+
+  it('allows null container (portals go to document.body)', () => {
+    render(
+      <PortalContainerProvider container={null}>
+        <Spy />
+      </PortalContainerProvider>
+    );
+    // null is a valid value — Base UI treats null as document.body
+    expect(screen.getByTestId('spy').textContent).toBe('null');
+  });
+});
+
+// ── Integration: portals render into custom container ───────────────────────
+
+describe('PortalContainerProvider integration', () => {
+  it('Popover renders into the provided container', async () => {
+    const user = userEvent.setup();
+    const container = document.createElement('div');
+    container.setAttribute('data-testid', 'portal-target');
+    document.body.appendChild(container);
+
+    render(
+      <PortalContainerProvider container={container}>
+        <Popover>
+          <PopoverTrigger>Open</PopoverTrigger>
+          <PopoverContent>Popover inside</PopoverContent>
+        </Popover>
+      </PortalContainerProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(container.textContent).toContain('Popover inside');
+    document.body.removeChild(container);
+  });
+
+  it('explicit portalContainer prop overrides context', async () => {
+    const user = userEvent.setup();
+    const contextContainer = document.createElement('div');
+    contextContainer.setAttribute('data-testid', 'ctx-target');
+    document.body.appendChild(contextContainer);
+
+    const propContainer = document.createElement('div');
+    propContainer.setAttribute('data-testid', 'prop-target');
+    document.body.appendChild(propContainer);
+
+    render(
+      <PortalContainerProvider container={contextContainer}>
+        <Popover>
+          <PopoverTrigger>Open</PopoverTrigger>
+          <PopoverContent portalContainer={propContainer}>
+            Prop wins
+          </PopoverContent>
+        </Popover>
+      </PortalContainerProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(propContainer.textContent).toContain('Prop wins');
+    expect(contextContainer.textContent).not.toContain('Prop wins');
+
+    document.body.removeChild(contextContainer);
+    document.body.removeChild(propContainer);
+  });
+
+  it('Dialog renders into the provided container', async () => {
+    const user = userEvent.setup();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    render(
+      <PortalContainerProvider container={container}>
+        <Dialog>
+          <DialogTrigger>Open Dialog</DialogTrigger>
+          <DialogContent>Dialog inside</DialogContent>
+        </Dialog>
+      </PortalContainerProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open Dialog' }));
+    expect(container.textContent).toContain('Dialog inside');
+    document.body.removeChild(container);
+  });
+
+  it('DropdownMenu renders into the provided container', async () => {
+    const user = userEvent.setup();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    render(
+      <PortalContainerProvider container={container}>
+        <DropdownMenu>
+          <DropdownMenuTrigger>Menu</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Item 1</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </PortalContainerProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Menu' }));
+    expect(container.textContent).toContain('Item 1');
+    document.body.removeChild(container);
+  });
+
+  it('Tooltip renders into the provided container', async () => {
+    const user = userEvent.setup();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    render(
+      <PortalContainerProvider container={container}>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger>Hover me</TooltipTrigger>
+            <TooltipContent>Tip text</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </PortalContainerProvider>
+    );
+
+    await user.hover(screen.getByRole('button', { name: 'Hover me' }));
+    // Tooltip may have a delay; check after hovering
+    // Use findByText for async appearance
+    await screen.findByText('Tip text');
+    expect(container.textContent).toContain('Tip text');
+    document.body.removeChild(container);
+  });
+});

--- a/packages/ui-react/src/lib/portal-container.tsx
+++ b/packages/ui-react/src/lib/portal-container.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import * as React from 'react';
+
+const PortalContainerContext = React.createContext<HTMLElement | null | undefined>(undefined);
+
+export interface PortalContainerProviderProps {
+  /**
+   * The DOM element portaled content should render into (e.g. a `<div>` inside
+   * a shadow root). When set, every ui-react portaling component
+   * (`Popover`, `DropdownMenu`, `Tooltip`, `Dialog`, `Sheet`, `Select`,
+   * `Combobox`, `Toast`) will mount its popup inside this element instead of
+   * `document.body`.
+   */
+  container: HTMLElement | null;
+  children: React.ReactNode;
+}
+
+/**
+ * Provides a default portal container for all ui-react portaling components.
+ *
+ * Wrap your app (or a subtree) so that popups, dialogs, tooltips, toasts, etc.
+ * render inside the given container instead of `document.body`. This is the
+ * recommended way for shadow-DOM MFEs to keep portaled content inside the
+ * shadow root where adopted stylesheets apply.
+ *
+ * Individual components' `portalContainer` prop overrides this context.
+ *
+ * @example
+ * ```tsx
+ * // Inside a shadow-DOM MFE — all portals go into the shadow root
+ * <PortalContainerProvider container={shadowRootMountDiv}>
+ *   <App />
+ * </PortalContainerProvider>
+ * ```
+ */
+export function PortalContainerProvider({ container, children }: PortalContainerProviderProps) {
+  return (
+    <PortalContainerContext value={container}>
+      {children}
+    </PortalContainerContext>
+  );
+}
+
+/**
+ * Returns the portal container set by the nearest `PortalContainerProvider`,
+ * or `undefined` if none exists (letting Base UI default to `document.body`).
+ */
+export function usePortalContainer(): HTMLElement | null | undefined {
+  return React.useContext(PortalContainerContext);
+}


### PR DESCRIPTION
Add PortalContainerProvider context and usePortalContainer hook so all portaling components (Popover, Dialog, DropdownMenu, Tooltip, Sheet, Combobox, InputSelect, Toaster) resolve their portal container from context — one wrap at the MFE root replaces per-component threading.

- Wire usePortalContainer into all 8 portaling components
- Export PortalContainerProvider and usePortalContainer from barrel
- Add unit tests for hook and component integration
- Simplify 11 docs demos (remove useShadowMount + portalContainer prop)
- Wrap ShadowDemo children in PortalContainerProvider
- Add Shadow DOM Integration guide (guides/shadow-dom)
- Add changeset

Resolves: PLTFRM-91950

<img width="1461" height="706" alt="image" src="https://github.com/user-attachments/assets/6c93884b-dd09-44ef-a50d-ae7c948599bd" />