### PR TITLE
chore(tokens): reformat tier files through DtcgSerializer

### DIFF
--- a/.changeset/reformat-token-tiers.md
+++ b/.changeset/reformat-token-tiers.md
@@ -1,0 +1,8 @@
+---
+'@acronis-platform/design-tokens': patch
+---
+
+Reformat `tiers/semantics.json` and `tiers/components.json` to match the
+canonical output of the sync pipeline (alphabetised keys, single-line
+`com.figma.scopes` arrays). No token values, types, or references were changed.
+Future sync diffs will show only real value changes.

--- a/packages/design-tokens/tiers/components.json
+++ b/packages/design-tokens/tiers/components.json
@@ -1,29 +1,29 @@
 {
   "$extensions": {
     "com.acronis.tailwindRoles": {
-      "container": "backgroundColor",
       "borderColor": "borderColor",
-      "icon": "fill",
-      "label": "textColor",
-      "logo": "fill",
-      "externalIcon": "fill",
-      "shortcut": "textColor",
-      "iconSeparator": "fill",
-      "headerLabel": "textColor",
-      "labelSection": "textColor",
-      "breadcrumbLabel": "textColor",
-      "labelCurrentPage": "textColor",
       "box": "backgroundColor",
-      "tick": "backgroundColor",
-      "description": "textColor",
-      "required": "textColor",
-      "placeholder": "textColor",
-      "value": "textColor",
-      "error": "textColor",
+      "breadcrumbLabel": "textColor",
       "clearIcon": "fill",
       "color": "textColor",
+      "container": "backgroundColor",
+      "description": "textColor",
+      "error": "textColor",
+      "externalIcon": "fill",
+      "headerLabel": "textColor",
+      "icon": "fill",
       "iconArrow": "fill",
-      "iconSearch": "fill"
+      "iconSearch": "fill",
+      "iconSeparator": "fill",
+      "label": "textColor",
+      "labelCurrentPage": "textColor",
+      "labelSection": "textColor",
+      "logo": "fill",
+      "placeholder": "textColor",
+      "required": "textColor",
+      "shortcut": "textColor",
+      "tick": "backgroundColor",
+      "value": "textColor"
     }
   },
   "$schema": "../schemas/tier.schema.json",
@@ -9122,15 +9122,7 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS",
-              "WIDTH_HEIGHT",
-              "GAP",
-              "STROKE_FLOAT",
-              "EFFECT_FLOAT",
-              "OPACITY",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS", "WIDTH_HEIGHT", "GAP", "STROKE_FLOAT", "EFFECT_FLOAT", "OPACITY", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:67775"
           },
           "$type": "dimension",
@@ -10853,15 +10845,7 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS",
-              "WIDTH_HEIGHT",
-              "GAP",
-              "STROKE_FLOAT",
-              "EFFECT_FLOAT",
-              "OPACITY",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS", "WIDTH_HEIGHT", "GAP", "STROKE_FLOAT", "EFFECT_FLOAT", "OPACITY", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2313:42563"
           },
           "$type": "dimension",
@@ -10946,15 +10930,7 @@
           "size": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "CORNER_RADIUS",
-                "WIDTH_HEIGHT",
-                "GAP",
-                "STROKE_FLOAT",
-                "EFFECT_FLOAT",
-                "OPACITY",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["CORNER_RADIUS", "WIDTH_HEIGHT", "GAP", "STROKE_FLOAT", "EFFECT_FLOAT", "OPACITY", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2265:264"
             },
             "$type": "dimension",

--- a/packages/design-tokens/tiers/semantics.json
+++ b/packages/design-tokens/tiers/semantics.json
@@ -2,11 +2,11 @@
   "$extensions": {
     "com.acronis.tailwindRoles": {
       "background": "backgroundColor",
-      "text": "textColor",
       "border": "borderColor",
-      "glyph": "fill",
       "focus": "ringColor",
-      "gradients": "backgroundImage"
+      "glyph": "fill",
+      "gradients": "backgroundImage",
+      "text": "textColor"
     }
   },
   "$schema": "../schemas/tier.schema.json",


### PR DESCRIPTION
## Summary

- Reformats `packages/design-tokens/tiers/semantics.json` and `tiers/components.json`
  to match the agreed format.
- Changes are **formatting-only**: key ordering is alphabetised, multi-line
  `com.figma.scopes` arrays are collapsed to single-line, and trailing commas
  are normalised — no token values, types, or references were modified.

## Why

The tier files had been written in a slightly different style than the sync pipeline now emits.

This caused every future `sync-tokens` run to produce noisy diffs that mixed real
value changes with cosmetic reordering, making reviews harder than necessary.

After this PR, any future updates would be easier to compare.

## Test plan

- [x] `pnpm --filter @acronis-platform/design-tokens validate` passes (schema
      validation confirms no token values were altered).
- [ ] `git diff` against a fresh `sync-tokens` run produces an empty diff for
      these two files (formatting is now stable).
- [ ] No downstream consumers (`tokens-pd`, `ui-react`) report build or
      type errors: `pnpm -r build` and `pnpm -r typecheck` green.