### PR TITLE
feat(design-tokens): add AI status semantic tokens

### DIFF
--- a/.changeset/sync-ai-status-tokens.md
+++ b/.changeset/sync-ai-status-tokens.md
@@ -1,5 +1,6 @@
 ---
 '@acronis-platform/design-tokens': minor
+'@acronis-platform/tokens-pd': minor
 ---
 
 Sync design tokens with Figma.

--- a/.changeset/sync-ai-status-tokens.md
+++ b/.changeset/sync-ai-status-tokens.md
@@ -1,0 +1,7 @@
+---
+'@acronis-platform/design-tokens': minor
+---
+
+Sync design tokens with Figma.
+
+Adds AI-status semantic tokens: background.status.ai variants, border.onStatus.ai/aiStrong, glyph.onStatus.ai, text.onStatus.ai. Updates gradients.ai.\* values used by Button, Tag, and SearchGlobal.

--- a/packages/design-tokens/tiers/components.json
+++ b/packages/design-tokens/tiers/components.json
@@ -40,8 +40,8 @@
             "$type": "string",
             "platforms": ["PD"],
             "values": {
-              "default": "solid",
-              "deep_sky_itkontoret": "solid"
+              "deep_sky_itkontoret": "solid",
+              "default": "solid"
             }
           },
           "borderWidth": {
@@ -53,8 +53,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.stroke.2}",
-              "deep_sky_itkontoret": "{units.stroke.2}"
+              "deep_sky_itkontoret": "{units.stroke.2}",
+              "default": "{units.stroke.2}"
             }
           },
           "color": {
@@ -66,8 +66,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{palette.base}",
-              "deep_sky_itkontoret": "{palette.base}"
+              "deep_sky_itkontoret": "{palette.base}",
+              "default": "{palette.base}"
             }
           }
         },
@@ -80,8 +80,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.radius.999}",
-            "deep_sky_itkontoret": "{units.radius.999}"
+            "deep_sky_itkontoret": "{units.radius.999}",
+            "default": "{units.radius.999}"
           }
         },
         "group": {
@@ -94,8 +94,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.gap.neg-6}",
-              "deep_sky_itkontoret": "{units.gap.neg-6}"
+              "deep_sky_itkontoret": "{units.gap.neg-6}",
+              "default": "{units.gap.neg-6}"
             }
           }
         },
@@ -108,8 +108,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.32}",
-            "deep_sky_itkontoret": "{units.size.32}"
+            "deep_sky_itkontoret": "{units.size.32}",
+            "default": "{units.size.32}"
           }
         }
       },
@@ -123,8 +123,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         }
       },
@@ -138,8 +138,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.caption.strong}",
-            "deep_sky_itkontoret": "{typography.caption.strong}"
+            "deep_sky_itkontoret": "{typography.caption.strong}",
+            "default": "{typography.caption.strong}"
           }
         }
       },
@@ -153,8 +153,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -166,8 +166,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.default}",
-            "deep_sky_itkontoret": "{typography.body.default}"
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}"
           }
         }
       }
@@ -182,8 +182,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{palette.orange.3}",
-          "deep_sky_itkontoret": "{palette.orange.3}"
+          "deep_sky_itkontoret": "{palette.orange.3}",
+          "default": "{palette.orange.3}"
         }
       },
       "red": {
@@ -195,8 +195,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{palette.red.3}",
-          "deep_sky_itkontoret": "{palette.red.3}"
+          "deep_sky_itkontoret": "{palette.red.3}",
+          "default": "{palette.red.3}"
         }
       },
       "teal": {
@@ -208,8 +208,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{palette.teal.3}",
-          "deep_sky_itkontoret": "{palette.teal.3}"
+          "deep_sky_itkontoret": "{palette.teal.3}",
+          "default": "{palette.teal.3}"
         }
       },
       "violet": {
@@ -221,8 +221,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{palette.violet.3}",
-          "deep_sky_itkontoret": "{palette.violet.3}"
+          "deep_sky_itkontoret": "{palette.violet.3}",
+          "default": "{palette.violet.3}"
         }
       },
       "yellow": {
@@ -234,8 +234,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{palette.yellow.3}",
-          "deep_sky_itkontoret": "{palette.yellow.3}"
+          "deep_sky_itkontoret": "{palette.yellow.3}",
+          "default": "{palette.yellow.3}"
         }
       }
     },
@@ -250,8 +250,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.orange.11}",
-            "deep_sky_itkontoret": "{palette.orange.11}"
+            "deep_sky_itkontoret": "{palette.orange.11}",
+            "default": "{palette.orange.11}"
           }
         },
         "red": {
@@ -263,8 +263,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.red.11}",
-            "deep_sky_itkontoret": "{palette.red.11}"
+            "deep_sky_itkontoret": "{palette.red.11}",
+            "default": "{palette.red.11}"
           }
         },
         "teal": {
@@ -276,8 +276,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.teal.11}",
-            "deep_sky_itkontoret": "{palette.teal.11}"
+            "deep_sky_itkontoret": "{palette.teal.11}",
+            "default": "{palette.teal.11}"
           }
         },
         "violet": {
@@ -289,8 +289,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.violet.11}",
-            "deep_sky_itkontoret": "{palette.violet.11}"
+            "deep_sky_itkontoret": "{palette.violet.11}",
+            "default": "{palette.violet.11}"
           }
         },
         "yellow": {
@@ -302,8 +302,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.yellow.11}",
-            "deep_sky_itkontoret": "{palette.yellow.11}"
+            "deep_sky_itkontoret": "{palette.yellow.11}",
+            "default": "{palette.yellow.11}"
           }
         }
       }
@@ -322,8 +322,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           },
           "hover": {
@@ -335,8 +335,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           },
           "idle": {
@@ -348,8 +348,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.secondary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}"
             }
           }
         },
@@ -362,8 +362,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.link.default}",
-            "deep_sky_itkontoret": "{typography.link.default}"
+            "deep_sky_itkontoret": "{typography.link.default}",
+            "default": "{typography.link.default}"
           }
         }
       }
@@ -379,8 +379,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -392,8 +392,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.default}",
-            "deep_sky_itkontoret": "{typography.body.default}"
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}"
           }
         }
       }
@@ -409,8 +409,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onSurface.neutral}",
-            "deep_sky_itkontoret": "{colors.glyph.onSurface.neutral}"
+            "deep_sky_itkontoret": "{colors.glyph.onSurface.neutral}",
+            "default": "{colors.glyph.onSurface.neutral}"
           }
         },
         "size": {
@@ -422,8 +422,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.16}",
-            "deep_sky_itkontoret": "{units.size.16}"
+            "deep_sky_itkontoret": "{units.size.16}",
+            "default": "{units.size.16}"
           }
         }
       }
@@ -438,8 +438,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.4}",
-          "deep_sky_itkontoret": "{units.gap.4}"
+          "deep_sky_itkontoret": "{units.gap.4}",
+          "default": "{units.gap.4}"
         }
       }
     }
@@ -456,8 +456,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.radius.4}",
-            "deep_sky_itkontoret": "{units.radius.4}"
+            "deep_sky_itkontoret": "{units.radius.4}",
+            "default": "{units.radius.4}"
           }
         },
         "gap": {
@@ -469,8 +469,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         },
         "height": {
@@ -482,8 +482,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.32}",
-            "deep_sky_itkontoret": "{units.size.32}"
+            "deep_sky_itkontoret": "{units.size.32}",
+            "default": "{units.size.32}"
           }
         },
         "paddingY": {
@@ -495,8 +495,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         }
       },
@@ -510,8 +510,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.16}",
-            "deep_sky_itkontoret": "{units.size.16}"
+            "deep_sky_itkontoret": "{units.size.16}",
+            "default": "{units.size.16}"
           }
         }
       },
@@ -525,8 +525,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.strong}",
-            "deep_sky_itkontoret": "{typography.body.strong}"
+            "deep_sky_itkontoret": "{typography.body.strong}",
+            "default": "{typography.body.strong}"
           }
         }
       }
@@ -543,8 +543,8 @@
             "$type": "string",
             "platforms": ["PD"],
             "values": {
-              "default": "{gradients.ai.active}",
-              "deep_sky_itkontoret": "{gradients.ai.active}"
+              "deep_sky_itkontoret": "{gradients.ai.active}",
+              "default": "{gradients.ai.active}"
             }
           },
           "disabled": {
@@ -556,8 +556,8 @@
             "$type": "string",
             "platforms": ["PD"],
             "values": {
-              "default": "{gradients.ai.disabled}",
-              "deep_sky_itkontoret": "{gradients.ai.disabled}"
+              "deep_sky_itkontoret": "{gradients.ai.disabled}",
+              "default": "{gradients.ai.disabled}"
             }
           },
           "hover": {
@@ -569,8 +569,8 @@
             "$type": "string",
             "platforms": ["PD"],
             "values": {
-              "default": "{gradients.ai.hover}",
-              "deep_sky_itkontoret": "{gradients.ai.hover}"
+              "deep_sky_itkontoret": "{gradients.ai.hover}",
+              "default": "{gradients.ai.hover}"
             }
           },
           "idle": {
@@ -582,8 +582,8 @@
             "$type": "string",
             "platforms": ["PD"],
             "values": {
-              "default": "{gradients.ai.idle}",
-              "deep_sky_itkontoret": "{gradients.ai.idle}"
+              "deep_sky_itkontoret": "{gradients.ai.idle}",
+              "default": "{gradients.ai.idle}"
             }
           }
         },
@@ -596,8 +596,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.12}",
-            "deep_sky_itkontoret": "{units.gap.12}"
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}"
           }
         },
         "widthMin": {
@@ -609,8 +609,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.64}",
-            "deep_sky_itkontoret": "{units.size.64}"
+            "deep_sky_itkontoret": "{units.size.64}",
+            "default": "{units.size.64}"
           }
         }
       },
@@ -625,8 +625,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           },
           "disabled": {
@@ -638,8 +638,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           },
           "hover": {
@@ -651,8 +651,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           },
           "idle": {
@@ -664,8 +664,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           }
         }
@@ -681,8 +681,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.text.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
+              "default": "{colors.text.onBrand.primary}"
             }
           },
           "disabled": {
@@ -694,8 +694,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onBrand.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onBrand.disabled}"
+              "deep_sky_itkontoret": "{colors.text.onBrand.disabled}",
+              "default": "{colors.text.onBrand.disabled}"
             }
           },
           "hover": {
@@ -707,8 +707,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.text.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
+              "default": "{colors.text.onBrand.primary}"
             }
           },
           "idle": {
@@ -720,8 +720,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.text.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
+              "default": "{colors.text.onBrand.primary}"
             }
           }
         }
@@ -739,8 +739,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.statusStrong.danger-pressed}",
-              "deep_sky_itkontoret": "{colors.background.statusStrong.danger-pressed}"
+              "deep_sky_itkontoret": "{colors.background.statusStrong.danger-pressed}",
+              "default": "{colors.background.statusStrong.danger-pressed}"
             }
           },
           "disabled": {
@@ -752,8 +752,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.status.danger}",
-              "deep_sky_itkontoret": "{colors.background.status.danger}"
+              "deep_sky_itkontoret": "{colors.background.status.danger}",
+              "default": "{colors.background.status.danger}"
             }
           },
           "hover": {
@@ -765,8 +765,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.statusStrong.danger-hover}",
-              "deep_sky_itkontoret": "{colors.background.statusStrong.danger-hover}"
+              "deep_sky_itkontoret": "{colors.background.statusStrong.danger-hover}",
+              "default": "{colors.background.statusStrong.danger-hover}"
             }
           },
           "idle": {
@@ -778,8 +778,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.statusStrong.danger}",
-              "deep_sky_itkontoret": "{colors.background.statusStrong.danger}"
+              "deep_sky_itkontoret": "{colors.background.statusStrong.danger}",
+              "default": "{colors.background.statusStrong.danger}"
             }
           }
         },
@@ -792,8 +792,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.12}",
-            "deep_sky_itkontoret": "{units.gap.12}"
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}"
           }
         },
         "widthMin": {
@@ -805,8 +805,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.64}",
-            "deep_sky_itkontoret": "{units.size.64}"
+            "deep_sky_itkontoret": "{units.size.64}",
+            "default": "{units.size.64}"
           }
         }
       },
@@ -821,8 +821,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onInverted.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onInverted.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           },
           "disabled": {
@@ -834,8 +834,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.disabled}",
-              "deep_sky_itkontoret": "{colors.glyph.onInverted.disabled}"
+              "deep_sky_itkontoret": "{colors.glyph.onInverted.disabled}",
+              "default": "{colors.glyph.onBrand.disabled}"
             }
           },
           "hover": {
@@ -847,8 +847,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onInverted.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onInverted.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           },
           "idle": {
@@ -860,8 +860,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onInverted.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onInverted.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           }
         }
@@ -877,8 +877,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.text.onInverted.primary}"
+              "deep_sky_itkontoret": "{colors.text.onInverted.primary}",
+              "default": "{colors.text.onBrand.primary}"
             }
           },
           "disabled": {
@@ -890,8 +890,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onBrand.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onBrand.disabled}"
+              "deep_sky_itkontoret": "{colors.text.onBrand.disabled}",
+              "default": "{colors.text.onBrand.disabled}"
             }
           },
           "hover": {
@@ -903,8 +903,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.text.onInverted.primary}"
+              "deep_sky_itkontoret": "{colors.text.onInverted.primary}",
+              "default": "{colors.text.onBrand.primary}"
             }
           },
           "idle": {
@@ -916,8 +916,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.text.onInverted.primary}"
+              "deep_sky_itkontoret": "{colors.text.onInverted.primary}",
+              "default": "{colors.text.onBrand.primary}"
             }
           }
         }
@@ -934,8 +934,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         }
       },
@@ -950,8 +950,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           },
           "disabled": {
@@ -963,8 +963,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
+              "default": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -976,8 +976,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           },
           "idle": {
@@ -989,8 +989,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           }
         }
@@ -1006,8 +1006,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.link-pressed}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
+              "default": "{colors.text.onSurface.link-pressed}"
             }
           },
           "disabled": {
@@ -1019,8 +1019,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.link-disabled}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
+              "default": "{colors.text.onSurface.link-disabled}"
             }
           },
           "hover": {
@@ -1032,8 +1032,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.link-hover}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
+              "default": "{colors.text.onSurface.link-hover}"
             }
           },
           "idle": {
@@ -1045,8 +1045,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.link}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.link}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link}",
+              "default": "{colors.text.onSurface.link}"
             }
           }
         },
@@ -1060,8 +1060,8 @@
             "$type": "string",
             "platforms": ["PD"],
             "values": {
-              "default": "none",
-              "deep_sky_itkontoret": "none"
+              "deep_sky_itkontoret": "none",
+              "default": "none"
             }
           },
           "disabled": {
@@ -1073,8 +1073,8 @@
             "$type": "string",
             "platforms": ["PD"],
             "values": {
-              "default": "none",
-              "deep_sky_itkontoret": "none"
+              "deep_sky_itkontoret": "none",
+              "default": "none"
             }
           },
           "hover": {
@@ -1086,8 +1086,8 @@
             "$type": "string",
             "platforms": ["PD"],
             "values": {
-              "default": "underline",
-              "deep_sky_itkontoret": "underline"
+              "deep_sky_itkontoret": "underline",
+              "default": "underline"
             }
           },
           "idle": {
@@ -1099,8 +1099,8 @@
             "$type": "string",
             "platforms": ["PD"],
             "values": {
-              "default": "none",
-              "deep_sky_itkontoret": "none"
+              "deep_sky_itkontoret": "none",
+              "default": "none"
             }
           }
         },
@@ -1113,8 +1113,8 @@
             "$type": "typography",
             "platforms": ["PD"],
             "values": {
-              "default": "{typography.link.strong}",
-              "deep_sky_itkontoret": "{typography.link.strong}"
+              "deep_sky_itkontoret": "{typography.link.strong}",
+              "default": "{typography.link.strong}"
             }
           },
           "disabled": {
@@ -1125,8 +1125,8 @@
             "$type": "typography",
             "platforms": ["PD"],
             "values": {
-              "default": "{typography.link.strong}",
-              "deep_sky_itkontoret": "{typography.link.strong}"
+              "deep_sky_itkontoret": "{typography.link.strong}",
+              "default": "{typography.link.strong}"
             }
           },
           "hover": {
@@ -1137,8 +1137,8 @@
             "$type": "typography",
             "platforms": ["PD"],
             "values": {
-              "default": "{typography.link.strong-underline}",
-              "deep_sky_itkontoret": "{typography.link.strong-underline}"
+              "deep_sky_itkontoret": "{typography.link.strong-underline}",
+              "default": "{typography.link.strong-underline}"
             }
           },
           "idle": {
@@ -1149,8 +1149,8 @@
             "$type": "typography",
             "platforms": ["PD"],
             "values": {
-              "default": "{typography.link.strong}",
-              "deep_sky_itkontoret": "{typography.link.strong}"
+              "deep_sky_itkontoret": "{typography.link.strong}",
+              "default": "{typography.link.strong}"
             }
           }
         }
@@ -1168,8 +1168,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "transparent",
-              "deep_sky_itkontoret": "transparent"
+              "deep_sky_itkontoret": "transparent",
+              "default": "transparent"
             }
           },
           "disabled": {
@@ -1181,8 +1181,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{palette.transparent.inverted.9}",
-              "deep_sky_itkontoret": "{palette.transparent.inverted.9}"
+              "deep_sky_itkontoret": "{palette.transparent.inverted.9}",
+              "default": "{palette.transparent.inverted.9}"
             }
           },
           "hover": {
@@ -1194,8 +1194,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "transparent",
-              "deep_sky_itkontoret": "transparent"
+              "deep_sky_itkontoret": "transparent",
+              "default": "transparent"
             }
           },
           "idle": {
@@ -1207,8 +1207,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "transparent",
-              "deep_sky_itkontoret": "transparent"
+              "deep_sky_itkontoret": "transparent",
+              "default": "transparent"
             }
           }
         },
@@ -1221,8 +1221,8 @@
           "$type": "string",
           "platforms": ["PD"],
           "values": {
-            "default": "solid",
-            "deep_sky_itkontoret": "solid"
+            "deep_sky_itkontoret": "solid",
+            "default": "solid"
           }
         },
         "borderWidth": {
@@ -1234,8 +1234,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         },
         "color": {
@@ -1248,8 +1248,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.inverted.active}",
-              "deep_sky_itkontoret": "{colors.background.inverted.active}"
+              "deep_sky_itkontoret": "{colors.background.inverted.active}",
+              "default": "{colors.background.inverted.active}"
             }
           },
           "disabled": {
@@ -1261,8 +1261,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.inverted.disabled}",
-              "deep_sky_itkontoret": "{colors.background.inverted.disabled}"
+              "deep_sky_itkontoret": "{colors.background.inverted.disabled}",
+              "default": "{colors.background.inverted.disabled}"
             }
           },
           "hover": {
@@ -1274,8 +1274,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.inverted.hover}",
-              "deep_sky_itkontoret": "{colors.background.inverted.hover}"
+              "deep_sky_itkontoret": "{colors.background.inverted.hover}",
+              "default": "{colors.background.inverted.hover}"
             }
           },
           "idle": {
@@ -1287,8 +1287,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.inverted.primary}",
-              "deep_sky_itkontoret": "{colors.background.inverted.primary}"
+              "deep_sky_itkontoret": "{colors.background.inverted.primary}",
+              "default": "{colors.background.inverted.primary}"
             }
           }
         },
@@ -1301,8 +1301,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.12}",
-            "deep_sky_itkontoret": "{units.gap.12}"
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}"
           }
         },
         "widthMin": {
@@ -1314,8 +1314,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.64}",
-            "deep_sky_itkontoret": "{units.size.64}"
+            "deep_sky_itkontoret": "{units.size.64}",
+            "default": "{units.size.64}"
           }
         }
       },
@@ -1330,8 +1330,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onInverted.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onInverted.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onInverted.primary}",
+              "default": "{colors.glyph.onInverted.primary}"
             }
           },
           "disabled": {
@@ -1343,8 +1343,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onInverted.disabled}",
-              "deep_sky_itkontoret": "{colors.glyph.onInverted.disabled}"
+              "deep_sky_itkontoret": "{colors.glyph.onInverted.disabled}",
+              "default": "{colors.glyph.onInverted.disabled}"
             }
           },
           "hover": {
@@ -1356,8 +1356,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onInverted.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onInverted.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onInverted.primary}",
+              "default": "{colors.glyph.onInverted.primary}"
             }
           },
           "idle": {
@@ -1369,8 +1369,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onInverted.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onInverted.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onInverted.primary}",
+              "default": "{colors.glyph.onInverted.primary}"
             }
           }
         }
@@ -1386,8 +1386,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onOverlay.primary}",
-              "deep_sky_itkontoret": "{colors.text.onOverlay.primary}"
+              "deep_sky_itkontoret": "{colors.text.onOverlay.primary}",
+              "default": "{colors.text.onOverlay.primary}"
             }
           },
           "disabled": {
@@ -1399,8 +1399,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onInverted.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onInverted.disabled}"
+              "deep_sky_itkontoret": "{colors.text.onInverted.disabled}",
+              "default": "{colors.text.onInverted.disabled}"
             }
           },
           "hover": {
@@ -1412,8 +1412,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onInverted.primary}",
-              "deep_sky_itkontoret": "{colors.text.onInverted.primary}"
+              "deep_sky_itkontoret": "{colors.text.onInverted.primary}",
+              "default": "{colors.text.onInverted.primary}"
             }
           },
           "idle": {
@@ -1425,8 +1425,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onInverted.primary}",
-              "deep_sky_itkontoret": "{colors.text.onInverted.primary}"
+              "deep_sky_itkontoret": "{colors.text.onInverted.primary}",
+              "default": "{colors.text.onInverted.primary}"
             }
           }
         }
@@ -1444,8 +1444,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.brand.secondary-active}",
-              "deep_sky_itkontoret": "{colors.background.brand.secondary-active}"
+              "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
+              "default": "{colors.background.brand.secondary-active}"
             }
           },
           "disabled": {
@@ -1457,8 +1457,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.brand.secondary-disabled}",
-              "deep_sky_itkontoret": "{colors.background.brand.secondary-disabled}"
+              "deep_sky_itkontoret": "{colors.background.brand.secondary-disabled}",
+              "default": "{colors.background.brand.secondary-disabled}"
             }
           },
           "hover": {
@@ -1470,8 +1470,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.brand.secondary-hover}",
-              "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}"
+              "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
+              "default": "{colors.background.brand.secondary-hover}"
             }
           },
           "idle": {
@@ -1483,8 +1483,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.brand.secondary}",
-              "deep_sky_itkontoret": "{colors.background.brand.secondary}"
+              "deep_sky_itkontoret": "{colors.background.brand.secondary}",
+              "default": "{colors.background.brand.secondary}"
             }
           }
         },
@@ -1497,8 +1497,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.12}",
-            "deep_sky_itkontoret": "{units.gap.12}"
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}"
           }
         },
         "widthMin": {
@@ -1510,8 +1510,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.64}",
-            "deep_sky_itkontoret": "{units.size.64}"
+            "deep_sky_itkontoret": "{units.size.64}",
+            "default": "{units.size.64}"
           }
         }
       },
@@ -1526,8 +1526,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           },
           "disabled": {
@@ -1539,8 +1539,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.disabled}",
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.disabled}"
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.disabled}",
+              "default": "{colors.glyph.onBrand.disabled}"
             }
           },
           "hover": {
@@ -1552,8 +1552,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           },
           "idle": {
@@ -1565,8 +1565,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           }
         }
@@ -1582,8 +1582,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.text.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
+              "default": "{colors.text.onBrand.primary}"
             }
           },
           "disabled": {
@@ -1595,8 +1595,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onBrand.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onBrand.disabled}"
+              "deep_sky_itkontoret": "{colors.text.onBrand.disabled}",
+              "default": "{colors.text.onBrand.disabled}"
             }
           },
           "hover": {
@@ -1608,8 +1608,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.text.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
+              "default": "{colors.text.onBrand.primary}"
             }
           },
           "idle": {
@@ -1621,8 +1621,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.text.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
+              "default": "{colors.text.onBrand.primary}"
             }
           }
         }
@@ -1640,8 +1640,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "transparent",
-              "deep_sky_itkontoret": "transparent"
+              "deep_sky_itkontoret": "transparent",
+              "default": "transparent"
             }
           },
           "disabled": {
@@ -1653,8 +1653,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}"
             }
           },
           "hover": {
@@ -1666,8 +1666,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "transparent",
-              "deep_sky_itkontoret": "transparent"
+              "deep_sky_itkontoret": "transparent",
+              "default": "transparent"
             }
           },
           "idle": {
@@ -1679,8 +1679,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}"
             }
           }
         },
@@ -1693,8 +1693,8 @@
           "$type": "string",
           "platforms": ["PD"],
           "values": {
-            "default": "solid",
-            "deep_sky_itkontoret": "solid"
+            "deep_sky_itkontoret": "solid",
+            "default": "solid"
           }
         },
         "borderWidth": {
@@ -1706,8 +1706,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         },
         "color": {
@@ -1720,8 +1720,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.active}",
-              "deep_sky_itkontoret": "{colors.background.surface.active}"
+              "deep_sky_itkontoret": "{colors.background.surface.active}",
+              "default": "{colors.background.surface.active}"
             }
           },
           "disabled": {
@@ -1733,8 +1733,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "transparent",
-              "deep_sky_itkontoret": "transparent"
+              "deep_sky_itkontoret": "transparent",
+              "default": "transparent"
             }
           },
           "hover": {
@@ -1746,8 +1746,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.hover}",
-              "deep_sky_itkontoret": "{colors.background.surface.hover}"
+              "deep_sky_itkontoret": "{colors.background.surface.hover}",
+              "default": "{colors.background.surface.hover}"
             }
           },
           "idle": {
@@ -1759,8 +1759,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "transparent",
-              "deep_sky_itkontoret": "transparent"
+              "deep_sky_itkontoret": "transparent",
+              "default": "transparent"
             }
           }
         },
@@ -1773,8 +1773,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.12}",
-            "deep_sky_itkontoret": "{units.gap.12}"
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}"
           }
         },
         "widthMin": {
@@ -1786,8 +1786,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.64}",
-            "deep_sky_itkontoret": "{units.size.64}"
+            "deep_sky_itkontoret": "{units.size.64}",
+            "default": "{units.size.64}"
           }
         }
       },
@@ -1802,8 +1802,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           },
           "disabled": {
@@ -1815,8 +1815,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
+              "default": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -1828,8 +1828,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           },
           "idle": {
@@ -1841,8 +1841,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           }
         }
@@ -1858,8 +1858,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.link}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
+              "default": "{colors.text.onSurface.link}"
             }
           },
           "disabled": {
@@ -1871,8 +1871,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.link-disabled}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
+              "default": "{colors.text.onSurface.link-disabled}"
             }
           },
           "hover": {
@@ -1884,8 +1884,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.link}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
+              "default": "{colors.text.onSurface.link}"
             }
           },
           "idle": {
@@ -1897,8 +1897,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.link}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.link}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link}",
+              "default": "{colors.text.onSurface.link}"
             }
           }
         }
@@ -1917,8 +1917,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.radius.4}",
-            "deep_sky_itkontoret": "{units.radius.4}"
+            "deep_sky_itkontoret": "{units.radius.4}",
+            "default": "{units.radius.4}"
           }
         },
         "color": {
@@ -1931,8 +1931,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.active}",
-              "deep_sky_itkontoret": "{colors.background.surface.active}"
+              "deep_sky_itkontoret": "{colors.background.surface.active}",
+              "default": "{colors.background.surface.active}"
             }
           },
           "disabled": {
@@ -1944,8 +1944,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.transparent}",
-              "deep_sky_itkontoret": "{colors.background.transparent}"
+              "deep_sky_itkontoret": "{colors.background.transparent}",
+              "default": "{colors.background.transparent}"
             }
           },
           "hover": {
@@ -1957,8 +1957,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.hover}",
-              "deep_sky_itkontoret": "{colors.background.surface.hover}"
+              "deep_sky_itkontoret": "{colors.background.surface.hover}",
+              "default": "{colors.background.surface.hover}"
             }
           },
           "idle": {
@@ -1970,8 +1970,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.transparent}",
-              "deep_sky_itkontoret": "{colors.background.transparent}"
+              "deep_sky_itkontoret": "{colors.background.transparent}",
+              "default": "{colors.background.transparent}"
             }
           }
         },
@@ -1984,8 +1984,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.32}",
-            "deep_sky_itkontoret": "{units.size.32}"
+            "deep_sky_itkontoret": "{units.size.32}",
+            "default": "{units.size.32}"
           }
         },
         "paddingX": {
@@ -1997,8 +1997,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.4}",
-            "deep_sky_itkontoret": "{units.gap.4}"
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}"
           }
         }
       },
@@ -2013,8 +2013,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           },
           "disabled": {
@@ -2026,8 +2026,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
+              "default": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -2039,8 +2039,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           },
           "idle": {
@@ -2052,8 +2052,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           }
         },
@@ -2066,8 +2066,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.24}",
-            "deep_sky_itkontoret": "{units.size.24}"
+            "deep_sky_itkontoret": "{units.size.24}",
+            "default": "{units.size.24}"
           }
         }
       }
@@ -2084,8 +2084,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.transparent}",
-              "deep_sky_itkontoret": "{colors.border.transparent}"
+              "deep_sky_itkontoret": "{colors.border.transparent}",
+              "default": "{colors.border.transparent}"
             }
           },
           "disabled": {
@@ -2097,8 +2097,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}"
             }
           },
           "hover": {
@@ -2110,8 +2110,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.transparent}",
-              "deep_sky_itkontoret": "{colors.border.transparent}"
+              "deep_sky_itkontoret": "{colors.border.transparent}",
+              "default": "{colors.border.transparent}"
             }
           },
           "idle": {
@@ -2123,8 +2123,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}"
             }
           }
         },
@@ -2137,8 +2137,8 @@
           "$type": "string",
           "platforms": ["PD"],
           "values": {
-            "default": "solid",
-            "deep_sky_itkontoret": "solid"
+            "deep_sky_itkontoret": "solid",
+            "default": "solid"
           }
         },
         "borderWidth": {
@@ -2150,8 +2150,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         }
       }
@@ -2169,8 +2169,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onSurface.border-active}",
-            "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+            "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+            "default": "{colors.border.onSurface.border-active}"
           }
         },
         "borderRadius": {
@@ -2182,8 +2182,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.radius.4}",
-            "deep_sky_itkontoret": "{units.radius.4}"
+            "deep_sky_itkontoret": "{units.radius.4}",
+            "default": "{units.radius.4}"
           }
         },
         "borderWidth": {
@@ -2195,8 +2195,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         },
         "color": {
@@ -2208,8 +2208,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.surface.primary}",
-            "deep_sky_itkontoret": "{colors.background.surface.primary}"
+            "deep_sky_itkontoret": "{colors.background.surface.primary}",
+            "default": "{colors.background.surface.primary}"
           }
         },
         "gap": {
@@ -2221,8 +2221,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         },
         "paddingX": {
@@ -2234,8 +2234,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         },
         "paddingY": {
@@ -2247,8 +2247,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         }
       }
@@ -2265,8 +2265,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           }
         }
@@ -2282,8 +2282,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.secondary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}"
             }
           },
           "textStyle": {
@@ -2295,8 +2295,8 @@
             "$type": "typography",
             "platforms": ["PD"],
             "values": {
-              "default": "{typography.body.default}",
-              "deep_sky_itkontoret": "{typography.body.default}"
+              "deep_sky_itkontoret": "{typography.body.default}",
+              "default": "{typography.body.default}"
             }
           }
         }
@@ -2314,8 +2314,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.active}",
-              "deep_sky_itkontoret": "{colors.background.surface.secondary}"
+              "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+              "default": "{colors.background.surface.active}"
             }
           },
           "hover": {
@@ -2327,8 +2327,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.hover}",
-              "deep_sky_itkontoret": "{colors.background.surface.active}"
+              "deep_sky_itkontoret": "{colors.background.surface.active}",
+              "default": "{colors.background.surface.hover}"
             }
           },
           "idle": {
@@ -2340,8 +2340,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.primary}",
-              "deep_sky_itkontoret": "{colors.background.surface.active}"
+              "deep_sky_itkontoret": "{colors.background.surface.active}",
+              "default": "{colors.background.surface.primary}"
             }
           }
         },
@@ -2354,8 +2354,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         },
         "height": {
@@ -2367,8 +2367,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.40}",
-            "deep_sky_itkontoret": "{units.size.40}"
+            "deep_sky_itkontoret": "{units.size.40}",
+            "default": "{units.size.40}"
           }
         },
         "paddingX": {
@@ -2380,8 +2380,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.12}",
-            "deep_sky_itkontoret": "{units.gap.12}"
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}"
           }
         },
         "paddingY": {
@@ -2393,8 +2393,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         }
       },
@@ -2408,8 +2408,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+            "default": "{colors.glyph.onSurface.primary}"
           }
         }
       },
@@ -2423,8 +2423,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.link}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.link}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.link}",
+            "default": "{colors.text.onSurface.link}"
           }
         },
         "textStyle": {
@@ -2436,8 +2436,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.strong}",
-            "deep_sky_itkontoret": "String value"
+            "deep_sky_itkontoret": "String value",
+            "default": "{typography.body.strong}"
           }
         }
       }
@@ -2453,8 +2453,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onSurface.border}",
-            "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+            "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+            "default": "{colors.border.onSurface.border}"
           }
         },
         "borderWidth": {
@@ -2466,8 +2466,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         },
         "paddingX": {
@@ -2479,8 +2479,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         },
         "paddingY": {
@@ -2492,8 +2492,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         }
       },
@@ -2507,8 +2507,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         }
       }
@@ -2524,8 +2524,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.radius.4}",
-            "deep_sky_itkontoret": "{units.radius.4}"
+            "deep_sky_itkontoret": "{units.radius.4}",
+            "default": "{units.radius.4}"
           }
         },
         "gap": {
@@ -2537,8 +2537,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         },
         "height": {
@@ -2550,8 +2550,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.32}",
-            "deep_sky_itkontoret": "{units.size.32}"
+            "deep_sky_itkontoret": "{units.size.32}",
+            "default": "{units.size.32}"
           }
         },
         "paddingX": {
@@ -2563,8 +2563,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.12}",
-            "deep_sky_itkontoret": "{units.gap.12}"
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}"
           }
         },
         "paddingY": {
@@ -2576,8 +2576,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         },
         "widthMin": {
@@ -2589,8 +2589,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.64}",
-            "deep_sky_itkontoret": "{units.size.64}"
+            "deep_sky_itkontoret": "{units.size.64}",
+            "default": "{units.size.64}"
           }
         }
       },
@@ -2604,8 +2604,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.16}",
-            "deep_sky_itkontoret": "{units.size.16}"
+            "deep_sky_itkontoret": "{units.size.16}",
+            "default": "{units.size.16}"
           }
         }
       },
@@ -2619,8 +2619,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.strong}",
-            "deep_sky_itkontoret": "{typography.body.strong}"
+            "deep_sky_itkontoret": "{typography.body.strong}",
+            "default": "{typography.body.strong}"
           }
         }
       }
@@ -2637,8 +2637,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.brand.secondary-active}",
-              "deep_sky_itkontoret": "{colors.background.brand.secondary-active}"
+              "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
+              "default": "{colors.background.brand.secondary-active}"
             }
           },
           "disabled": {
@@ -2650,8 +2650,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.brand.secondary-disabled}",
-              "deep_sky_itkontoret": "{colors.background.brand.secondary-disabled}"
+              "deep_sky_itkontoret": "{colors.background.brand.secondary-disabled}",
+              "default": "{colors.background.brand.secondary-disabled}"
             }
           },
           "hover": {
@@ -2663,8 +2663,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.brand.secondary-hover}",
-              "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}"
+              "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
+              "default": "{colors.background.brand.secondary-hover}"
             }
           },
           "idle": {
@@ -2676,8 +2676,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.brand.secondary}",
-              "deep_sky_itkontoret": "{colors.background.brand.secondary}"
+              "deep_sky_itkontoret": "{colors.background.brand.secondary}",
+              "default": "{colors.background.brand.secondary}"
             }
           }
         }
@@ -2692,8 +2692,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onBrand.primary}",
-            "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+            "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+            "default": "{colors.glyph.onBrand.primary}"
           }
         }
       },
@@ -2707,8 +2707,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onBrand.primary}",
-            "deep_sky_itkontoret": "{colors.text.onBrand.primary}"
+            "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
+            "default": "{colors.text.onBrand.primary}"
           }
         }
       }
@@ -2725,8 +2725,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "transparent",
-              "deep_sky_itkontoret": "transparent"
+              "deep_sky_itkontoret": "transparent",
+              "default": "transparent"
             }
           },
           "disabled": {
@@ -2738,8 +2738,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}"
             }
           },
           "hover": {
@@ -2751,8 +2751,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "transparent",
-              "deep_sky_itkontoret": "transparent"
+              "deep_sky_itkontoret": "transparent",
+              "default": "transparent"
             }
           },
           "idle": {
@@ -2764,8 +2764,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}"
             }
           }
         },
@@ -2778,8 +2778,8 @@
           "$type": "string",
           "platforms": ["PD"],
           "values": {
-            "default": "solid",
-            "deep_sky_itkontoret": "solid"
+            "deep_sky_itkontoret": "solid",
+            "default": "solid"
           }
         },
         "borderWidth": {
@@ -2791,8 +2791,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         },
         "color": {
@@ -2805,8 +2805,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.active}",
-              "deep_sky_itkontoret": "{colors.background.surface.active}"
+              "deep_sky_itkontoret": "{colors.background.surface.active}",
+              "default": "{colors.background.surface.active}"
             }
           },
           "disabled": {
@@ -2818,8 +2818,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "transparent",
-              "deep_sky_itkontoret": "transparent"
+              "deep_sky_itkontoret": "transparent",
+              "default": "transparent"
             }
           },
           "hover": {
@@ -2831,8 +2831,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.hover}",
-              "deep_sky_itkontoret": "{colors.background.surface.hover}"
+              "deep_sky_itkontoret": "{colors.background.surface.hover}",
+              "default": "{colors.background.surface.hover}"
             }
           },
           "idle": {
@@ -2844,8 +2844,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "transparent",
-              "deep_sky_itkontoret": "transparent"
+              "deep_sky_itkontoret": "transparent",
+              "default": "transparent"
             }
           }
         }
@@ -2861,8 +2861,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           },
           "disabled": {
@@ -2874,8 +2874,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
+              "default": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -2887,8 +2887,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           },
           "idle": {
@@ -2900,8 +2900,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           }
         }
@@ -2917,8 +2917,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.link}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.link}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link}",
+              "default": "{colors.text.onSurface.link}"
             }
           },
           "disabled": {
@@ -2930,8 +2930,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.link-disabled}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
+              "default": "{colors.text.onSurface.link-disabled}"
             }
           },
           "hover": {
@@ -2943,8 +2943,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.link}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.link}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link}",
+              "default": "{colors.text.onSurface.link}"
             }
           },
           "idle": {
@@ -2956,8 +2956,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.link}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.link}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link}",
+              "default": "{colors.text.onSurface.link}"
             }
           }
         }
@@ -2976,8 +2976,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onSurface.border}",
-            "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+            "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+            "default": "{colors.border.onSurface.border}"
           }
         },
         "focused": {
@@ -2989,8 +2989,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onSurface.border}",
-            "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+            "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+            "default": "{colors.border.onSurface.border}"
           }
         },
         "hover": {
@@ -3002,8 +3002,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onSurface.border}",
-            "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+            "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+            "default": "{colors.border.onSurface.border}"
           }
         },
         "idle": {
@@ -3015,8 +3015,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onSurface.border}",
-            "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+            "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+            "default": "{colors.border.onSurface.border}"
           }
         }
       },
@@ -3030,8 +3030,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.radius.8}",
-            "deep_sky_itkontoret": "{units.radius.8}"
+            "deep_sky_itkontoret": "{units.radius.8}",
+            "default": "{units.radius.8}"
           }
         },
         "borderStyle": {
@@ -3043,8 +3043,8 @@
           "$type": "string",
           "platforms": ["PD"],
           "values": {
-            "default": "solid",
-            "deep_sky_itkontoret": "solid"
+            "deep_sky_itkontoret": "solid",
+            "default": "solid"
           }
         },
         "borderWidth": {
@@ -3056,8 +3056,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         },
         "color": {
@@ -3070,8 +3070,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.active}",
-              "deep_sky_itkontoret": "{colors.background.surface.primary}"
+              "deep_sky_itkontoret": "{colors.background.surface.primary}",
+              "default": "{colors.background.surface.active}"
             }
           },
           "hover": {
@@ -3083,8 +3083,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.hover}",
-              "deep_sky_itkontoret": "{colors.background.surface.primary}"
+              "deep_sky_itkontoret": "{colors.background.surface.primary}",
+              "default": "{colors.background.surface.hover}"
             }
           },
           "idle": {
@@ -3096,8 +3096,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.primary}",
-              "deep_sky_itkontoret": "{colors.background.surface.primary}"
+              "deep_sky_itkontoret": "{colors.background.surface.primary}",
+              "default": "{colors.background.surface.primary}"
             }
           }
         },
@@ -3110,8 +3110,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.64}",
-            "deep_sky_itkontoret": "{units.size.64}"
+            "deep_sky_itkontoret": "{units.size.64}",
+            "default": "{units.size.64}"
           }
         },
         "paddingX": {
@@ -3123,8 +3123,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.16}",
-            "deep_sky_itkontoret": "{units.gap.16}"
+            "deep_sky_itkontoret": "{units.gap.16}",
+            "default": "{units.gap.16}"
           }
         },
         "paddingY": {
@@ -3136,8 +3136,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         }
       },
@@ -3151,8 +3151,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         }
       },
@@ -3166,8 +3166,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.secondary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+            "default": "{colors.text.onSurface.secondary}"
           }
         },
         "textStyle": {
@@ -3179,8 +3179,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.caption.default}",
-            "deep_sky_itkontoret": "{typography.caption.default}"
+            "deep_sky_itkontoret": "{typography.caption.default}",
+            "default": "{typography.caption.default}"
           }
         }
       },
@@ -3194,8 +3194,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.headings.title-accent}",
-            "deep_sky_itkontoret": "{typography.headings.title-accent}"
+            "deep_sky_itkontoret": "{typography.headings.title-accent}",
+            "default": "{typography.headings.title-accent}"
           }
         }
       }
@@ -3211,8 +3211,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.link}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.link}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.link}",
+            "default": "{colors.text.onSurface.link}"
           }
         }
       }
@@ -3229,8 +3229,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.secondary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}"
             }
           },
           "idle": {
@@ -3242,8 +3242,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           }
         }
@@ -3262,8 +3262,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.radius.2}",
-            "deep_sky_itkontoret": "{units.radius.2}"
+            "deep_sky_itkontoret": "{units.radius.2}",
+            "default": "{units.radius.2}"
           }
         },
         "borderWidth": {
@@ -3275,8 +3275,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         },
         "marginX": {
@@ -3288,8 +3288,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.4}",
-            "deep_sky_itkontoret": "{units.gap.4}"
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}"
           }
         },
         "size": {
@@ -3301,8 +3301,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.16}",
-            "deep_sky_itkontoret": "{units.size.16}"
+            "deep_sky_itkontoret": "{units.size.16}",
+            "default": "{units.size.16}"
           }
         }
       },
@@ -3316,8 +3316,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         },
         "widthMax": {
@@ -3329,8 +3329,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.632}",
-            "deep_sky_itkontoret": "{units.size.632}"
+            "deep_sky_itkontoret": "{units.size.632}",
+            "default": "{units.size.632}"
           }
         },
         "widthMin": {
@@ -3342,8 +3342,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.16}",
-            "deep_sky_itkontoret": "{units.size.16}"
+            "deep_sky_itkontoret": "{units.size.16}",
+            "default": "{units.size.16}"
           }
         }
       },
@@ -3357,8 +3357,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         },
         "widthMax": {
@@ -3370,8 +3370,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.632}",
-            "deep_sky_itkontoret": "{units.size.632}"
+            "deep_sky_itkontoret": "{units.size.632}",
+            "default": "{units.size.632}"
           }
         }
       },
@@ -3385,8 +3385,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.secondary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+            "default": "{colors.text.onSurface.secondary}"
           }
         },
         "textStyle": {
@@ -3398,8 +3398,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.default}",
-            "deep_sky_itkontoret": "{typography.body.default}"
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}"
           }
         }
       },
@@ -3413,8 +3413,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -3426,8 +3426,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.default}",
-            "deep_sky_itkontoret": "{typography.body.default}"
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}"
           }
         }
       }
@@ -3444,8 +3444,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-active}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}"
             }
           },
           "disabled": {
@@ -3457,8 +3457,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}"
             }
           },
           "hover": {
@@ -3470,8 +3470,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-active}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -3483,8 +3483,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-active}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}"
             }
           }
         },
@@ -3498,8 +3498,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.brand.secondary-active}",
-              "deep_sky_itkontoret": "{colors.background.brand.secondary-active}"
+              "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
+              "default": "{colors.background.brand.secondary-active}"
             }
           },
           "disabled": {
@@ -3511,8 +3511,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.secondary}",
-              "deep_sky_itkontoret": "{colors.background.surface.secondary}"
+              "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+              "default": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -3524,8 +3524,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.brand.secondary-hover}",
-              "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}"
+              "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
+              "default": "{colors.background.brand.secondary-hover}"
             }
           },
           "idle": {
@@ -3537,8 +3537,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.brand.secondary}",
-              "deep_sky_itkontoret": "{colors.background.brand.secondary}"
+              "deep_sky_itkontoret": "{colors.background.brand.secondary}",
+              "default": "{colors.background.brand.secondary}"
             }
           }
         }
@@ -3554,8 +3554,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           },
           "disabled": {
@@ -3567,8 +3567,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
+              "default": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -3580,8 +3580,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           },
           "idle": {
@@ -3593,8 +3593,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           }
         }
@@ -3612,8 +3612,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-active}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}"
             }
           },
           "disabled": {
@@ -3625,8 +3625,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}"
             }
           },
           "hover": {
@@ -3638,8 +3638,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-active}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -3651,8 +3651,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-active}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}"
             }
           }
         },
@@ -3666,8 +3666,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.brand.secondary-active}",
-              "deep_sky_itkontoret": "{colors.background.brand.secondary-active}"
+              "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
+              "default": "{colors.background.brand.secondary-active}"
             }
           },
           "disabled": {
@@ -3679,8 +3679,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.secondary}",
-              "deep_sky_itkontoret": "{colors.background.surface.secondary}"
+              "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+              "default": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -3692,8 +3692,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.brand.secondary-hover}",
-              "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}"
+              "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
+              "default": "{colors.background.brand.secondary-hover}"
             }
           },
           "idle": {
@@ -3705,8 +3705,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.brand.secondary}",
-              "deep_sky_itkontoret": "{colors.background.brand.secondary}"
+              "deep_sky_itkontoret": "{colors.background.brand.secondary}",
+              "default": "{colors.background.brand.secondary}"
             }
           }
         }
@@ -3722,8 +3722,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           },
           "disabled": {
@@ -3735,8 +3735,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
+              "default": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -3748,8 +3748,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           },
           "idle": {
@@ -3761,8 +3761,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           }
         }
@@ -3780,8 +3780,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-active}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}"
             }
           },
           "disabled": {
@@ -3793,8 +3793,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.divider}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.divider}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.divider}",
+              "default": "{colors.border.onSurface.divider}"
             }
           },
           "hover": {
@@ -3806,8 +3806,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-active}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -3819,8 +3819,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}"
             }
           }
         },
@@ -3834,8 +3834,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.active}",
-              "deep_sky_itkontoret": "{colors.background.surface.active}"
+              "deep_sky_itkontoret": "{colors.background.surface.active}",
+              "default": "{colors.background.surface.active}"
             }
           },
           "disabled": {
@@ -3847,8 +3847,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.secondary}",
-              "deep_sky_itkontoret": "{colors.background.surface.secondary}"
+              "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+              "default": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -3860,8 +3860,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.hover}",
-              "deep_sky_itkontoret": "{colors.background.surface.hover}"
+              "deep_sky_itkontoret": "{colors.background.surface.hover}",
+              "default": "{colors.background.surface.hover}"
             }
           },
           "idle": {
@@ -3873,8 +3873,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.primary}",
-              "deep_sky_itkontoret": "{colors.background.surface.primary}"
+              "deep_sky_itkontoret": "{colors.background.surface.primary}",
+              "default": "{colors.background.surface.primary}"
             }
           }
         }
@@ -3892,8 +3892,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onSurface.border}",
-            "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+            "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+            "default": "{colors.border.onSurface.border}"
           }
         },
         "hover": {
@@ -3904,8 +3904,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onSurface.border-active}",
-            "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+            "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+            "default": "{colors.border.onSurface.border-active}"
           }
         },
         "idle": {
@@ -3916,8 +3916,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onSurface.border}",
-            "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+            "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+            "default": "{colors.border.onSurface.border}"
           }
         }
       },
@@ -3929,8 +3929,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.radius.12}",
-          "deep_sky_itkontoret": "{units.radius.12}"
+          "deep_sky_itkontoret": "{units.radius.12}",
+          "default": "{units.radius.12}"
         }
       },
       "style": {
@@ -3941,8 +3941,8 @@
         "$type": "string",
         "platforms": ["PD"],
         "values": {
-          "default": "solid",
-          "deep_sky_itkontoret": "solid"
+          "deep_sky_itkontoret": "solid",
+          "default": "solid"
         }
       },
       "width": {
@@ -3953,8 +3953,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.stroke.1}",
-          "deep_sky_itkontoret": "{units.stroke.1}"
+          "deep_sky_itkontoret": "{units.stroke.1}",
+          "default": "{units.stroke.1}"
         }
       }
     },
@@ -3968,8 +3968,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.surface.active}",
-            "deep_sky_itkontoret": "{colors.background.surface.active}"
+            "deep_sky_itkontoret": "{colors.background.surface.active}",
+            "default": "{colors.background.surface.active}"
           }
         },
         "hover": {
@@ -3980,8 +3980,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.surface.hover}",
-            "deep_sky_itkontoret": "{colors.background.surface.hover}"
+            "deep_sky_itkontoret": "{colors.background.surface.hover}",
+            "default": "{colors.background.surface.hover}"
           }
         },
         "idle": {
@@ -3992,8 +3992,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.surface.secondary}",
-            "deep_sky_itkontoret": "{colors.background.surface.secondary}"
+            "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+            "default": "{colors.background.surface.secondary}"
           }
         }
       },
@@ -4005,8 +4005,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.4}",
-          "deep_sky_itkontoret": "{units.gap.4}"
+          "deep_sky_itkontoret": "{units.gap.4}",
+          "default": "{units.gap.4}"
         }
       },
       "height": {
@@ -4017,8 +4017,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.size.24}",
-          "deep_sky_itkontoret": "{units.size.24}"
+          "deep_sky_itkontoret": "{units.size.24}",
+          "default": "{units.size.24}"
         }
       },
       "paddingX": {
@@ -4029,8 +4029,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.8}",
-          "deep_sky_itkontoret": "{units.gap.8}"
+          "deep_sky_itkontoret": "{units.gap.8}",
+          "default": "{units.gap.8}"
         }
       },
       "widthMin": {
@@ -4041,8 +4041,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.size.48}",
-          "deep_sky_itkontoret": "{units.size.48}"
+          "deep_sky_itkontoret": "{units.size.48}",
+          "default": "{units.size.48}"
         }
       }
     },
@@ -4055,8 +4055,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.glyph.onSurface.primary}",
-          "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+          "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+          "default": "{colors.glyph.onSurface.primary}"
         }
       },
       "size": {
@@ -4067,8 +4067,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.size.16}",
-          "deep_sky_itkontoret": "{units.size.16}"
+          "deep_sky_itkontoret": "{units.size.16}",
+          "default": "{units.size.16}"
         }
       }
     },
@@ -4081,8 +4081,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.text.onSurface.primary}",
-          "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+          "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+          "default": "{colors.text.onSurface.primary}"
         }
       },
       "textStyle": {
@@ -4093,8 +4093,8 @@
         "$type": "typography",
         "platforms": ["PD"],
         "values": {
-          "default": "{typography.body.default}",
-          "deep_sky_itkontoret": "{typography.body.default}"
+          "deep_sky_itkontoret": "{typography.body.default}",
+          "default": "{typography.body.default}"
         }
       }
     }
@@ -4111,8 +4111,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.radius.4}",
-            "deep_sky_itkontoret": "{units.radius.4}"
+            "deep_sky_itkontoret": "{units.radius.4}",
+            "default": "{units.radius.4}"
           }
         },
         "borderWidth": {
@@ -4124,8 +4124,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         },
         "color": {
@@ -4138,8 +4138,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.secondary}",
-              "deep_sky_itkontoret": "{colors.background.surface.secondary}"
+              "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+              "default": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -4151,8 +4151,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.primary}",
-              "deep_sky_itkontoret": "{colors.background.surface.primary}"
+              "deep_sky_itkontoret": "{colors.background.surface.primary}",
+              "default": "{colors.background.surface.primary}"
             }
           },
           "idle": {
@@ -4164,8 +4164,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.primary}",
-              "deep_sky_itkontoret": "{colors.background.surface.primary}"
+              "deep_sky_itkontoret": "{colors.background.surface.primary}",
+              "default": "{colors.background.surface.primary}"
             }
           }
         },
@@ -4178,8 +4178,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.12}",
-            "deep_sky_itkontoret": "{units.gap.12}"
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}"
           }
         },
         "gapRange": {
@@ -4191,8 +4191,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         },
         "height": {
@@ -4204,8 +4204,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.32}",
-            "deep_sky_itkontoret": "{units.size.32}"
+            "deep_sky_itkontoret": "{units.size.32}",
+            "default": "{units.size.32}"
           }
         },
         "paddingX": {
@@ -4217,8 +4217,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.12}",
-            "deep_sky_itkontoret": "{units.gap.12}"
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}"
           }
         },
         "paddingY": {
@@ -4230,8 +4230,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.4}",
-            "deep_sky_itkontoret": "{units.gap.4}"
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}"
           }
         }
       },
@@ -4245,8 +4245,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.4}",
-            "deep_sky_itkontoret": "{units.gap.4}"
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}"
           }
         },
         "widthMin": {
@@ -4258,8 +4258,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.128}",
-            "deep_sky_itkontoret": "{units.size.128}"
+            "deep_sky_itkontoret": "{units.size.128}",
+            "default": "{units.size.128}"
           }
         }
       },
@@ -4273,8 +4273,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.4}",
-            "deep_sky_itkontoret": "{units.gap.4}"
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}"
           }
         }
       },
@@ -4289,8 +4289,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+              "default": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -4302,8 +4302,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           },
           "idle": {
@@ -4315,8 +4315,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           }
         },
@@ -4329,8 +4329,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.form-label}",
-            "deep_sky_itkontoret": "{typography.body.form-label}"
+            "deep_sky_itkontoret": "{typography.body.form-label}",
+            "default": "{typography.body.form-label}"
           }
         }
       },
@@ -4345,8 +4345,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+              "default": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -4358,8 +4358,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.secondary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}"
             }
           },
           "idle": {
@@ -4371,8 +4371,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.secondary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}"
             }
           }
         },
@@ -4385,8 +4385,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.default}",
-            "deep_sky_itkontoret": "{typography.body.default}"
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}"
           }
         }
       },
@@ -4400,8 +4400,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.destructive}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.destructive}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
+            "default": "{colors.text.onSurface.destructive}"
           }
         },
         "textStyle": {
@@ -4413,8 +4413,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.caption.default}",
-            "deep_sky_itkontoret": "{typography.caption.default}"
+            "deep_sky_itkontoret": "{typography.caption.default}",
+            "default": "{typography.caption.default}"
           }
         }
       },
@@ -4429,8 +4429,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+              "default": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -4442,8 +4442,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           },
           "idle": {
@@ -4455,8 +4455,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           }
         },
@@ -4469,8 +4469,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.default}",
-            "deep_sky_itkontoret": "{typography.body.default}"
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}"
           }
         }
       },
@@ -4485,8 +4485,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+              "default": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -4498,8 +4498,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           },
           "idle": {
@@ -4511,8 +4511,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           }
         },
@@ -4525,8 +4525,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.default}",
-            "deep_sky_itkontoret": "{typography.body.default}"
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}"
           }
         }
       }
@@ -4543,8 +4543,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-error}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
+              "default": "{colors.border.onSurface.border-error}"
             }
           },
           "hover": {
@@ -4556,8 +4556,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-error}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
+              "default": "{colors.border.onSurface.border-error}"
             }
           },
           "idle": {
@@ -4569,8 +4569,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-error}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
+              "default": "{colors.border.onSurface.border-error}"
             }
           }
         }
@@ -4585,8 +4585,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.destructive}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.destructive}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
+            "default": "{colors.text.onSurface.destructive}"
           }
         },
         "textStyle": {
@@ -4598,8 +4598,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.caption.default}",
-            "deep_sky_itkontoret": "{typography.caption.default}"
+            "deep_sky_itkontoret": "{typography.caption.default}",
+            "default": "{typography.caption.default}"
           }
         }
       },
@@ -4614,8 +4614,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.destructive}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.destructive}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.destructive}",
+              "default": "{colors.glyph.onSurface.destructive}"
             }
           },
           "idle": {
@@ -4627,8 +4627,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.destructive}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.destructive}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.destructive}",
+              "default": "{colors.glyph.onSurface.destructive}"
             }
           }
         }
@@ -4646,8 +4646,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-active}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}"
             }
           },
           "disabled": {
@@ -4659,8 +4659,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}"
             }
           },
           "hover": {
@@ -4672,8 +4672,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-active}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -4685,8 +4685,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}"
             }
           }
         }
@@ -4702,8 +4702,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+              "default": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -4715,8 +4715,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.secondary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}"
             }
           },
           "idle": {
@@ -4728,8 +4728,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.secondary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}"
             }
           }
         },
@@ -4742,8 +4742,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.caption.default}",
-            "deep_sky_itkontoret": "{typography.caption.default}"
+            "deep_sky_itkontoret": "{typography.caption.default}",
+            "default": "{typography.caption.default}"
           }
         }
       },
@@ -4758,8 +4758,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
+              "default": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -4771,8 +4771,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           },
           "idle": {
@@ -4784,8 +4784,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           }
         }
@@ -4803,8 +4803,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.border.onSurface.border}",
-          "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+          "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+          "default": "{colors.border.onSurface.border}"
         }
       },
       "hover": {
@@ -4816,8 +4816,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.border.onSurface.border-active}",
-          "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+          "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+          "default": "{colors.border.onSurface.border-active}"
         }
       },
       "idle": {
@@ -4829,8 +4829,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.border.onSurface.border}",
-          "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+          "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+          "default": "{colors.border.onSurface.border}"
         }
       }
     },
@@ -4844,8 +4844,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.radius.4}",
-          "deep_sky_itkontoret": "{units.radius.4}"
+          "deep_sky_itkontoret": "{units.radius.4}",
+          "default": "{units.radius.4}"
         }
       },
       "borderWidth": {
@@ -4857,8 +4857,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.stroke.1}",
-          "deep_sky_itkontoret": "{units.stroke.1}"
+          "deep_sky_itkontoret": "{units.stroke.1}",
+          "default": "{units.stroke.1}"
         }
       },
       "color": {
@@ -4871,8 +4871,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.surface.secondary}",
-            "deep_sky_itkontoret": "{colors.background.surface.secondary}"
+            "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+            "default": "{colors.background.surface.secondary}"
           }
         },
         "hover": {
@@ -4884,8 +4884,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.surface.primary}",
-            "deep_sky_itkontoret": "{colors.background.surface.primary}"
+            "deep_sky_itkontoret": "{colors.background.surface.primary}",
+            "default": "{colors.background.surface.primary}"
           }
         },
         "idle": {
@@ -4897,8 +4897,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.surface.primary}",
-            "deep_sky_itkontoret": "{colors.background.surface.primary}"
+            "deep_sky_itkontoret": "{colors.background.surface.primary}",
+            "default": "{colors.background.surface.primary}"
           }
         }
       },
@@ -4911,8 +4911,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.8}",
-          "deep_sky_itkontoret": "{units.gap.8}"
+          "deep_sky_itkontoret": "{units.gap.8}",
+          "default": "{units.gap.8}"
         }
       },
       "height": {
@@ -4924,8 +4924,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.size.32}",
-          "deep_sky_itkontoret": "{units.size.32}"
+          "deep_sky_itkontoret": "{units.size.32}",
+          "default": "{units.size.32}"
         }
       },
       "paddingX": {
@@ -4937,8 +4937,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.12}",
-          "deep_sky_itkontoret": "{units.gap.12}"
+          "deep_sky_itkontoret": "{units.gap.12}",
+          "default": "{units.gap.12}"
         }
       },
       "paddingY": {
@@ -4950,8 +4950,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.4}",
-          "deep_sky_itkontoret": "{units.gap.4}"
+          "deep_sky_itkontoret": "{units.gap.4}",
+          "default": "{units.gap.4}"
         }
       }
     },
@@ -4965,8 +4965,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.glyph.onSurface.primary}",
-          "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+          "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+          "default": "{colors.glyph.onSurface.primary}"
         }
       }
     },
@@ -4980,8 +4980,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.text.onSurface.disabled}",
-          "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+          "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+          "default": "{colors.text.onSurface.disabled}"
         }
       },
       "hover": {
@@ -4993,8 +4993,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.text.onSurface.primary}",
-          "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+          "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+          "default": "{colors.text.onSurface.primary}"
         }
       },
       "idle": {
@@ -5006,8 +5006,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.text.onSurface.primary}",
-          "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+          "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+          "default": "{colors.text.onSurface.primary}"
         }
       }
     },
@@ -5021,8 +5021,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.4}",
-          "deep_sky_itkontoret": "{units.gap.4}"
+          "deep_sky_itkontoret": "{units.gap.4}",
+          "default": "{units.gap.4}"
         }
       },
       "widthMin": {
@@ -5034,8 +5034,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.size.128}",
-          "deep_sky_itkontoret": "{units.size.128}"
+          "deep_sky_itkontoret": "{units.size.128}",
+          "default": "{units.size.128}"
         }
       }
     },
@@ -5049,8 +5049,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.4}",
-          "deep_sky_itkontoret": "{units.gap.4}"
+          "deep_sky_itkontoret": "{units.gap.4}",
+          "default": "{units.gap.4}"
         }
       }
     },
@@ -5065,8 +5065,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onSurface.disabled}",
-            "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}"
+            "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
+            "default": "{colors.glyph.onSurface.disabled}"
           }
         },
         "hover": {
@@ -5078,8 +5078,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+            "default": "{colors.glyph.onSurface.primary}"
           }
         },
         "idle": {
@@ -5091,8 +5091,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+            "default": "{colors.glyph.onSurface.primary}"
           }
         }
       }
@@ -5107,8 +5107,8 @@
         "$type": "typography",
         "platforms": ["PD"],
         "values": {
-          "default": "{typography.body.form-label}",
-          "deep_sky_itkontoret": "{typography.body.form-label}"
+          "deep_sky_itkontoret": "{typography.body.form-label}",
+          "default": "{typography.body.form-label}"
         }
       }
     },
@@ -5123,8 +5123,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.disabled}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+            "default": "{colors.text.onSurface.disabled}"
           }
         },
         "hover": {
@@ -5136,8 +5136,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.secondary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+            "default": "{colors.text.onSurface.secondary}"
           }
         },
         "idle": {
@@ -5149,8 +5149,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.secondary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+            "default": "{colors.text.onSurface.secondary}"
           }
         }
       }
@@ -5165,8 +5165,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.text.onSurface.destructive}",
-          "deep_sky_itkontoret": "{colors.text.onSurface.destructive}"
+          "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
+          "default": "{colors.text.onSurface.destructive}"
         }
       },
       "textStyle": {
@@ -5178,8 +5178,8 @@
         "$type": "typography",
         "platforms": ["PD"],
         "values": {
-          "default": "{typography.body.default}",
-          "deep_sky_itkontoret": "{typography.body.default}"
+          "deep_sky_itkontoret": "{typography.body.default}",
+          "default": "{typography.body.default}"
         }
       }
     },
@@ -5194,8 +5194,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.disabled}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+            "default": "{colors.text.onSurface.disabled}"
           }
         },
         "hover": {
@@ -5207,8 +5207,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}"
           }
         },
         "idle": {
@@ -5220,8 +5220,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}"
           }
         }
       },
@@ -5234,8 +5234,8 @@
         "$type": "typography",
         "platforms": ["PD"],
         "values": {
-          "default": "{typography.body.default}",
-          "deep_sky_itkontoret": "{typography.body.default}"
+          "deep_sky_itkontoret": "{typography.body.default}",
+          "default": "{typography.body.default}"
         }
       }
     }
@@ -5252,8 +5252,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         },
         "label": {
@@ -5267,8 +5267,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.text.onSurface.secondary}",
-                "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+                "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+                "default": "{colors.text.onSurface.secondary}"
               }
             },
             "value": {
@@ -5280,8 +5280,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.text.onSurface.primary}",
-                "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+                "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+                "default": "{colors.text.onSurface.primary}"
               }
             }
           },
@@ -5294,8 +5294,8 @@
             "$type": "typography",
             "platforms": ["PD"],
             "values": {
-              "default": "{typography.body.default}",
-              "deep_sky_itkontoret": "{typography.body.default}"
+              "deep_sky_itkontoret": "{typography.body.default}",
+              "default": "{typography.body.default}"
             }
           }
         },
@@ -5308,8 +5308,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.12}",
-            "deep_sky_itkontoret": "{units.gap.12}"
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}"
           }
         },
         "paddingY": {
@@ -5321,8 +5321,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.12}",
-            "deep_sky_itkontoret": "{units.gap.12}"
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}"
           }
         }
       },
@@ -5336,8 +5336,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onSurface.border-active}",
-            "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+            "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+            "default": "{colors.border.onSurface.border-active}"
           }
         },
         "borderRadius": {
@@ -5349,8 +5349,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.radius.4}",
-            "deep_sky_itkontoret": "{units.radius.4}"
+            "deep_sky_itkontoret": "{units.radius.4}",
+            "default": "{units.radius.4}"
           }
         },
         "borderWidth": {
@@ -5362,8 +5362,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         },
         "color": {
@@ -5375,8 +5375,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.surface.primary}",
-            "deep_sky_itkontoret": "{colors.background.surface.primary}"
+            "deep_sky_itkontoret": "{colors.background.surface.primary}",
+            "default": "{colors.background.surface.primary}"
           }
         },
         "gap": {
@@ -5388,8 +5388,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         },
         "paddingX": {
@@ -5401,8 +5401,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         },
         "paddingY": {
@@ -5414,8 +5414,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         }
       },
@@ -5429,8 +5429,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.size.8}"
+            "deep_sky_itkontoret": "{units.size.8}",
+            "default": "{units.gap.8}"
           }
         },
         "paddingX": {
@@ -5442,8 +5442,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.16}",
-            "deep_sky_itkontoret": "{units.gap.16}"
+            "deep_sky_itkontoret": "{units.gap.16}",
+            "default": "{units.gap.16}"
           }
         },
         "paddingY": {
@@ -5455,8 +5455,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.16}",
-            "deep_sky_itkontoret": "{units.size.16}"
+            "deep_sky_itkontoret": "{units.size.16}",
+            "default": "{units.gap.16}"
           }
         },
         "widthMin": {
@@ -5468,8 +5468,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.128}",
-            "deep_sky_itkontoret": "{units.size.128}"
+            "deep_sky_itkontoret": "{units.size.128}",
+            "default": "{units.size.128}"
           }
         }
       }
@@ -5486,8 +5486,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.gap.8}",
-              "deep_sky_itkontoret": "{units.gap.8}"
+              "deep_sky_itkontoret": "{units.gap.8}",
+              "default": "{units.gap.8}"
             }
           },
           "height": {
@@ -5499,8 +5499,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.size.40}",
-              "deep_sky_itkontoret": "{units.size.40}"
+              "deep_sky_itkontoret": "{units.size.40}",
+              "default": "{units.size.40}"
             }
           },
           "paddingX": {
@@ -5512,8 +5512,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.gap.12}",
-              "deep_sky_itkontoret": "{units.gap.12}"
+              "deep_sky_itkontoret": "{units.gap.12}",
+              "default": "{units.gap.12}"
             }
           },
           "paddingY": {
@@ -5525,8 +5525,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.gap.8}",
-              "deep_sky_itkontoret": "{units.gap.8}"
+              "deep_sky_itkontoret": "{units.gap.8}",
+              "default": "{units.gap.8}"
             }
           }
         },
@@ -5539,8 +5539,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.glyph.onSurface.primary}"
           }
         },
         "iconCollapse": {
@@ -5552,8 +5552,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.glyph.onSurface.primary}"
           }
         },
         "iconTenant": {
@@ -5565,8 +5565,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.glyph.onSurface.primary}"
           }
         },
         "label": {
@@ -5579,8 +5579,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           }
         }
@@ -5597,8 +5597,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.background.surface.secondary}",
-                "deep_sky_itkontoret": "{colors.background.surface.secondary}"
+                "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+                "default": "{colors.background.surface.secondary}"
               }
             },
             "hover": {
@@ -5610,8 +5610,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.background.surface.active}",
-                "deep_sky_itkontoret": "{colors.background.surface.active}"
+                "deep_sky_itkontoret": "{colors.background.surface.active}",
+                "default": "{colors.background.surface.active}"
               }
             },
             "idle": {
@@ -5623,8 +5623,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.background.surface.active}",
-                "deep_sky_itkontoret": "{colors.background.surface.active}"
+                "deep_sky_itkontoret": "{colors.background.surface.active}",
+                "default": "{colors.background.surface.active}"
               }
             }
           }
@@ -5642,8 +5642,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.background.surface.secondary}",
-                "deep_sky_itkontoret": "{colors.background.surface.secondary}"
+                "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+                "default": "{colors.background.surface.secondary}"
               }
             },
             "hover": {
@@ -5655,8 +5655,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.background.surface.hover}",
-                "deep_sky_itkontoret": "{colors.background.surface.hover}"
+                "deep_sky_itkontoret": "{colors.background.surface.hover}",
+                "default": "{colors.background.surface.hover}"
               }
             },
             "idle": {
@@ -5668,8 +5668,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.background.surface.primary}",
-                "deep_sky_itkontoret": "{colors.background.surface.primary}"
+                "deep_sky_itkontoret": "{colors.background.surface.primary}",
+                "default": "{colors.background.surface.primary}"
               }
             }
           }
@@ -5687,8 +5687,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onSurface.border}",
-            "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+            "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+            "default": "{colors.border.onSurface.border}"
           }
         },
         "borderWidth": {
@@ -5700,8 +5700,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         },
         "paddingY": {
@@ -5713,8 +5713,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         }
       },
@@ -5728,8 +5728,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.12}",
-            "deep_sky_itkontoret": "{units.gap.12}"
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}"
           }
         },
         "paddingY": {
@@ -5741,8 +5741,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         }
       },
@@ -5756,8 +5756,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -5769,8 +5769,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.strong}",
-            "deep_sky_itkontoret": "{typography.body.strong}"
+            "deep_sky_itkontoret": "{typography.body.strong}",
+            "default": "{typography.body.strong}"
           }
         }
       },
@@ -5784,8 +5784,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         }
       }
@@ -5801,8 +5801,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.radius.4}",
-            "deep_sky_itkontoret": "{units.radius.4}"
+            "deep_sky_itkontoret": "{units.radius.4}",
+            "default": "{units.radius.4}"
           }
         },
         "borderWidth": {
@@ -5814,8 +5814,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         },
         "color": {
@@ -5828,8 +5828,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.secondary}",
-              "deep_sky_itkontoret": "{colors.background.surface.secondary}"
+              "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+              "default": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -5841,8 +5841,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.primary}",
-              "deep_sky_itkontoret": "{colors.background.surface.primary}"
+              "deep_sky_itkontoret": "{colors.background.surface.primary}",
+              "default": "{colors.background.surface.primary}"
             }
           },
           "idle": {
@@ -5854,8 +5854,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.primary}",
-              "deep_sky_itkontoret": "{colors.background.surface.primary}"
+              "deep_sky_itkontoret": "{colors.background.surface.primary}",
+              "default": "{colors.background.surface.primary}"
             }
           }
         },
@@ -5868,8 +5868,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.12}"
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.8}"
           }
         },
         "height": {
@@ -5881,8 +5881,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.32}",
-            "deep_sky_itkontoret": "{units.size.32}"
+            "deep_sky_itkontoret": "{units.size.32}",
+            "default": "{units.size.32}"
           }
         },
         "paddingX": {
@@ -5894,8 +5894,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.12}",
-            "deep_sky_itkontoret": "{units.gap.12}"
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}"
           }
         },
         "paddingY": {
@@ -5907,8 +5907,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.4}",
-            "deep_sky_itkontoret": "{units.gap.4}"
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}"
           }
         }
       },
@@ -5922,8 +5922,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.4}",
-            "deep_sky_itkontoret": "{units.gap.4}"
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}"
           }
         },
         "widthMin": {
@@ -5935,8 +5935,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.128}",
-            "deep_sky_itkontoret": "{units.size.128}"
+            "deep_sky_itkontoret": "{units.size.128}",
+            "default": "{units.size.128}"
           }
         }
       },
@@ -5950,8 +5950,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.4}",
-            "deep_sky_itkontoret": "{units.gap.4}"
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}"
           }
         }
       },
@@ -5966,8 +5966,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+              "default": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -5979,8 +5979,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           },
           "idle": {
@@ -5992,8 +5992,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           }
         },
@@ -6006,8 +6006,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.form-label}",
-            "deep_sky_itkontoret": "{typography.body.form-label}"
+            "deep_sky_itkontoret": "{typography.body.form-label}",
+            "default": "{typography.body.form-label}"
           }
         }
       },
@@ -6022,8 +6022,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+              "default": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -6035,8 +6035,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.secondary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}"
             }
           },
           "idle": {
@@ -6048,8 +6048,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.secondary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}"
             }
           }
         }
@@ -6064,8 +6064,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.destructive}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.destructive}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
+            "default": "{colors.text.onSurface.destructive}"
           }
         },
         "textStyle": {
@@ -6077,8 +6077,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.default}",
-            "deep_sky_itkontoret": "{typography.body.default}"
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}"
           }
         }
       },
@@ -6093,8 +6093,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+              "default": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -6106,8 +6106,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           },
           "idle": {
@@ -6119,8 +6119,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           }
         },
@@ -6133,8 +6133,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.default}",
-            "deep_sky_itkontoret": "{typography.body.default}"
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}"
           }
         }
       }
@@ -6151,8 +6151,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-error}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
+              "default": "{colors.border.onSurface.border-error}"
             }
           },
           "idle": {
@@ -6164,8 +6164,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-error}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
+              "default": "{colors.border.onSurface.border-error}"
             }
           }
         }
@@ -6180,8 +6180,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.destructive}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.destructive}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
+            "default": "{colors.text.onSurface.destructive}"
           }
         },
         "textStyle": {
@@ -6193,8 +6193,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.caption.default}",
-            "deep_sky_itkontoret": "{typography.caption.default}"
+            "deep_sky_itkontoret": "{typography.caption.default}",
+            "default": "{typography.caption.default}"
           }
         }
       },
@@ -6209,8 +6209,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.destructive}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.glyph.onSurface.destructive}"
             }
           },
           "idle": {
@@ -6222,8 +6222,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.destructive}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.glyph.onSurface.destructive}"
             }
           }
         }
@@ -6239,8 +6239,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
+              "default": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -6252,8 +6252,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.destructive}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.destructive}"
             }
           },
           "idle": {
@@ -6265,8 +6265,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.destructive}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.destructive}"
             }
           }
         }
@@ -6284,8 +6284,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}"
             }
           },
           "hover": {
@@ -6297,8 +6297,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-active}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -6310,8 +6310,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}"
             }
           }
         }
@@ -6327,8 +6327,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+              "default": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -6340,8 +6340,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.secondary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}"
             }
           },
           "idle": {
@@ -6353,8 +6353,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.secondary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}"
             }
           }
         },
@@ -6367,8 +6367,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.caption.default}",
-            "deep_sky_itkontoret": "{typography.caption.default}"
+            "deep_sky_itkontoret": "{typography.caption.default}",
+            "default": "{typography.caption.default}"
           }
         }
       },
@@ -6383,8 +6383,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+              "default": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -6396,8 +6396,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           },
           "idle": {
@@ -6409,8 +6409,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           }
         }
@@ -6426,8 +6426,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
+              "default": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -6439,8 +6439,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           },
           "idle": {
@@ -6452,8 +6452,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           }
         }
@@ -6472,8 +6472,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.radius.4}",
-            "deep_sky_itkontoret": "{units.radius.4}"
+            "deep_sky_itkontoret": "{units.radius.4}",
+            "default": "{units.radius.4}"
           }
         },
         "borderWidth": {
@@ -6485,8 +6485,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         },
         "color": {
@@ -6499,8 +6499,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.secondary}",
-              "deep_sky_itkontoret": "{colors.background.surface.secondary}"
+              "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+              "default": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -6512,8 +6512,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.primary}",
-              "deep_sky_itkontoret": "{colors.background.surface.primary}"
+              "deep_sky_itkontoret": "{colors.background.surface.primary}",
+              "default": "{colors.background.surface.primary}"
             }
           },
           "idle": {
@@ -6525,8 +6525,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.primary}",
-              "deep_sky_itkontoret": "{colors.background.surface.primary}"
+              "deep_sky_itkontoret": "{colors.background.surface.primary}",
+              "default": "{colors.background.surface.primary}"
             }
           }
         },
@@ -6539,8 +6539,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.12}",
-            "deep_sky_itkontoret": "{units.gap.12}"
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}"
           }
         },
         "height": {
@@ -6552,8 +6552,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.32}",
-            "deep_sky_itkontoret": "{units.size.32}"
+            "deep_sky_itkontoret": "{units.size.32}",
+            "default": "{units.size.32}"
           }
         },
         "paddingX": {
@@ -6565,8 +6565,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.12}",
-            "deep_sky_itkontoret": "{units.gap.12}"
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}"
           }
         },
         "paddingY": {
@@ -6578,8 +6578,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.4}",
-            "deep_sky_itkontoret": "{units.gap.4}"
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}"
           }
         }
       },
@@ -6593,8 +6593,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+            "default": "{colors.glyph.onSurface.primary}"
           }
         }
       },
@@ -6608,8 +6608,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.4}",
-            "deep_sky_itkontoret": "{units.gap.4}"
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}"
           }
         },
         "widthMin": {
@@ -6621,8 +6621,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.128}",
-            "deep_sky_itkontoret": "{units.size.128}"
+            "deep_sky_itkontoret": "{units.size.128}",
+            "default": "{units.size.128}"
           }
         }
       },
@@ -6636,8 +6636,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.4}",
-            "deep_sky_itkontoret": "{units.gap.4}"
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}"
           }
         }
       },
@@ -6652,8 +6652,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+              "default": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -6665,8 +6665,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           },
           "idle": {
@@ -6678,8 +6678,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           }
         },
@@ -6692,8 +6692,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.form-label}",
-            "deep_sky_itkontoret": "{typography.body.form-label}"
+            "deep_sky_itkontoret": "{typography.body.form-label}",
+            "default": "{typography.body.form-label}"
           }
         }
       },
@@ -6708,8 +6708,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -6721,8 +6721,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.secondary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}"
             }
           },
           "idle": {
@@ -6734,8 +6734,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.secondary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}"
             }
           }
         }
@@ -6750,8 +6750,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.destructive}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.destructive}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
+            "default": "{colors.text.onSurface.destructive}"
           }
         },
         "textStyle": {
@@ -6763,8 +6763,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.default}",
-            "deep_sky_itkontoret": "{typography.body.default}"
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}"
           }
         }
       },
@@ -6779,8 +6779,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+              "default": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -6792,8 +6792,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           },
           "idle": {
@@ -6805,8 +6805,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           }
         },
@@ -6819,8 +6819,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.default}",
-            "deep_sky_itkontoret": "{typography.body.default}"
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}"
           }
         }
       }
@@ -6837,8 +6837,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-error}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
+              "default": "{colors.border.onSurface.border-error}"
             }
           },
           "idle": {
@@ -6850,8 +6850,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-error}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
+              "default": "{colors.border.onSurface.border-error}"
             }
           }
         }
@@ -6866,8 +6866,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.destructive}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.destructive}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
+            "default": "{colors.text.onSurface.destructive}"
           }
         },
         "textStyle": {
@@ -6879,8 +6879,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.caption.default}",
-            "deep_sky_itkontoret": "{typography.caption.default}"
+            "deep_sky_itkontoret": "{typography.caption.default}",
+            "default": "{typography.caption.default}"
           }
         }
       }
@@ -6897,8 +6897,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}"
             }
           },
           "hover": {
@@ -6910,8 +6910,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-active}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -6923,8 +6923,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}"
             }
           }
         }
@@ -6940,8 +6940,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+              "default": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -6953,8 +6953,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.secondary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}"
             }
           },
           "idle": {
@@ -6966,8 +6966,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.secondary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}"
             }
           }
         },
@@ -6980,8 +6980,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.caption.default}",
-            "deep_sky_itkontoret": "{typography.caption.default}"
+            "deep_sky_itkontoret": "{typography.caption.default}",
+            "default": "{typography.caption.default}"
           }
         }
       }
@@ -6998,8 +6998,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.border.onSurface.border}",
-          "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+          "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+          "default": "{colors.border.onSurface.border}"
         }
       },
       "focus": {
@@ -7011,8 +7011,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.border.onSurface.border-active}",
-          "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+          "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+          "default": "{colors.border.onSurface.border-active}"
         }
       },
       "hover": {
@@ -7024,8 +7024,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.border.onSurface.border-active}",
-          "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+          "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+          "default": "{colors.border.onSurface.border-active}"
         }
       },
       "idle": {
@@ -7037,8 +7037,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.border.onSurface.border}",
-          "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+          "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+          "default": "{colors.border.onSurface.border}"
         }
       }
     },
@@ -7052,8 +7052,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.radius.4}",
-          "deep_sky_itkontoret": "{units.radius.4}"
+          "deep_sky_itkontoret": "{units.radius.4}",
+          "default": "{units.radius.4}"
         }
       },
       "borderWidth": {
@@ -7065,8 +7065,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.stroke.1}",
-          "deep_sky_itkontoret": "{units.stroke.1}"
+          "deep_sky_itkontoret": "{units.stroke.1}",
+          "default": "{units.stroke.1}"
         }
       },
       "color": {
@@ -7079,8 +7079,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.surface.secondary}",
-            "deep_sky_itkontoret": "{colors.background.surface.secondary}"
+            "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+            "default": "{colors.background.surface.secondary}"
           }
         },
         "hover": {
@@ -7092,8 +7092,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.surface.primary}",
-            "deep_sky_itkontoret": "{colors.background.surface.primary}"
+            "deep_sky_itkontoret": "{colors.background.surface.primary}",
+            "default": "{colors.background.surface.primary}"
           }
         },
         "idle": {
@@ -7105,8 +7105,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.surface.primary}",
-            "deep_sky_itkontoret": "{colors.background.surface.primary}"
+            "deep_sky_itkontoret": "{colors.background.surface.primary}",
+            "default": "{colors.background.surface.primary}"
           }
         }
       },
@@ -7119,8 +7119,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.12}",
-          "deep_sky_itkontoret": "{units.gap.12}"
+          "deep_sky_itkontoret": "{units.gap.12}",
+          "default": "{units.gap.12}"
         }
       },
       "heightMin": {
@@ -7132,8 +7132,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.size.96}",
-          "deep_sky_itkontoret": "{units.size.96}"
+          "deep_sky_itkontoret": "{units.size.96}",
+          "default": "{units.size.96}"
         }
       },
       "paddingX": {
@@ -7145,8 +7145,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.12}",
-          "deep_sky_itkontoret": "{units.gap.12}"
+          "deep_sky_itkontoret": "{units.gap.12}",
+          "default": "{units.gap.12}"
         }
       },
       "paddingY": {
@@ -7158,8 +7158,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.8}",
-          "deep_sky_itkontoret": "{units.gap.8}"
+          "deep_sky_itkontoret": "{units.gap.8}",
+          "default": "{units.gap.8}"
         }
       }
     },
@@ -7173,8 +7173,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.4}",
-          "deep_sky_itkontoret": "{units.gap.4}"
+          "deep_sky_itkontoret": "{units.gap.4}",
+          "default": "{units.gap.4}"
         }
       },
       "widthMin": {
@@ -7186,8 +7186,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.size.256}",
-          "deep_sky_itkontoret": "{units.size.256}"
+          "deep_sky_itkontoret": "{units.size.256}",
+          "default": "{units.size.256}"
         }
       }
     },
@@ -7201,8 +7201,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.4}",
-          "deep_sky_itkontoret": "{units.gap.4}"
+          "deep_sky_itkontoret": "{units.gap.4}",
+          "default": "{units.gap.4}"
         }
       }
     },
@@ -7217,8 +7217,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.disabled}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+            "default": "{colors.text.onSurface.disabled}"
           }
         },
         "hover": {
@@ -7230,8 +7230,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.secondary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+            "default": "{colors.text.onSurface.secondary}"
           }
         },
         "idle": {
@@ -7243,8 +7243,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.secondary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+            "default": "{colors.text.onSurface.secondary}"
           }
         }
       },
@@ -7257,8 +7257,8 @@
         "$type": "typography",
         "platforms": ["PD"],
         "values": {
-          "default": "{typography.caption.default}",
-          "deep_sky_itkontoret": "{typography.caption.default}"
+          "deep_sky_itkontoret": "{typography.caption.default}",
+          "default": "{typography.caption.default}"
         }
       }
     },
@@ -7273,8 +7273,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-error}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
+              "default": "{colors.border.onSurface.border-error}"
             }
           },
           "idle": {
@@ -7285,8 +7285,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-error}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
+              "default": "{colors.border.onSurface.border-error}"
             }
           }
         }
@@ -7300,8 +7300,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.destructive}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.destructive}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
+            "default": "{colors.text.onSurface.destructive}"
           }
         },
         "textStyle": {
@@ -7312,8 +7312,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.caption.default}",
-            "deep_sky_itkontoret": "{typography.caption.default}"
+            "deep_sky_itkontoret": "{typography.caption.default}",
+            "default": "{typography.caption.default}"
           }
         }
       }
@@ -7329,8 +7329,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.disabled}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+            "default": "{colors.text.onSurface.disabled}"
           }
         },
         "hover": {
@@ -7342,8 +7342,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}"
           }
         },
         "idle": {
@@ -7355,8 +7355,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}"
           }
         }
       },
@@ -7369,8 +7369,8 @@
         "$type": "typography",
         "platforms": ["PD"],
         "values": {
-          "default": "{typography.body.form-label}",
-          "deep_sky_itkontoret": "{typography.body.form-label}"
+          "deep_sky_itkontoret": "{typography.body.form-label}",
+          "default": "{typography.body.form-label}"
         }
       }
     },
@@ -7385,8 +7385,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.disabled}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+            "default": "{colors.text.onSurface.disabled}"
           }
         },
         "hover": {
@@ -7398,8 +7398,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.secondary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+            "default": "{colors.text.onSurface.secondary}"
           }
         },
         "idle": {
@@ -7411,8 +7411,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.secondary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+            "default": "{colors.text.onSurface.secondary}"
           }
         }
       },
@@ -7425,8 +7425,8 @@
         "$type": "typography",
         "platforms": ["PD"],
         "values": {
-          "default": "{typography.body.default}",
-          "deep_sky_itkontoret": "{typography.body.default}"
+          "deep_sky_itkontoret": "{typography.body.default}",
+          "default": "{typography.body.default}"
         }
       }
     },
@@ -7440,8 +7440,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.text.onSurface.destructive}",
-          "deep_sky_itkontoret": "{colors.text.onSurface.destructive}"
+          "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
+          "default": "{colors.text.onSurface.destructive}"
         }
       },
       "textStyle": {
@@ -7453,8 +7453,8 @@
         "$type": "typography",
         "platforms": ["PD"],
         "values": {
-          "default": "{typography.body.default}",
-          "deep_sky_itkontoret": "{typography.body.default}"
+          "deep_sky_itkontoret": "{typography.body.default}",
+          "default": "{typography.body.default}"
         }
       }
     },
@@ -7469,8 +7469,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.disabled}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+            "default": "{colors.text.onSurface.disabled}"
           }
         },
         "hover": {
@@ -7482,8 +7482,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}"
           }
         },
         "idle": {
@@ -7495,8 +7495,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}"
           }
         }
       },
@@ -7509,8 +7509,8 @@
         "$type": "typography",
         "platforms": ["PD"],
         "values": {
-          "default": "{typography.body.default}",
-          "deep_sky_itkontoret": "{typography.body.default}"
+          "deep_sky_itkontoret": "{typography.body.default}",
+          "default": "{typography.body.default}"
         }
       }
     }
@@ -7525,8 +7525,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.text.onSurface.link-pressed}",
-          "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}"
+          "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
+          "default": "{colors.text.onSurface.link-pressed}"
         }
       },
       "disabled": {
@@ -7537,8 +7537,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.text.onSurface.link-disabled}",
-          "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}"
+          "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
+          "default": "{colors.text.onSurface.link-disabled}"
         }
       },
       "hover": {
@@ -7549,8 +7549,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.text.onSurface.link-hover}",
-          "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}"
+          "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
+          "default": "{colors.text.onSurface.link-hover}"
         }
       },
       "idle": {
@@ -7561,8 +7561,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.text.onSurface.link}",
-          "deep_sky_itkontoret": "{colors.text.onSurface.link}"
+          "deep_sky_itkontoret": "{colors.text.onSurface.link}",
+          "default": "{colors.text.onSurface.link}"
         }
       }
     },
@@ -7575,8 +7575,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.4}",
-          "deep_sky_itkontoret": "{units.gap.4}"
+          "deep_sky_itkontoret": "{units.gap.4}",
+          "default": "{units.gap.4}"
         }
       },
       "height": {
@@ -7587,8 +7587,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.size.32}",
-          "deep_sky_itkontoret": "{units.size.32}"
+          "deep_sky_itkontoret": "{units.size.32}",
+          "default": "{units.size.32}"
         }
       }
     },
@@ -7602,8 +7602,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.link-pressed}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
+            "default": "{colors.text.onSurface.link-pressed}"
           }
         },
         "disabled": {
@@ -7614,8 +7614,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.link-disabled}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
+            "default": "{colors.text.onSurface.link-disabled}"
           }
         },
         "hover": {
@@ -7626,8 +7626,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.link-hover}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
+            "default": "{colors.text.onSurface.link-hover}"
           }
         },
         "idle": {
@@ -7638,8 +7638,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.link}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.link}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.link}",
+            "default": "{colors.text.onSurface.link}"
           }
         }
       }
@@ -7653,8 +7653,8 @@
         "$type": "string",
         "platforms": ["PD"],
         "values": {
-          "default": "none",
-          "deep_sky_itkontoret": "none"
+          "deep_sky_itkontoret": "none",
+          "default": "none"
         }
       },
       "disabled": {
@@ -7665,8 +7665,8 @@
         "$type": "string",
         "platforms": ["PD"],
         "values": {
-          "default": "none",
-          "deep_sky_itkontoret": "none"
+          "deep_sky_itkontoret": "none",
+          "default": "none"
         }
       },
       "hover": {
@@ -7677,8 +7677,8 @@
         "$type": "string",
         "platforms": ["PD"],
         "values": {
-          "default": "underline",
-          "deep_sky_itkontoret": "underline"
+          "deep_sky_itkontoret": "underline",
+          "default": "underline"
         }
       },
       "idle": {
@@ -7689,8 +7689,8 @@
         "$type": "string",
         "platforms": ["PD"],
         "values": {
-          "default": "none",
-          "deep_sky_itkontoret": "none"
+          "deep_sky_itkontoret": "none",
+          "default": "none"
         }
       }
     },
@@ -7703,8 +7703,8 @@
         "$type": "typography",
         "platforms": ["PD"],
         "values": {
-          "default": "{typography.link.strong}",
-          "deep_sky_itkontoret": "{typography.link.strong}"
+          "deep_sky_itkontoret": "{typography.link.strong}",
+          "default": "{typography.link.strong}"
         }
       },
       "disabled": {
@@ -7715,8 +7715,8 @@
         "$type": "typography",
         "platforms": ["PD"],
         "values": {
-          "default": "{typography.link.strong}",
-          "deep_sky_itkontoret": "{typography.link.strong}"
+          "deep_sky_itkontoret": "{typography.link.strong}",
+          "default": "{typography.link.strong}"
         }
       },
       "hover": {
@@ -7727,8 +7727,8 @@
         "$type": "typography",
         "platforms": ["PD"],
         "values": {
-          "default": "{typography.link.strong-underline}",
-          "deep_sky_itkontoret": "{typography.link.strong-underline}"
+          "deep_sky_itkontoret": "{typography.link.strong-underline}",
+          "default": "{typography.link.strong-underline}"
         }
       },
       "idle": {
@@ -7739,8 +7739,8 @@
         "$type": "typography",
         "platforms": ["PD"],
         "values": {
-          "default": "{typography.link.strong}",
-          "deep_sky_itkontoret": "{typography.link.strong}"
+          "deep_sky_itkontoret": "{typography.link.strong}",
+          "default": "{typography.link.strong}"
         }
       }
     }
@@ -7757,8 +7757,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.radius.999}",
-            "deep_sky_itkontoret": "{units.radius.999}"
+            "deep_sky_itkontoret": "{units.radius.999}",
+            "default": "{units.radius.999}"
           }
         },
         "borderWidth": {
@@ -7770,8 +7770,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         },
         "marginX": {
@@ -7783,8 +7783,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.4}",
-            "deep_sky_itkontoret": "{units.gap.4}"
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}"
           }
         },
         "size": {
@@ -7796,8 +7796,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.16}",
-            "deep_sky_itkontoret": "{units.size.16}"
+            "deep_sky_itkontoret": "{units.size.16}",
+            "default": "{units.size.16}"
           }
         }
       },
@@ -7811,8 +7811,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         },
         "widthMax": {
@@ -7824,8 +7824,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.632}",
-            "deep_sky_itkontoret": "{units.size.632}"
+            "deep_sky_itkontoret": "{units.size.632}",
+            "default": "{units.size.632}"
           }
         },
         "widthMin": {
@@ -7837,8 +7837,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.16}",
-            "deep_sky_itkontoret": "{units.size.16}"
+            "deep_sky_itkontoret": "{units.size.16}",
+            "default": "{units.size.16}"
           }
         }
       },
@@ -7852,8 +7852,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         },
         "widthMax": {
@@ -7865,8 +7865,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.632}",
-            "deep_sky_itkontoret": "{units.size.632}"
+            "deep_sky_itkontoret": "{units.size.632}",
+            "default": "{units.size.632}"
           }
         }
       },
@@ -7880,8 +7880,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.secondary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+            "default": "{colors.text.onSurface.secondary}"
           }
         },
         "textStyle": {
@@ -7893,8 +7893,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.default}",
-            "deep_sky_itkontoret": "{typography.body.default}"
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}"
           }
         }
       },
@@ -7908,8 +7908,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -7921,8 +7921,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.default}",
-            "deep_sky_itkontoret": "{typography.body.default}"
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}"
           }
         }
       }
@@ -7939,8 +7939,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-active}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}"
             }
           },
           "disabled": {
@@ -7952,8 +7952,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}"
             }
           },
           "hover": {
@@ -7965,8 +7965,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-active}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -7978,8 +7978,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-active}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}"
             }
           }
         },
@@ -7993,8 +7993,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.brand.secondary-active}",
-              "deep_sky_itkontoret": "{colors.background.brand.secondary-active}"
+              "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
+              "default": "{colors.background.brand.secondary-active}"
             }
           },
           "disabled": {
@@ -8006,8 +8006,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.secondary}",
-              "deep_sky_itkontoret": "{colors.background.surface.secondary}"
+              "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+              "default": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -8019,8 +8019,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.brand.secondary-hover}",
-              "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}"
+              "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
+              "default": "{colors.background.brand.secondary-hover}"
             }
           },
           "idle": {
@@ -8032,8 +8032,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.brand.secondary}",
-              "deep_sky_itkontoret": "{colors.background.brand.secondary}"
+              "deep_sky_itkontoret": "{colors.background.brand.secondary}",
+              "default": "{colors.background.brand.secondary}"
             }
           }
         }
@@ -8049,8 +8049,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           },
           "disabled": {
@@ -8062,8 +8062,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
+              "default": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -8075,8 +8075,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           },
           "idle": {
@@ -8088,8 +8088,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+              "default": "{colors.glyph.onBrand.primary}"
             }
           }
         }
@@ -8107,8 +8107,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-active}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}"
             }
           },
           "disabled": {
@@ -8120,8 +8120,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.divider}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.divider}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.divider}",
+              "default": "{colors.border.onSurface.divider}"
             }
           },
           "hover": {
@@ -8133,8 +8133,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border-active}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -8146,8 +8146,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}"
             }
           }
         },
@@ -8161,8 +8161,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.active}",
-              "deep_sky_itkontoret": "{colors.background.surface.active}"
+              "deep_sky_itkontoret": "{colors.background.surface.active}",
+              "default": "{colors.background.surface.active}"
             }
           },
           "disabled": {
@@ -8174,8 +8174,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.secondary}",
-              "deep_sky_itkontoret": "{colors.background.surface.secondary}"
+              "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+              "default": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -8187,8 +8187,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.hover}",
-              "deep_sky_itkontoret": "{colors.background.surface.hover}"
+              "deep_sky_itkontoret": "{colors.background.surface.hover}",
+              "default": "{colors.background.surface.hover}"
             }
           },
           "idle": {
@@ -8200,8 +8200,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.primary}",
-              "deep_sky_itkontoret": "{colors.background.surface.primary}"
+              "deep_sky_itkontoret": "{colors.background.surface.primary}",
+              "default": "{colors.background.surface.primary}"
             }
           }
         }
@@ -8219,8 +8219,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.radius.4}",
-          "deep_sky_itkontoret": "{units.radius.4}"
+          "deep_sky_itkontoret": "{units.radius.4}",
+          "default": "{units.radius.4}"
         }
       },
       "color": {
@@ -8232,8 +8232,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.background.brand.secondary}",
-          "deep_sky_itkontoret": "{colors.background.brand.secondary}"
+          "deep_sky_itkontoret": "{colors.background.brand.secondary}",
+          "default": "{colors.background.brand.secondary}"
         }
       },
       "height": {
@@ -8245,8 +8245,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.size.32}",
-          "deep_sky_itkontoret": "{units.size.32}"
+          "deep_sky_itkontoret": "{units.size.32}",
+          "default": "{units.size.32}"
         }
       },
       "width": {
@@ -8258,8 +8258,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.size.7}",
-          "deep_sky_itkontoret": "{units.size.7}"
+          "deep_sky_itkontoret": "{units.size.7}",
+          "default": "{units.size.7}"
         }
       }
     },
@@ -8274,8 +8274,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onSurface.border-active}",
-            "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+            "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+            "default": "{colors.border.onSurface.border-active}"
           }
         },
         "hover": {
@@ -8287,8 +8287,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onSurface.border-active}",
-            "deep_sky_itkontoret": "{colors.border.onSurface.border-active}"
+            "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+            "default": "{colors.border.onSurface.border-active}"
           }
         }
       },
@@ -8301,8 +8301,8 @@
         "$type": "string",
         "platforms": ["PD"],
         "values": {
-          "default": "solid",
-          "deep_sky_itkontoret": "solid"
+          "deep_sky_itkontoret": "solid",
+          "default": "solid"
         }
       },
       "width": {
@@ -8314,8 +8314,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.stroke.1}",
-          "deep_sky_itkontoret": "{units.stroke.1}"
+          "deep_sky_itkontoret": "{units.stroke.1}",
+          "default": "{units.stroke.1}"
         }
       }
     },
@@ -8328,8 +8328,8 @@
       "$type": "string",
       "platforms": ["PD"],
       "values": {
-        "default": "ew-resize",
-        "deep_sky_itkontoret": "ew-resize"
+        "deep_sky_itkontoret": "ew-resize",
+        "default": "ew-resize"
       }
     }
   },
@@ -8344,8 +8344,8 @@
         "$type": "string",
         "platforms": ["PD"],
         "values": {
-          "default": "{gradients.ai.active}",
-          "deep_sky_itkontoret": "{gradients.ai.active}"
+          "deep_sky_itkontoret": "{gradients.ai.active}",
+          "default": "{gradients.ai.active}"
         }
       },
       "hover": {
@@ -8357,8 +8357,8 @@
         "$type": "string",
         "platforms": ["PD"],
         "values": {
-          "default": "{gradients.ai.hover}",
-          "deep_sky_itkontoret": "{gradients.ai.hover}"
+          "deep_sky_itkontoret": "{gradients.ai.hover}",
+          "default": "{gradients.ai.hover}"
         }
       },
       "idle": {
@@ -8370,8 +8370,8 @@
         "$type": "string",
         "platforms": ["PD"],
         "values": {
-          "default": "{gradients.ai.idle}",
-          "deep_sky_itkontoret": "{gradients.ai.idle}"
+          "deep_sky_itkontoret": "{gradients.ai.idle}",
+          "default": "{gradients.ai.idle}"
         }
       }
     },
@@ -8385,8 +8385,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.radius.24}",
-          "deep_sky_itkontoret": "{units.radius.24}"
+          "deep_sky_itkontoret": "{units.radius.24}",
+          "default": "{units.radius.24}"
         }
       },
       "borderStyle": {
@@ -8398,8 +8398,8 @@
         "$type": "string",
         "platforms": ["PD"],
         "values": {
-          "default": "solid",
-          "deep_sky_itkontoret": "solid"
+          "deep_sky_itkontoret": "solid",
+          "default": "solid"
         }
       },
       "borderWidth": {
@@ -8411,8 +8411,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.stroke.2}",
-          "deep_sky_itkontoret": "{units.stroke.2}"
+          "deep_sky_itkontoret": "{units.stroke.2}",
+          "default": "{units.stroke.2}"
         }
       },
       "color": {
@@ -8424,8 +8424,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.background.surface.primary}",
-          "deep_sky_itkontoret": "{colors.background.surface.primary}"
+          "deep_sky_itkontoret": "{colors.background.surface.primary}",
+          "default": "{colors.background.surface.primary}"
         }
       },
       "gap": {
@@ -8437,8 +8437,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.8}",
-          "deep_sky_itkontoret": "{units.gap.8}"
+          "deep_sky_itkontoret": "{units.gap.8}",
+          "default": "{units.gap.8}"
         }
       },
       "height": {
@@ -8450,8 +8450,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.size.48}",
-          "deep_sky_itkontoret": "{units.size.48}"
+          "deep_sky_itkontoret": "{units.size.48}",
+          "default": "{units.size.48}"
         }
       },
       "paddingX": {
@@ -8463,8 +8463,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.16}",
-          "deep_sky_itkontoret": "{units.gap.16}"
+          "deep_sky_itkontoret": "{units.gap.16}",
+          "default": "{units.gap.16}"
         }
       },
       "width": {
@@ -8476,8 +8476,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.size.512}",
-          "deep_sky_itkontoret": "{units.size.512}"
+          "deep_sky_itkontoret": "{units.size.512}",
+          "default": "{units.size.512}"
         }
       },
       "widthMax": {
@@ -8489,8 +8489,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.size.512}",
-          "deep_sky_itkontoret": "{units.size.512}"
+          "deep_sky_itkontoret": "{units.size.512}",
+          "default": "{units.size.512}"
         }
       },
       "widthMin": {
@@ -8502,8 +8502,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.size.256}",
-          "deep_sky_itkontoret": "{units.size.256}"
+          "deep_sky_itkontoret": "{units.size.256}",
+          "default": "{units.size.256}"
         }
       }
     },
@@ -8517,8 +8517,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.glyph.onStatus.ai}",
-          "deep_sky_itkontoret": "{colors.glyph.onStatus.ai}"
+          "deep_sky_itkontoret": "{colors.glyph.onStatus.ai}",
+          "default": "{colors.glyph.onStatus.ai}"
         }
       },
       "size": {
@@ -8530,8 +8530,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.size.16}",
-          "deep_sky_itkontoret": "{units.size.16}"
+          "deep_sky_itkontoret": "{units.size.16}",
+          "default": "{units.size.16}"
         }
       }
     },
@@ -8545,8 +8545,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.text.onStatus.ai}",
-          "deep_sky_itkontoret": "{colors.text.onStatus.ai}"
+          "deep_sky_itkontoret": "{colors.text.onStatus.ai}",
+          "default": "{colors.text.onStatus.ai}"
         }
       },
       "textStyle": {
@@ -8558,8 +8558,8 @@
         "$type": "typography",
         "platforms": ["PD"],
         "values": {
-          "default": "{typography.body.default}",
-          "deep_sky_itkontoret": "{typography.body.default}"
+          "deep_sky_itkontoret": "{typography.body.default}",
+          "default": "{typography.body.default}"
         }
       }
     },
@@ -8573,8 +8573,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.text.onSurface.secondary}",
-          "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+          "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+          "default": "{colors.text.onSurface.secondary}"
         }
       },
       "textStyle": {
@@ -8586,8 +8586,8 @@
         "$type": "typography",
         "platforms": ["PD"],
         "values": {
-          "default": "{typography.body.default}",
-          "deep_sky_itkontoret": "{typography.body.default}"
+          "deep_sky_itkontoret": "{typography.body.default}",
+          "default": "{typography.body.default}"
         }
       }
     }
@@ -8605,8 +8605,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.gap.8}",
-              "deep_sky_itkontoret": "{units.gap.8}"
+              "deep_sky_itkontoret": "{units.gap.8}",
+              "default": "{units.gap.8}"
             }
           },
           "height": {
@@ -8618,8 +8618,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.size.40}",
-              "deep_sky_itkontoret": "{units.size.40}"
+              "deep_sky_itkontoret": "{units.size.40}",
+              "default": "{units.size.40}"
             }
           },
           "paddingX": {
@@ -8631,8 +8631,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.gap.16}",
-              "deep_sky_itkontoret": "{units.gap.16}"
+              "deep_sky_itkontoret": "{units.gap.16}",
+              "default": "{units.gap.16}"
             }
           },
           "paddingY": {
@@ -8644,8 +8644,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.gap.8}",
-              "deep_sky_itkontoret": "{units.gap.8}"
+              "deep_sky_itkontoret": "{units.gap.8}",
+              "default": "{units.gap.8}"
             }
           }
         },
@@ -8659,8 +8659,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.gap.4}",
-              "deep_sky_itkontoret": "{units.gap.4}"
+              "deep_sky_itkontoret": "{units.gap.4}",
+              "default": "{units.gap.4}"
             }
           },
           "size": {
@@ -8672,8 +8672,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.size.16}",
-              "deep_sky_itkontoret": "{units.size.16}"
+              "deep_sky_itkontoret": "{units.size.16}",
+              "default": "{units.size.16}"
             }
           }
         },
@@ -8687,8 +8687,8 @@
             "$type": "typography",
             "platforms": ["PD"],
             "values": {
-              "default": "{typography.body.strong}",
-              "deep_sky_itkontoret": "{typography.body.strong}"
+              "deep_sky_itkontoret": "{typography.body.strong}",
+              "default": "{typography.body.strong}"
             }
           }
         }
@@ -8705,8 +8705,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.background.brand.primary-active}",
-                "deep_sky_itkontoret": "{colors.background.brand.primary-active}"
+                "deep_sky_itkontoret": "{colors.background.brand.primary-active}",
+                "default": "{colors.background.brand.primary-active}"
               }
             },
             "hover": {
@@ -8718,8 +8718,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.background.brand.primary-active}",
-                "deep_sky_itkontoret": "{colors.background.brand.primary-active}"
+                "deep_sky_itkontoret": "{colors.background.brand.primary-active}",
+                "default": "{colors.background.brand.primary-active}"
               }
             },
             "idle": {
@@ -8731,8 +8731,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.background.brand.primary-active}",
-                "deep_sky_itkontoret": "{colors.background.brand.primary-active}"
+                "deep_sky_itkontoret": "{colors.background.brand.primary-active}",
+                "default": "{colors.background.brand.primary-active}"
               }
             }
           }
@@ -8748,8 +8748,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.glyph.onBrand.primary}",
-                "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+                "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+                "default": "{colors.glyph.onBrand.primary}"
               }
             },
             "hover": {
@@ -8761,8 +8761,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.glyph.onBrand.primary}",
-                "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+                "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+                "default": "{colors.glyph.onBrand.primary}"
               }
             },
             "idle": {
@@ -8774,8 +8774,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.glyph.onBrand.primary}",
-                "deep_sky_itkontoret": "{colors.glyph.onBrand.secondary}"
+                "deep_sky_itkontoret": "{colors.glyph.onBrand.secondary}",
+                "default": "{colors.glyph.onBrand.primary}"
               }
             }
           }
@@ -8791,8 +8791,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.text.onBrand.primary}",
-                "deep_sky_itkontoret": "{colors.text.onBrand.primary}"
+                "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
+                "default": "{colors.text.onBrand.primary}"
               }
             },
             "hover": {
@@ -8804,8 +8804,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.text.onBrand.primary}",
-                "deep_sky_itkontoret": "{colors.text.onBrand.primary}"
+                "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
+                "default": "{colors.text.onBrand.primary}"
               }
             },
             "idle": {
@@ -8817,8 +8817,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.text.onBrand.primary}",
-                "deep_sky_itkontoret": "{colors.text.onBrand.primary}"
+                "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
+                "default": "{colors.text.onBrand.primary}"
               }
             }
           }
@@ -8836,8 +8836,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.background.brand.primary-hover}",
-                "deep_sky_itkontoret": "{colors.background.brand.primary-hover}"
+                "deep_sky_itkontoret": "{colors.background.brand.primary-hover}",
+                "default": "{colors.background.brand.primary-hover}"
               }
             },
             "hover": {
@@ -8849,8 +8849,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.background.brand.primary-hover}",
-                "deep_sky_itkontoret": "{colors.background.brand.primary-hover}"
+                "deep_sky_itkontoret": "{colors.background.brand.primary-hover}",
+                "default": "{colors.background.brand.primary-hover}"
               }
             },
             "idle": {
@@ -8862,8 +8862,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.background.brand.primary}",
-                "deep_sky_itkontoret": "{colors.background.brand.primary}"
+                "deep_sky_itkontoret": "{colors.background.brand.primary}",
+                "default": "{colors.background.brand.primary}"
               }
             }
           }
@@ -8879,8 +8879,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.glyph.onBrand.primary}",
-                "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+                "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+                "default": "{colors.glyph.onBrand.primary}"
               }
             },
             "hover": {
@@ -8892,8 +8892,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.glyph.onBrand.primary}",
-                "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+                "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+                "default": "{colors.glyph.onBrand.primary}"
               }
             },
             "idle": {
@@ -8905,8 +8905,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.glyph.onBrand.secondary}",
-                "deep_sky_itkontoret": "{colors.glyph.onBrand.secondary}"
+                "deep_sky_itkontoret": "{colors.glyph.onBrand.secondary}",
+                "default": "{colors.glyph.onBrand.secondary}"
               }
             }
           }
@@ -8922,8 +8922,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.text.onBrand.primary}",
-                "deep_sky_itkontoret": "{colors.text.onBrand.primary}"
+                "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
+                "default": "{colors.text.onBrand.primary}"
               }
             },
             "hover": {
@@ -8935,8 +8935,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.text.onBrand.primary}",
-                "deep_sky_itkontoret": "{colors.text.onBrand.primary}"
+                "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
+                "default": "{colors.text.onBrand.primary}"
               }
             },
             "idle": {
@@ -8948,8 +8948,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.text.onBrand.secondary}",
-                "deep_sky_itkontoret": "{colors.text.onBrand.secondary}"
+                "deep_sky_itkontoret": "{colors.text.onBrand.secondary}",
+                "default": "{colors.text.onBrand.secondary}"
               }
             }
           }
@@ -8968,8 +8968,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.gap.8}",
-              "deep_sky_itkontoret": "{units.gap.8}"
+              "deep_sky_itkontoret": "{units.gap.8}",
+              "default": "{units.gap.8}"
             }
           }
         },
@@ -8983,8 +8983,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onBrand.secondary}",
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.secondary}"
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.secondary}",
+              "default": "{colors.glyph.onBrand.secondary}"
             }
           },
           "size": {
@@ -8996,8 +8996,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.size.16}",
-              "deep_sky_itkontoret": "{units.size.16}"
+              "deep_sky_itkontoret": "{units.size.16}",
+              "default": "{units.size.16}"
             }
           }
         },
@@ -9011,8 +9011,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onBrand.secondary}",
-              "deep_sky_itkontoret": "{colors.text.onBrand.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onBrand.secondary}",
+              "default": "{colors.text.onBrand.secondary}"
             }
           },
           "textStyle": {
@@ -9024,8 +9024,8 @@
             "$type": "typography",
             "platforms": ["PD"],
             "values": {
-              "default": "{typography.body.default}",
-              "deep_sky_itkontoret": "{typography.body.default}"
+              "deep_sky_itkontoret": "{typography.body.default}",
+              "default": "{typography.body.default}"
             }
           }
         }
@@ -9042,8 +9042,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         }
       },
@@ -9057,8 +9057,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onBrand.border}",
-            "deep_sky_itkontoret": "{colors.border.onBrand.border}"
+            "deep_sky_itkontoret": "{colors.border.onBrand.border}",
+            "default": "{colors.border.onBrand.border}"
           }
         },
         "borderWidth": {
@@ -9070,8 +9070,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         },
         "paddingY": {
@@ -9083,8 +9083,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         }
       }
@@ -9100,8 +9100,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.brand.primary}",
-            "deep_sky_itkontoret": "{colors.background.brand.primary}"
+            "deep_sky_itkontoret": "{colors.background.brand.primary}",
+            "default": "{colors.background.brand.primary}"
           }
         }
       },
@@ -9115,8 +9115,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onBrand.border}",
-            "deep_sky_itkontoret": "{colors.border.onBrand.border}"
+            "deep_sky_itkontoret": "{colors.border.onBrand.border}",
+            "default": "{colors.border.onBrand.border}"
           }
         },
         "borderWidth": {
@@ -9128,8 +9128,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         }
       },
@@ -9143,8 +9143,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         }
       },
@@ -9158,8 +9158,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onBrand.primary}",
-            "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}"
+            "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+            "default": "{colors.glyph.onBrand.primary}"
           }
         }
       },
@@ -9173,8 +9173,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         }
       }
@@ -9190,8 +9190,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.48}",
-            "deep_sky_itkontoret": "{units.size.48}"
+            "deep_sky_itkontoret": "{units.size.48}",
+            "default": "{units.size.48}"
           }
         }
       },
@@ -9205,8 +9205,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         },
         "paddingY": {
@@ -9218,8 +9218,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.16}",
-            "deep_sky_itkontoret": "{units.gap.16}"
+            "deep_sky_itkontoret": "{units.gap.16}",
+            "default": "{units.gap.16}"
           }
         }
       },
@@ -9233,8 +9233,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.32}",
-            "deep_sky_itkontoret": "{units.size.32}"
+            "deep_sky_itkontoret": "{units.size.32}",
+            "default": "{units.size.32}"
           }
         }
       }
@@ -9250,8 +9250,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.256}",
-            "deep_sky_itkontoret": "{units.size.256}"
+            "deep_sky_itkontoret": "{units.size.256}",
+            "default": "{units.size.256}"
           }
         }
       },
@@ -9265,8 +9265,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.16}",
-            "deep_sky_itkontoret": "{units.gap.16}"
+            "deep_sky_itkontoret": "{units.gap.16}",
+            "default": "{units.gap.16}"
           }
         },
         "paddingY": {
@@ -9278,8 +9278,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         }
       },
@@ -9293,8 +9293,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.48}",
-            "deep_sky_itkontoret": "{units.size.48}"
+            "deep_sky_itkontoret": "{units.size.48}",
+            "default": "{units.size.48}"
           }
         }
       }
@@ -9313,8 +9313,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.gap.8}",
-              "deep_sky_itkontoret": "{units.gap.8}"
+              "deep_sky_itkontoret": "{units.gap.8}",
+              "default": "{units.gap.8}"
             }
           },
           "heightMin": {
@@ -9326,8 +9326,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.size.40}",
-              "deep_sky_itkontoret": "{units.size.40}"
+              "deep_sky_itkontoret": "{units.size.40}",
+              "default": "{units.size.40}"
             }
           },
           "paddingX": {
@@ -9339,8 +9339,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.gap.16}",
-              "deep_sky_itkontoret": "{units.gap.16}"
+              "deep_sky_itkontoret": "{units.gap.16}",
+              "default": "{units.gap.16}"
             }
           },
           "paddingY": {
@@ -9352,8 +9352,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.gap.8}",
-              "deep_sky_itkontoret": "{units.gap.8}"
+              "deep_sky_itkontoret": "{units.gap.8}",
+              "default": "{units.gap.8}"
             }
           }
         },
@@ -9368,8 +9368,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.glyph.onSurface.primary}",
-                "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+                "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+                "default": "{colors.glyph.onSurface.primary}"
               }
             }
           },
@@ -9382,8 +9382,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.gap.4}",
-              "deep_sky_itkontoret": "{units.gap.4}"
+              "deep_sky_itkontoret": "{units.gap.4}",
+              "default": "{units.gap.4}"
             }
           },
           "size": {
@@ -9395,8 +9395,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.size.16}",
-              "deep_sky_itkontoret": "{units.size.16}"
+              "deep_sky_itkontoret": "{units.size.16}",
+              "default": "{units.size.16}"
             }
           }
         },
@@ -9411,8 +9411,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.text.onSurface.primary}",
-                "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+                "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+                "default": "{colors.text.onSurface.primary}"
               }
             }
           },
@@ -9425,8 +9425,8 @@
             "$type": "typography",
             "platforms": ["PD"],
             "values": {
-              "default": "{typography.body.default}",
-              "deep_sky_itkontoret": "{typography.body.default}"
+              "deep_sky_itkontoret": "{typography.body.default}",
+              "default": "{typography.body.default}"
             }
           }
         }
@@ -9443,8 +9443,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.background.surface.active}",
-                "deep_sky_itkontoret": "{colors.background.surface.active}"
+                "deep_sky_itkontoret": "{colors.background.surface.active}",
+                "default": "{colors.background.surface.active}"
               }
             },
             "hover": {
@@ -9456,8 +9456,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.background.surface.active}",
-                "deep_sky_itkontoret": "{colors.background.surface.active}"
+                "deep_sky_itkontoret": "{colors.background.surface.active}",
+                "default": "{colors.background.surface.active}"
               }
             },
             "idle": {
@@ -9469,8 +9469,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.background.surface.active}",
-                "deep_sky_itkontoret": "{colors.background.surface.active}"
+                "deep_sky_itkontoret": "{colors.background.surface.active}",
+                "default": "{colors.background.surface.active}"
               }
             }
           }
@@ -9488,8 +9488,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.background.surface.hover}",
-                "deep_sky_itkontoret": "{colors.background.surface.hover}"
+                "deep_sky_itkontoret": "{colors.background.surface.hover}",
+                "default": "{colors.background.surface.hover}"
               }
             },
             "hover": {
@@ -9501,8 +9501,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.background.surface.hover}",
-                "deep_sky_itkontoret": "{colors.background.surface.hover}"
+                "deep_sky_itkontoret": "{colors.background.surface.hover}",
+                "default": "{colors.background.surface.hover}"
               }
             },
             "idle": {
@@ -9514,8 +9514,8 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "default": "{colors.background.surface.secondary}",
-                "deep_sky_itkontoret": "{colors.background.surface.primary}"
+                "deep_sky_itkontoret": "{colors.background.surface.primary}",
+                "default": "{colors.background.surface.secondary}"
               }
             }
           }
@@ -9534,8 +9534,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.gap.8}",
-              "deep_sky_itkontoret": "{units.gap.8}"
+              "deep_sky_itkontoret": "{units.gap.8}",
+              "default": "{units.gap.8}"
             }
           }
         },
@@ -9549,8 +9549,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           },
           "size": {
@@ -9562,8 +9562,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.size.16}",
-              "deep_sky_itkontoret": "{units.size.16}"
+              "deep_sky_itkontoret": "{units.size.16}",
+              "default": "{units.size.16}"
             }
           }
         },
@@ -9577,8 +9577,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.secondary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}"
             }
           },
           "textStyle": {
@@ -9590,8 +9590,8 @@
             "$type": "typography",
             "platforms": ["PD"],
             "values": {
-              "default": "{typography.body.default}",
-              "deep_sky_itkontoret": "{typography.body.default}"
+              "deep_sky_itkontoret": "{typography.body.default}",
+              "default": "{typography.body.default}"
             }
           }
         }
@@ -9608,8 +9608,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         }
       },
@@ -9623,8 +9623,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.0}"
           }
         }
       },
@@ -9638,8 +9638,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         },
         "minWidth": {
@@ -9651,8 +9651,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": 36,
-            "deep_sky_itkontoret": 36
+            "deep_sky_itkontoret": 36,
+            "default": 36
           }
         },
         "paddingX": {
@@ -9664,8 +9664,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.16}",
-            "deep_sky_itkontoret": "{units.gap.16}"
+            "deep_sky_itkontoret": "{units.gap.16}",
+            "default": "{units.gap.16}"
           }
         },
         "paddingY": {
@@ -9677,8 +9677,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.2}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.2}"
           }
         }
       },
@@ -9692,8 +9692,11 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onSurface.primary}",
-            "deep_sky_itkontoret": { "colorSpace": "hsl", "components": [0, 0, 100] }
+            "deep_sky_itkontoret": {
+              "colorSpace": "hsl",
+              "components": [0, 0, 100]
+            },
+            "default": "{colors.glyph.onSurface.primary}"
           }
         }
       },
@@ -9707,8 +9710,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -9720,8 +9723,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.strong}",
-            "deep_sky_itkontoret": "{typography.body.strong}"
+            "deep_sky_itkontoret": "{typography.body.strong}",
+            "default": "{typography.body.strong}"
           }
         }
       }
@@ -9737,8 +9740,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onSurface.border}",
-            "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+            "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+            "default": "{colors.border.onSurface.border}"
           }
         },
         "borderWidth": {
@@ -9750,8 +9753,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         },
         "color": {
@@ -9763,8 +9766,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.surface.secondary}",
-            "deep_sky_itkontoret": "{colors.background.surface.primary}"
+            "deep_sky_itkontoret": "{colors.background.surface.primary}",
+            "default": "{colors.background.surface.secondary}"
           }
         }
       },
@@ -9778,8 +9781,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onSurface.border}",
-            "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+            "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+            "default": "{colors.border.onSurface.border}"
           }
         },
         "borderWidth": {
@@ -9791,8 +9794,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         }
       },
@@ -9806,8 +9809,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.16}",
-            "deep_sky_itkontoret": "{units.gap.16}"
+            "deep_sky_itkontoret": "{units.gap.16}",
+            "default": "{units.gap.16}"
           }
         },
         "paddingY": {
@@ -9819,8 +9822,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.12}",
-            "deep_sky_itkontoret": "{units.gap.12}"
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}"
           }
         }
       },
@@ -9834,8 +9837,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -9847,8 +9850,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.headings.title}",
-            "deep_sky_itkontoret": "{typography.headings.title}"
+            "deep_sky_itkontoret": "{typography.headings.title}",
+            "default": "{typography.headings.title}"
           }
         }
       },
@@ -9862,8 +9865,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         }
       }
@@ -9879,8 +9882,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.secondary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+            "default": "{colors.text.onSurface.secondary}"
           }
         },
         "textStyle": {
@@ -9892,8 +9895,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.strong}",
-            "deep_sky_itkontoret": "{typography.body.strong}"
+            "deep_sky_itkontoret": "{typography.body.strong}",
+            "default": "{typography.body.strong}"
           }
         }
       },
@@ -9907,8 +9910,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.48}",
-            "deep_sky_itkontoret": "{units.size.48}"
+            "deep_sky_itkontoret": "{units.size.48}",
+            "default": "{units.size.48}"
           }
         }
       },
@@ -9922,8 +9925,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.4}",
-            "deep_sky_itkontoret": "{units.gap.4}"
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}"
           }
         },
         "paddingY": {
@@ -9935,8 +9938,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.16}",
-            "deep_sky_itkontoret": "{units.gap.16}"
+            "deep_sky_itkontoret": "{units.gap.16}",
+            "default": "{units.gap.16}"
           }
         }
       },
@@ -9950,8 +9953,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         },
         "paddingY": {
@@ -9963,8 +9966,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.16}",
-            "deep_sky_itkontoret": "{units.gap.16}"
+            "deep_sky_itkontoret": "{units.gap.16}",
+            "default": "{units.gap.16}"
           }
         }
       },
@@ -9978,8 +9981,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onSurface.neutral}",
-            "deep_sky_itkontoret": "{colors.glyph.onSurface.neutral}"
+            "deep_sky_itkontoret": "{colors.glyph.onSurface.neutral}",
+            "default": "{colors.glyph.onSurface.neutral}"
           }
         },
         "size": {
@@ -9991,8 +9994,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.16}",
-            "deep_sky_itkontoret": "{units.size.16}"
+            "deep_sky_itkontoret": "{units.size.16}",
+            "default": "{units.size.16}"
           }
         }
       },
@@ -10006,8 +10009,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -10019,8 +10022,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.strong}",
-            "deep_sky_itkontoret": "{typography.body.strong}"
+            "deep_sky_itkontoret": "{typography.body.strong}",
+            "default": "{typography.body.strong}"
           }
         }
       }
@@ -10036,8 +10039,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.256}",
-            "deep_sky_itkontoret": "{units.size.256}"
+            "deep_sky_itkontoret": "{units.size.256}",
+            "default": "{units.size.256}"
           }
         }
       },
@@ -10051,8 +10054,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.16}",
-            "deep_sky_itkontoret": "{units.gap.16}"
+            "deep_sky_itkontoret": "{units.gap.16}",
+            "default": "{units.gap.16}"
           }
         },
         "paddingY": {
@@ -10064,8 +10067,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         }
       }
@@ -10084,8 +10087,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.transparent}",
-              "deep_sky_itkontoret": "{colors.border.transparent}"
+              "deep_sky_itkontoret": "{colors.border.transparent}",
+              "default": "{colors.border.transparent}"
             }
           },
           "disabled": {
@@ -10097,8 +10100,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.onSurface.border}",
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}"
             }
           },
           "hover": {
@@ -10110,8 +10113,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.transparent}",
-              "deep_sky_itkontoret": "{colors.border.transparent}"
+              "deep_sky_itkontoret": "{colors.border.transparent}",
+              "default": "{colors.border.transparent}"
             }
           },
           "idle": {
@@ -10123,8 +10126,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.border.transparent}",
-              "deep_sky_itkontoret": "{colors.border.transparent}"
+              "deep_sky_itkontoret": "{colors.border.transparent}",
+              "default": "{colors.border.transparent}"
             }
           }
         },
@@ -10137,8 +10140,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.radius.999}",
-            "deep_sky_itkontoret": "{units.radius.999}"
+            "deep_sky_itkontoret": "{units.radius.999}",
+            "default": "{units.radius.999}"
           }
         },
         "borderStyle": {
@@ -10150,8 +10153,8 @@
           "$type": "string",
           "platforms": ["PD"],
           "values": {
-            "default": "solid",
-            "deep_sky_itkontoret": "solid"
+            "deep_sky_itkontoret": "solid",
+            "default": "solid"
           }
         },
         "borderWidth": {
@@ -10163,8 +10166,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         },
         "height": {
@@ -10176,8 +10179,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.16}",
-            "deep_sky_itkontoret": "{units.size.16}"
+            "deep_sky_itkontoret": "{units.size.16}",
+            "default": "{units.size.16}"
           }
         },
         "paddingX": {
@@ -10189,8 +10192,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.2}",
-            "deep_sky_itkontoret": "{units.gap.2}"
+            "deep_sky_itkontoret": "{units.gap.2}",
+            "default": "{units.gap.2}"
           }
         },
         "paddingY": {
@@ -10202,8 +10205,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.2}",
-            "deep_sky_itkontoret": "{units.gap.2}"
+            "deep_sky_itkontoret": "{units.gap.2}",
+            "default": "{units.gap.2}"
           }
         },
         "width": {
@@ -10215,8 +10218,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.32}",
-            "deep_sky_itkontoret": "{units.size.32}"
+            "deep_sky_itkontoret": "{units.size.32}",
+            "default": "{units.size.32}"
           }
         }
       },
@@ -10230,8 +10233,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         }
       },
@@ -10245,8 +10248,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -10258,8 +10261,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.default}",
-            "deep_sky_itkontoret": "{typography.body.default}"
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}"
           }
         }
       },
@@ -10273,8 +10276,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.radius.999}",
-            "deep_sky_itkontoret": "{units.radius.999}"
+            "deep_sky_itkontoret": "{units.radius.999}",
+            "default": "{units.radius.999}"
           }
         },
         "color": {
@@ -10287,8 +10290,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{palette.base}",
-              "deep_sky_itkontoret": "{palette.base}"
+              "deep_sky_itkontoret": "{palette.base}",
+              "default": "{palette.base}"
             }
           },
           "disabled": {
@@ -10300,8 +10303,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onStatus.disabled}",
-              "deep_sky_itkontoret": "{colors.glyph.onStatus.disabled}"
+              "deep_sky_itkontoret": "{colors.glyph.onStatus.disabled}",
+              "default": "{colors.glyph.onStatus.disabled}"
             }
           },
           "hover": {
@@ -10313,8 +10316,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{palette.base}",
-              "deep_sky_itkontoret": "{palette.base}"
+              "deep_sky_itkontoret": "{palette.base}",
+              "default": "{palette.base}"
             }
           },
           "idle": {
@@ -10326,8 +10329,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{palette.base}",
-              "deep_sky_itkontoret": "{palette.base}"
+              "deep_sky_itkontoret": "{palette.base}",
+              "default": "{palette.base}"
             }
           }
         },
@@ -10340,8 +10343,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.12}",
-            "deep_sky_itkontoret": "{units.size.12}"
+            "deep_sky_itkontoret": "{units.size.12}",
+            "default": "{units.size.12}"
           }
         }
       }
@@ -10358,8 +10361,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.status.off}",
-              "deep_sky_itkontoret": "{colors.background.status.off}"
+              "deep_sky_itkontoret": "{colors.background.status.off}",
+              "default": "{colors.background.status.off}"
             }
           },
           "disabled": {
@@ -10371,8 +10374,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.secondary}",
-              "deep_sky_itkontoret": "{colors.background.surface.secondary}"
+              "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+              "default": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -10384,8 +10387,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.status.off}",
-              "deep_sky_itkontoret": "{colors.background.status.off}"
+              "deep_sky_itkontoret": "{colors.background.status.off}",
+              "default": "{colors.background.status.off}"
             }
           },
           "idle": {
@@ -10397,8 +10400,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.status.off}",
-              "deep_sky_itkontoret": "{colors.background.status.off}"
+              "deep_sky_itkontoret": "{colors.background.status.off}",
+              "default": "{colors.background.status.off}"
             }
           }
         }
@@ -10416,8 +10419,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.status.on}",
-              "deep_sky_itkontoret": "{colors.background.status.on}"
+              "deep_sky_itkontoret": "{colors.background.status.on}",
+              "default": "{colors.background.status.on}"
             }
           },
           "disabled": {
@@ -10429,8 +10432,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.secondary}",
-              "deep_sky_itkontoret": "{colors.background.surface.secondary}"
+              "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+              "default": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -10442,8 +10445,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.status.on}",
-              "deep_sky_itkontoret": "{colors.background.status.on}"
+              "deep_sky_itkontoret": "{colors.background.status.on}",
+              "default": "{colors.background.status.on}"
             }
           },
           "idle": {
@@ -10455,8 +10458,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.status.on}",
-              "deep_sky_itkontoret": "{colors.background.status.on}"
+              "deep_sky_itkontoret": "{colors.background.status.on}",
+              "default": "{colors.background.status.on}"
             }
           }
         }
@@ -10474,8 +10477,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.8}",
-          "deep_sky_itkontoret": "{units.gap.8}"
+          "deep_sky_itkontoret": "{units.gap.8}",
+          "default": "{units.gap.8}"
         }
       },
       "value": {
@@ -10489,8 +10492,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.disabled}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+              "default": "{colors.text.onSurface.disabled}"
             }
           },
           "idle": {
@@ -10502,8 +10505,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.text.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}"
             }
           }
         },
@@ -10516,8 +10519,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.default}",
-            "deep_sky_itkontoret": "{typography.body.default}"
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}"
           }
         }
       }
@@ -10534,8 +10537,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.active}",
-              "deep_sky_itkontoret": "{colors.background.surface.active}"
+              "deep_sky_itkontoret": "{colors.background.surface.active}",
+              "default": "{colors.background.surface.active}"
             }
           },
           "hover": {
@@ -10547,8 +10550,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.hover}",
-              "deep_sky_itkontoret": "{colors.background.surface.hover}"
+              "deep_sky_itkontoret": "{colors.background.surface.hover}",
+              "default": "{colors.background.surface.hover}"
             }
           },
           "idle": {
@@ -10560,8 +10563,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "transparent",
-              "deep_sky_itkontoret": "transparent"
+              "deep_sky_itkontoret": "transparent",
+              "default": "transparent"
             }
           }
         },
@@ -10574,8 +10577,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.16}",
-            "deep_sky_itkontoret": "{units.size.16}"
+            "deep_sky_itkontoret": "{units.size.16}",
+            "default": "{units.size.16}"
           }
         }
       },
@@ -10588,8 +10591,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.8}",
-          "deep_sky_itkontoret": "{units.gap.8}"
+          "deep_sky_itkontoret": "{units.gap.8}",
+          "default": "{units.gap.8}"
         }
       },
       "label": {
@@ -10602,8 +10605,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onSurface.primary}",
-            "deep_sky_itkontoret": "{colors.text.onSurface.primary}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -10615,8 +10618,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.body.strong}",
-            "deep_sky_itkontoret": "{typography.body.strong}"
+            "deep_sky_itkontoret": "{typography.body.strong}",
+            "default": "{typography.body.strong}"
           }
         }
       },
@@ -10631,8 +10634,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.primary}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}"
             }
           },
           "inactive": {
@@ -10644,8 +10647,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.glyph.onSurface.neutral}",
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.neutral}"
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.neutral}",
+              "default": "{colors.glyph.onSurface.neutral}"
             }
           }
         },
@@ -10658,8 +10661,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.16}",
-            "deep_sky_itkontoret": "{units.size.16}"
+            "deep_sky_itkontoret": "{units.size.16}",
+            "default": "{units.size.16}"
           }
         }
       }
@@ -10675,8 +10678,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onSurface.border}",
-            "deep_sky_itkontoret": "{colors.border.onSurface.border}"
+            "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+            "default": "{colors.border.onSurface.border}"
           }
         },
         "borderStyle": {
@@ -10688,8 +10691,8 @@
           "$type": "string",
           "platforms": ["PD"],
           "values": {
-            "default": "solid",
-            "deep_sky_itkontoret": "solid"
+            "deep_sky_itkontoret": "solid",
+            "default": "solid"
           }
         },
         "borderWidth": {
@@ -10701,8 +10704,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         },
         "minHeight": {
@@ -10714,8 +10717,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.40}",
-            "deep_sky_itkontoret": "{units.size.40}"
+            "deep_sky_itkontoret": "{units.size.40}",
+            "default": "{units.size.40}"
           }
         },
         "paddingX": {
@@ -10727,8 +10730,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.16}",
-            "deep_sky_itkontoret": "{units.size.16}"
+            "deep_sky_itkontoret": "{units.size.16}",
+            "default": "{units.size.16}"
           }
         },
         "paddingY": {
@@ -10740,8 +10743,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.8}",
-            "deep_sky_itkontoret": "{units.size.8}"
+            "deep_sky_itkontoret": "{units.size.8}",
+            "default": "{units.size.8}"
           }
         }
       },
@@ -10755,8 +10758,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.active}",
-              "deep_sky_itkontoret": "{colors.background.surface.active}"
+              "deep_sky_itkontoret": "{colors.background.surface.active}",
+              "default": "{colors.background.surface.active}"
             }
           },
           "hover": {
@@ -10767,8 +10770,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "{colors.background.surface.hover}",
-              "deep_sky_itkontoret": "{colors.background.surface.hover}"
+              "deep_sky_itkontoret": "{colors.background.surface.hover}",
+              "default": "{colors.background.surface.hover}"
             }
           },
           "idle": {
@@ -10779,8 +10782,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "default": "transparent",
-              "deep_sky_itkontoret": "transparent"
+              "deep_sky_itkontoret": "transparent",
+              "default": "transparent"
             }
           }
         }
@@ -10799,8 +10802,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.radius.999}",
-            "deep_sky_itkontoret": "{units.radius.999}"
+            "deep_sky_itkontoret": "{units.radius.999}",
+            "default": "{units.radius.999}"
           }
         },
         "borderWidth": {
@@ -10812,8 +10815,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.stroke.1}",
-            "deep_sky_itkontoret": "{units.stroke.1}"
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}"
           }
         },
         "gap": {
@@ -10825,8 +10828,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.4}",
-            "deep_sky_itkontoret": "{units.gap.4}"
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}"
           }
         },
         "paddingX": {
@@ -10838,8 +10841,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.8}",
-            "deep_sky_itkontoret": "{units.gap.8}"
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}"
           }
         },
         "paddingY": {
@@ -10851,8 +10854,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.gap.0}",
-            "deep_sky_itkontoret": "{units.gap.0}"
+            "deep_sky_itkontoret": "{units.gap.0}",
+            "default": "{units.gap.0}"
           }
         },
         "widthMax": {
@@ -10864,8 +10867,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.256}",
-            "deep_sky_itkontoret": "{units.size.256}"
+            "deep_sky_itkontoret": "{units.size.256}",
+            "default": "{units.size.256}"
           }
         },
         "widthMin": {
@@ -10877,8 +10880,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "default": "{units.size.32}",
-            "deep_sky_itkontoret": "{units.size.32}"
+            "deep_sky_itkontoret": "{units.size.32}",
+            "default": "{units.size.32}"
           }
         }
       },
@@ -10892,8 +10895,8 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "default": "{typography.caption.strong}",
-            "deep_sky_itkontoret": "{typography.caption.strong}"
+            "deep_sky_itkontoret": "{typography.caption.strong}",
+            "default": "{typography.caption.strong}"
           }
         }
       },
@@ -10908,8 +10911,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.size.24}",
-              "deep_sky_itkontoret": "{units.size.24}"
+              "deep_sky_itkontoret": "{units.size.24}",
+              "default": "{units.size.24}"
             }
           }
         },
@@ -10923,8 +10926,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.stroke.1-6}",
-              "deep_sky_itkontoret": "{units.stroke.1-6}"
+              "deep_sky_itkontoret": "{units.stroke.1-6}",
+              "default": "{units.stroke.1-6}"
             }
           },
           "size": {
@@ -10936,8 +10939,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.size.16}",
-              "deep_sky_itkontoret": "{units.size.16}"
+              "deep_sky_itkontoret": "{units.size.16}",
+              "default": "{units.size.16}"
             }
           }
         }
@@ -10953,8 +10956,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "default": "{units.size.20}",
-              "deep_sky_itkontoret": "{units.size.20}"
+              "deep_sky_itkontoret": "{units.size.20}",
+              "default": "{units.size.20}"
             }
           }
         }
@@ -10971,8 +10974,8 @@
           "$type": "string",
           "platforms": ["PD"],
           "values": {
-            "default": "{gradients.ai.idle}",
-            "deep_sky_itkontoret": "{gradients.ai.idle}"
+            "deep_sky_itkontoret": "{gradients.ai.idle}",
+            "default": "{gradients.ai.idle}"
           }
         },
         "color": {
@@ -10984,8 +10987,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.status.ai}",
-            "deep_sky_itkontoret": "{colors.background.status.ai}"
+            "deep_sky_itkontoret": "{colors.background.status.ai}",
+            "default": "{colors.background.status.ai}"
           }
         }
       },
@@ -10999,8 +11002,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onStatus.ai}",
-            "deep_sky_itkontoret": "{colors.glyph.onStatus.ai}"
+            "deep_sky_itkontoret": "{colors.glyph.onStatus.ai}",
+            "default": "{colors.glyph.onStatus.ai}"
           }
         }
       },
@@ -11014,8 +11017,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onStatus.ai}",
-            "deep_sky_itkontoret": "{colors.text.onStatus.ai}"
+            "deep_sky_itkontoret": "{colors.text.onStatus.ai}",
+            "default": "{colors.text.onStatus.ai}"
           }
         }
       }
@@ -11031,8 +11034,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onStatus.critical}",
-            "deep_sky_itkontoret": "{colors.border.onStatus.critical}"
+            "deep_sky_itkontoret": "{colors.border.onStatus.critical}",
+            "default": "{colors.border.onStatus.critical}"
           }
         },
         "color": {
@@ -11044,8 +11047,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.status.critical}",
-            "deep_sky_itkontoret": "{colors.background.status.critical}"
+            "deep_sky_itkontoret": "{colors.background.status.critical}",
+            "default": "{colors.background.status.critical}"
           }
         }
       },
@@ -11059,8 +11062,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onStatus.critical}",
-            "deep_sky_itkontoret": "{colors.glyph.onStatus.critical}"
+            "deep_sky_itkontoret": "{colors.glyph.onStatus.critical}",
+            "default": "{colors.glyph.onStatus.critical}"
           }
         }
       },
@@ -11074,8 +11077,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onStatus.critical}",
-            "deep_sky_itkontoret": "{colors.text.onStatus.critical}"
+            "deep_sky_itkontoret": "{colors.text.onStatus.critical}",
+            "default": "{colors.text.onStatus.critical}"
           }
         }
       }
@@ -11091,8 +11094,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onStatus.danger}",
-            "deep_sky_itkontoret": "{colors.border.onStatus.danger}"
+            "deep_sky_itkontoret": "{colors.border.onStatus.danger}",
+            "default": "{colors.border.onStatus.danger}"
           }
         },
         "color": {
@@ -11104,8 +11107,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.status.danger}",
-            "deep_sky_itkontoret": "{colors.background.status.danger}"
+            "deep_sky_itkontoret": "{colors.background.status.danger}",
+            "default": "{colors.background.status.danger}"
           }
         }
       },
@@ -11119,8 +11122,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onStatus.danger}",
-            "deep_sky_itkontoret": "{colors.glyph.onStatus.danger}"
+            "deep_sky_itkontoret": "{colors.glyph.onStatus.danger}",
+            "default": "{colors.glyph.onStatus.danger}"
           }
         }
       },
@@ -11134,8 +11137,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onStatus.danger}",
-            "deep_sky_itkontoret": "{colors.text.onStatus.danger}"
+            "deep_sky_itkontoret": "{colors.text.onStatus.danger}",
+            "default": "{colors.text.onStatus.danger}"
           }
         }
       }
@@ -11151,8 +11154,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onStatus.info}",
-            "deep_sky_itkontoret": "{colors.border.onStatus.info}"
+            "deep_sky_itkontoret": "{colors.border.onStatus.info}",
+            "default": "{colors.border.onStatus.info}"
           }
         },
         "color": {
@@ -11164,8 +11167,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.status.info}",
-            "deep_sky_itkontoret": "{colors.background.status.info}"
+            "deep_sky_itkontoret": "{colors.background.status.info}",
+            "default": "{colors.background.status.info}"
           }
         }
       },
@@ -11179,8 +11182,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onStatus.info}",
-            "deep_sky_itkontoret": "{colors.glyph.onStatus.info}"
+            "deep_sky_itkontoret": "{colors.glyph.onStatus.info}",
+            "default": "{colors.glyph.onStatus.info}"
           }
         }
       },
@@ -11194,8 +11197,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onStatus.info}",
-            "deep_sky_itkontoret": "{colors.text.onStatus.info}"
+            "deep_sky_itkontoret": "{colors.text.onStatus.info}",
+            "default": "{colors.text.onStatus.info}"
           }
         }
       }
@@ -11211,8 +11214,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onStatus.neutral}",
-            "deep_sky_itkontoret": "{colors.border.onStatus.neutral}"
+            "deep_sky_itkontoret": "{colors.border.onStatus.neutral}",
+            "default": "{colors.border.onStatus.neutral}"
           }
         },
         "color": {
@@ -11224,8 +11227,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.status.neutral}",
-            "deep_sky_itkontoret": "{colors.background.status.neutral}"
+            "deep_sky_itkontoret": "{colors.background.status.neutral}",
+            "default": "{colors.background.status.neutral}"
           }
         }
       },
@@ -11239,8 +11242,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onStatus.neutral}",
-            "deep_sky_itkontoret": "{colors.glyph.onStatus.neutral}"
+            "deep_sky_itkontoret": "{colors.glyph.onStatus.neutral}",
+            "default": "{colors.glyph.onStatus.neutral}"
           }
         }
       },
@@ -11254,8 +11257,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onStatus.neutral}",
-            "deep_sky_itkontoret": "{colors.text.onStatus.neutral}"
+            "deep_sky_itkontoret": "{colors.text.onStatus.neutral}",
+            "default": "{colors.text.onStatus.neutral}"
           }
         }
       }
@@ -11271,8 +11274,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onStatus.success}",
-            "deep_sky_itkontoret": "{colors.border.onStatus.success}"
+            "deep_sky_itkontoret": "{colors.border.onStatus.success}",
+            "default": "{colors.border.onStatus.success}"
           }
         },
         "color": {
@@ -11284,8 +11287,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.status.success}",
-            "deep_sky_itkontoret": "{colors.background.status.success}"
+            "deep_sky_itkontoret": "{colors.background.status.success}",
+            "default": "{colors.background.status.success}"
           }
         }
       },
@@ -11299,8 +11302,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onStatus.success}",
-            "deep_sky_itkontoret": "{colors.glyph.onStatus.success}"
+            "deep_sky_itkontoret": "{colors.glyph.onStatus.success}",
+            "default": "{colors.glyph.onStatus.success}"
           }
         }
       },
@@ -11314,8 +11317,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onStatus.success}",
-            "deep_sky_itkontoret": "{colors.text.onStatus.success}"
+            "deep_sky_itkontoret": "{colors.text.onStatus.success}",
+            "default": "{colors.text.onStatus.success}"
           }
         }
       }
@@ -11331,8 +11334,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.border.onStatus.warning}",
-            "deep_sky_itkontoret": "{colors.border.onStatus.warning}"
+            "deep_sky_itkontoret": "{colors.border.onStatus.warning}",
+            "default": "{colors.border.onStatus.warning}"
           }
         },
         "color": {
@@ -11344,8 +11347,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.background.status.warning}",
-            "deep_sky_itkontoret": "{colors.background.status.warning}"
+            "deep_sky_itkontoret": "{colors.background.status.warning}",
+            "default": "{colors.background.status.warning}"
           }
         }
       },
@@ -11359,8 +11362,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.glyph.onStatus.warning}",
-            "deep_sky_itkontoret": "{colors.glyph.onStatus.warning}"
+            "deep_sky_itkontoret": "{colors.glyph.onStatus.warning}",
+            "default": "{colors.glyph.onStatus.warning}"
           }
         }
       },
@@ -11374,8 +11377,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "default": "{colors.text.onStatus.warning}",
-            "deep_sky_itkontoret": "{colors.text.onStatus.warning}"
+            "deep_sky_itkontoret": "{colors.text.onStatus.warning}",
+            "default": "{colors.text.onStatus.warning}"
           }
         }
       }
@@ -11392,8 +11395,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.radius.4}",
-          "deep_sky_itkontoret": "{units.radius.4}"
+          "deep_sky_itkontoret": "{units.radius.4}",
+          "default": "{units.radius.4}"
         }
       },
       "color": {
@@ -11405,8 +11408,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.background.overlay.inverted-dark}",
-          "deep_sky_itkontoret": "{colors.background.overlay.inverted-dark}"
+          "deep_sky_itkontoret": "{colors.background.overlay.inverted-dark}",
+          "default": "{colors.background.overlay.inverted-dark}"
         }
       },
       "paddingX": {
@@ -11418,8 +11421,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.12}",
-          "deep_sky_itkontoret": "{units.gap.12}"
+          "deep_sky_itkontoret": "{units.gap.12}",
+          "default": "{units.gap.12}"
         }
       },
       "paddingY": {
@@ -11431,8 +11434,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.gap.8}",
-          "deep_sky_itkontoret": "{units.gap.8}"
+          "deep_sky_itkontoret": "{units.gap.8}",
+          "default": "{units.gap.8}"
         }
       },
       "widthMax": {
@@ -11444,8 +11447,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.size.256}",
-          "deep_sky_itkontoret": "{units.size.256}"
+          "deep_sky_itkontoret": "{units.size.256}",
+          "default": "{units.size.256}"
         }
       },
       "widthMin": {
@@ -11457,8 +11460,8 @@
         "$type": "dimension",
         "platforms": ["PD"],
         "values": {
-          "default": "{units.size.48}",
-          "deep_sky_itkontoret": "{units.size.48}"
+          "deep_sky_itkontoret": "{units.size.48}",
+          "default": "{units.size.48}"
         }
       }
     },
@@ -11472,8 +11475,8 @@
         "$type": "color",
         "platforms": ["PD"],
         "values": {
-          "default": "{colors.text.onOverlay.inverted-light}",
-          "deep_sky_itkontoret": "{colors.text.onOverlay.inverted-light}"
+          "deep_sky_itkontoret": "{colors.text.onOverlay.inverted-light}",
+          "default": "{colors.text.onOverlay.inverted-light}"
         }
       },
       "textStyle": {
@@ -11485,8 +11488,8 @@
         "$type": "typography",
         "platforms": ["PD"],
         "values": {
-          "default": "{typography.caption.strong}",
-          "deep_sky_itkontoret": "{typography.caption.strong}"
+          "deep_sky_itkontoret": "{typography.caption.strong}",
+          "default": "{typography.caption.strong}"
         }
       }
     }

--- a/packages/design-tokens/tiers/semantics.json
+++ b/packages/design-tokens/tiers/semantics.json
@@ -21,11 +21,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.13}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [196.32, 81.7, 30]
-            }
+            },
+            "default": "{palette.blue.13}"
           }
         },
         "primary-active": {
@@ -35,11 +35,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.7}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [199.81, 89.08, 53.33]
-            }
+            },
+            "default": "{palette.blue.7}"
           }
         },
         "primary-disabled": {
@@ -49,8 +49,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.5}",
-            "deep_sky_itkontoret": { "colorSpace": "hsl", "components": [200, 100, 81.76] }
+            "deep_sky_itkontoret": {
+              "colorSpace": "hsl",
+              "components": [200, 100, 81.76]
+            },
+            "default": "{palette.blue.5}"
           }
         },
         "primary-focus": {
@@ -60,11 +63,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.10}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [199.81, 89.08, 53.33]
-            }
+            },
+            "default": "{palette.blue.10}"
           }
         },
         "primary-hover": {
@@ -74,11 +77,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.12}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [195.93, 84.96, 26.08]
-            }
+            },
+            "default": "{palette.blue.12}"
           }
         },
         "secondary": {
@@ -88,11 +91,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.7}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [208.8, 15.53, 31.57]
-            }
+            },
+            "default": "{palette.blue.7}"
           }
         },
         "secondary-active": {
@@ -102,11 +105,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.9}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [205.71, 14.58, 18.82]
-            }
+            },
+            "default": "{palette.blue.9}"
           }
         },
         "secondary-disabled": {
@@ -116,11 +119,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.3}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [210, 7.69, 79.61]
-            }
+            },
+            "default": "{palette.blue.3}"
           }
         },
         "secondary-hover": {
@@ -130,11 +133,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.8}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [207, 15.63, 25.1]
-            }
+            },
+            "default": "{palette.blue.8}"
           }
         }
       },
@@ -146,8 +149,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.8}",
-            "deep_sky_itkontoret": "{palette.blue.8}"
+            "deep_sky_itkontoret": "{palette.blue.8}",
+            "default": "{palette.blue.8}"
           }
         },
         "disabled": {
@@ -157,8 +160,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.11}",
-            "deep_sky_itkontoret": "{palette.blue.11}"
+            "deep_sky_itkontoret": "{palette.blue.11}",
+            "default": "{palette.blue.11}"
           }
         },
         "hover": {
@@ -168,8 +171,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.9}",
-            "deep_sky_itkontoret": "{palette.blue.9}"
+            "deep_sky_itkontoret": "{palette.blue.9}",
+            "default": "{palette.blue.9}"
           }
         },
         "primary": {
@@ -179,8 +182,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.10}",
-            "deep_sky_itkontoret": "{palette.blue.10}"
+            "deep_sky_itkontoret": "{palette.blue.10}",
+            "default": "{palette.blue.10}"
           }
         }
       },
@@ -192,8 +195,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.inverted.1}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.1}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.1}",
+            "default": "{palette.transparent.inverted.1}"
           }
         },
         "inverted-dark": {
@@ -203,8 +206,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.dark.inverted}",
-            "deep_sky_itkontoret": "{palette.transparent.dark.inverted}"
+            "deep_sky_itkontoret": "{palette.transparent.dark.inverted}",
+            "default": "{palette.transparent.dark.inverted}"
           }
         },
         "primary": {
@@ -214,8 +217,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.dark.11}",
-            "deep_sky_itkontoret": "{palette.transparent.dark.11}"
+            "deep_sky_itkontoret": "{palette.transparent.dark.11}",
+            "default": "{palette.transparent.dark.11}"
           }
         }
       },
@@ -227,8 +230,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.violet.1}",
-            "deep_sky_itkontoret": "{palette.violet.1}"
+            "deep_sky_itkontoret": "{palette.violet.1}",
+            "default": "{palette.violet.1}"
           }
         },
         "ai-hover": {
@@ -238,8 +241,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.violet.2}",
-            "deep_sky_itkontoret": "{palette.violet.2}"
+            "deep_sky_itkontoret": "{palette.violet.2}",
+            "default": "{palette.violet.2}"
           }
         },
         "ai-pressed": {
@@ -249,8 +252,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.violet.3}",
-            "deep_sky_itkontoret": "{palette.violet.3}"
+            "deep_sky_itkontoret": "{palette.violet.3}",
+            "default": "{palette.violet.3}"
           }
         },
         "critical": {
@@ -260,8 +263,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.orange.1}",
-            "deep_sky_itkontoret": "{palette.orange.1}"
+            "deep_sky_itkontoret": "{palette.orange.1}",
+            "default": "{palette.orange.1}"
           }
         },
         "critical-hover": {
@@ -271,8 +274,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.orange.2}",
-            "deep_sky_itkontoret": "{palette.orange.2}"
+            "deep_sky_itkontoret": "{palette.orange.2}",
+            "default": "{palette.orange.2}"
           }
         },
         "critical-pressed": {
@@ -282,8 +285,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.orange.3}",
-            "deep_sky_itkontoret": "{palette.orange.3}"
+            "deep_sky_itkontoret": "{palette.orange.3}",
+            "default": "{palette.orange.3}"
           }
         },
         "danger": {
@@ -293,8 +296,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.red.1}",
-            "deep_sky_itkontoret": "{palette.red.1}"
+            "deep_sky_itkontoret": "{palette.red.1}",
+            "default": "{palette.red.1}"
           }
         },
         "danger-hover": {
@@ -304,8 +307,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.red.2}",
-            "deep_sky_itkontoret": "{palette.red.2}"
+            "deep_sky_itkontoret": "{palette.red.2}",
+            "default": "{palette.red.2}"
           }
         },
         "danger-pressed": {
@@ -315,8 +318,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.red.3}",
-            "deep_sky_itkontoret": "{palette.red.3}"
+            "deep_sky_itkontoret": "{palette.red.3}",
+            "default": "{palette.red.3}"
           }
         },
         "info": {
@@ -326,8 +329,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.electricblue.electricblue-1}",
-            "deep_sky_itkontoret": "{palette.electricblue.electricblue-1}"
+            "deep_sky_itkontoret": "{palette.electricblue.electricblue-1}",
+            "default": "{palette.electricblue.electricblue-1}"
           }
         },
         "info-hover": {
@@ -337,8 +340,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.electricblue.electricblue-2}",
-            "deep_sky_itkontoret": "{palette.electricblue.electricblue-2}"
+            "deep_sky_itkontoret": "{palette.electricblue.electricblue-2}",
+            "default": "{palette.electricblue.electricblue-2}"
           }
         },
         "info-pressed": {
@@ -348,8 +351,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.electricblue.electricblue-3}",
-            "deep_sky_itkontoret": "{palette.electricblue.electricblue-3}"
+            "deep_sky_itkontoret": "{palette.electricblue.electricblue-3}",
+            "default": "{palette.electricblue.electricblue-3}"
           }
         },
         "neutral": {
@@ -359,8 +362,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.base}",
-            "deep_sky_itkontoret": "{palette.base}"
+            "deep_sky_itkontoret": "{palette.base}",
+            "default": "{palette.base}"
           }
         },
         "neutral-hover": {
@@ -370,8 +373,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.grayscale.1}",
-            "deep_sky_itkontoret": "{palette.grayscale.1}"
+            "deep_sky_itkontoret": "{palette.grayscale.1}",
+            "default": "{palette.grayscale.1}"
           }
         },
         "neutral-pressed": {
@@ -381,8 +384,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.grayscale.2}",
-            "deep_sky_itkontoret": "{palette.grayscale.2}"
+            "deep_sky_itkontoret": "{palette.grayscale.2}",
+            "default": "{palette.grayscale.2}"
           }
         },
         "off": {
@@ -392,11 +395,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.3}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [210, 7.69, 79.61]
-            }
+            },
+            "default": "{palette.blue.3}"
           }
         },
         "on": {
@@ -406,8 +409,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.green.6}",
-            "deep_sky_itkontoret": "{palette.green.6}"
+            "deep_sky_itkontoret": "{palette.green.6}",
+            "default": "{palette.green.6}"
           }
         },
         "success": {
@@ -417,8 +420,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.green.1}",
-            "deep_sky_itkontoret": "{palette.green.1}"
+            "deep_sky_itkontoret": "{palette.green.1}",
+            "default": "{palette.green.1}"
           }
         },
         "success-hover": {
@@ -428,8 +431,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.green.2}",
-            "deep_sky_itkontoret": "{palette.green.2}"
+            "deep_sky_itkontoret": "{palette.green.2}",
+            "default": "{palette.green.2}"
           }
         },
         "success-pressed": {
@@ -439,8 +442,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.green.3}",
-            "deep_sky_itkontoret": "{palette.green.3}"
+            "deep_sky_itkontoret": "{palette.green.3}",
+            "default": "{palette.green.3}"
           }
         },
         "warning": {
@@ -450,8 +453,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.yellow.1}",
-            "deep_sky_itkontoret": "{palette.yellow.1}"
+            "deep_sky_itkontoret": "{palette.yellow.1}",
+            "default": "{palette.yellow.1}"
           }
         },
         "warning-hover": {
@@ -461,8 +464,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.yellow.2}",
-            "deep_sky_itkontoret": "{palette.yellow.2}"
+            "deep_sky_itkontoret": "{palette.yellow.2}",
+            "default": "{palette.yellow.2}"
           }
         },
         "warning-pressed": {
@@ -472,208 +475,208 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.yellow.3}",
-            "deep_sky_itkontoret": "{palette.yellow.3}"
+            "deep_sky_itkontoret": "{palette.yellow.3}",
+            "default": "{palette.yellow.3}"
           }
         }
       },
       "statusStrong": {
         "critical": {
           "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263451"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.orange.7}",
-            "deep_sky_itkontoret": "{palette.orange.7}"
+            "deep_sky_itkontoret": "{palette.orange.7}",
+            "default": "{palette.orange.7}"
           }
         },
         "critical-hover": {
           "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263452"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.orange.8}",
-            "deep_sky_itkontoret": "{palette.orange.8}"
+            "deep_sky_itkontoret": "{palette.orange.8}",
+            "default": "{palette.orange.8}"
           }
         },
         "critical-pressed": {
           "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263453"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.orange.9}",
-            "deep_sky_itkontoret": "{palette.orange.9}"
+            "deep_sky_itkontoret": "{palette.orange.9}",
+            "default": "{palette.orange.9}"
           }
         },
         "danger": {
           "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263454"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.red.7}",
-            "deep_sky_itkontoret": "{palette.red.7}"
+            "deep_sky_itkontoret": "{palette.red.7}",
+            "default": "{palette.red.7}"
           }
         },
         "danger-hover": {
           "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263455"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.red.9}",
-            "deep_sky_itkontoret": "{palette.red.9}"
+            "deep_sky_itkontoret": "{palette.red.9}",
+            "default": "{palette.red.9}"
           }
         },
         "danger-pressed": {
           "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263456"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.red.10}",
-            "deep_sky_itkontoret": "{palette.red.10}"
+            "deep_sky_itkontoret": "{palette.red.10}",
+            "default": "{palette.red.10}"
           }
         },
         "info": {
           "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263442"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.electricblue.electricblue-7-primary}",
-            "deep_sky_itkontoret": "{palette.electricblue.electricblue-7-primary}"
+            "deep_sky_itkontoret": "{palette.electricblue.electricblue-7-primary}",
+            "default": "{palette.electricblue.electricblue-7-primary}"
           }
         },
         "info-hover": {
           "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263443"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.electricblue.electricblue-8}",
-            "deep_sky_itkontoret": "{palette.electricblue.electricblue-8}"
+            "deep_sky_itkontoret": "{palette.electricblue.electricblue-8}",
+            "default": "{palette.electricblue.electricblue-8}"
           }
         },
         "info-pressed": {
           "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263444"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.electricblue.electricblue-9}",
-            "deep_sky_itkontoret": "{palette.electricblue.electricblue-9}"
+            "deep_sky_itkontoret": "{palette.electricblue.electricblue-9}",
+            "default": "{palette.electricblue.electricblue-9}"
           }
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263460"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.grayscale.7}",
-            "deep_sky_itkontoret": "{palette.grayscale.7}"
+            "deep_sky_itkontoret": "{palette.grayscale.7}",
+            "default": "{palette.grayscale.7}"
           }
         },
         "neutral-hover": {
           "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263461"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.grayscale.8}",
-            "deep_sky_itkontoret": "{palette.grayscale.8}"
+            "deep_sky_itkontoret": "{palette.grayscale.8}",
+            "default": "{palette.grayscale.8}"
           }
         },
         "neutral-pressed": {
           "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263462"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.grayscale.9}",
-            "deep_sky_itkontoret": "{palette.grayscale.9}"
+            "deep_sky_itkontoret": "{palette.grayscale.9}",
+            "default": "{palette.grayscale.9}"
           }
         },
         "success": {
           "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263445"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.green.7}",
-            "deep_sky_itkontoret": "{palette.green.7}"
+            "deep_sky_itkontoret": "{palette.green.7}",
+            "default": "{palette.green.7}"
           }
         },
         "success-hover": {
           "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263446"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.green.8}",
-            "deep_sky_itkontoret": "{palette.green.8}"
+            "deep_sky_itkontoret": "{palette.green.8}",
+            "default": "{palette.green.8}"
           }
         },
         "success-pressed": {
           "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263447"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.green.9}",
-            "deep_sky_itkontoret": "{palette.green.9}"
+            "deep_sky_itkontoret": "{palette.green.9}",
+            "default": "{palette.green.9}"
           }
         },
         "warning": {
           "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263448"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.yellow.7}",
-            "deep_sky_itkontoret": "{palette.yellow.7}"
+            "deep_sky_itkontoret": "{palette.yellow.7}",
+            "default": "{palette.yellow.7}"
           }
         },
         "warning-hover": {
           "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263449"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.yellow.8}",
-            "deep_sky_itkontoret": "{palette.yellow.8}"
+            "deep_sky_itkontoret": "{palette.yellow.8}",
+            "default": "{palette.yellow.8}"
           }
         },
         "warning-pressed": {
           "$extensions": {
-            "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263450"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.yellow.9}",
-            "deep_sky_itkontoret": "{palette.yellow.9}"
+            "deep_sky_itkontoret": "{palette.yellow.9}",
+            "default": "{palette.yellow.9}"
           }
         }
       },
@@ -685,11 +688,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.3}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [210, 18.18, 87.06]
-            }
+            },
+            "default": "{palette.blue.3}"
           }
         },
         "hover": {
@@ -699,11 +702,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.1}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [200, 8.57, 93.14]
-            }
+            },
+            "default": "{palette.blue.1}"
           }
         },
         "primary": {
@@ -713,8 +716,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.base}",
-            "deep_sky_itkontoret": "{palette.base}"
+            "deep_sky_itkontoret": "{palette.base}",
+            "default": "{palette.base}"
           }
         },
         "secondary": {
@@ -724,11 +727,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.0}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [240, 5.88, 96.67]
-            }
+            },
+            "default": "{palette.blue.0}"
           }
         }
       },
@@ -739,8 +742,8 @@
         },
         "platforms": ["PD"],
         "values": {
-          "default": "{palette.transparent.clear}",
-          "deep_sky_itkontoret": "{palette.transparent.clear}"
+          "deep_sky_itkontoret": "{palette.transparent.clear}",
+          "default": "{palette.transparent.clear}"
         }
       }
     },
@@ -753,8 +756,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.inverted.9}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.9}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.9}",
+            "default": "{palette.transparent.inverted.9}"
           }
         },
         "border-active": {
@@ -764,8 +767,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.grayscale.0}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.0}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.0}",
+            "default": "{palette.grayscale.0}"
           }
         },
         "divider": {
@@ -775,13 +778,24 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.inverted.9}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.9}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.9}",
+            "default": "{palette.transparent.inverted.9}"
           }
         }
       },
       "onStatus": {
-        "ai-strong": {
+        "ai": {
+          "$extensions": {
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:4313:50249"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.violet.4}",
+            "default": "{palette.violet.4}"
+          }
+        },
+        "aiStrong": {
           "$extensions": {
             "com.figma.scopes": [],
             "com.figma.variableId": "VariableID:2277:437"
@@ -789,8 +803,8 @@
           "$type": "gradient",
           "platforms": ["PD"],
           "values": {
-            "default": "{gradients.ai.idle}",
-            "deep_sky_itkontoret": "{gradients.ai.idle}"
+            "deep_sky_itkontoret": "{gradients.ai.idle}",
+            "default": "{gradients.ai.idle}"
           }
         },
         "critical": {
@@ -800,8 +814,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.orange.4}",
-            "deep_sky_itkontoret": "{palette.orange.4}"
+            "deep_sky_itkontoret": "{palette.orange.4}",
+            "default": "{palette.orange.4}"
           }
         },
         "critical-strong": {
@@ -811,8 +825,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.orange.8}",
-            "deep_sky_itkontoret": "{palette.orange.8}"
+            "deep_sky_itkontoret": "{palette.orange.8}",
+            "default": "{palette.orange.8}"
           }
         },
         "danger": {
@@ -822,8 +836,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.red.4}",
-            "deep_sky_itkontoret": "{palette.red.4}"
+            "deep_sky_itkontoret": "{palette.red.4}",
+            "default": "{palette.red.4}"
           }
         },
         "danger-strong": {
@@ -833,8 +847,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.red.8}",
-            "deep_sky_itkontoret": "{palette.red.8}"
+            "deep_sky_itkontoret": "{palette.red.8}",
+            "default": "{palette.red.8}"
           }
         },
         "info": {
@@ -844,8 +858,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.electricblue.electricblue-4}",
-            "deep_sky_itkontoret": "{palette.electricblue.electricblue-4}"
+            "deep_sky_itkontoret": "{palette.electricblue.electricblue-4}",
+            "default": "{palette.electricblue.electricblue-4}"
           }
         },
         "info-strong": {
@@ -855,8 +869,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.electricblue.electricblue-8}",
-            "deep_sky_itkontoret": "{palette.electricblue.electricblue-8}"
+            "deep_sky_itkontoret": "{palette.electricblue.electricblue-8}",
+            "default": "{palette.electricblue.electricblue-8}"
           }
         },
         "neutral": {
@@ -866,8 +880,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.grayscale.4}",
-            "deep_sky_itkontoret": "{palette.grayscale.4}"
+            "deep_sky_itkontoret": "{palette.grayscale.4}",
+            "default": "{palette.grayscale.4}"
           }
         },
         "neutral-strong": {
@@ -877,8 +891,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.grayscale.8}",
-            "deep_sky_itkontoret": "{palette.grayscale.8}"
+            "deep_sky_itkontoret": "{palette.grayscale.8}",
+            "default": "{palette.grayscale.8}"
           }
         },
         "success": {
@@ -888,8 +902,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.green.4}",
-            "deep_sky_itkontoret": "{palette.green.4}"
+            "deep_sky_itkontoret": "{palette.green.4}",
+            "default": "{palette.green.4}"
           }
         },
         "success-strong": {
@@ -899,8 +913,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.green.8}",
-            "deep_sky_itkontoret": "{palette.green.8}"
+            "deep_sky_itkontoret": "{palette.green.8}",
+            "default": "{palette.green.8}"
           }
         },
         "warning": {
@@ -910,8 +924,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.yellow.4}",
-            "deep_sky_itkontoret": "{palette.yellow.4}"
+            "deep_sky_itkontoret": "{palette.yellow.4}",
+            "default": "{palette.yellow.4}"
           }
         },
         "warning-strong": {
@@ -921,8 +935,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.yellow.8}",
-            "deep_sky_itkontoret": "{palette.yellow.8}"
+            "deep_sky_itkontoret": "{palette.yellow.8}",
+            "default": "{palette.yellow.8}"
           }
         }
       },
@@ -934,11 +948,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.3}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [210, 7.69, 79.61]
-            }
+            },
+            "default": "{palette.blue.3}"
           }
         },
         "border-active": {
@@ -948,11 +962,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.7}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [208.8, 15.53, 31.57]
-            }
+            },
+            "default": "{palette.blue.7}"
           }
         },
         "border-error": {
@@ -962,8 +976,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.red.7}",
-            "deep_sky_itkontoret": "{palette.red.7}"
+            "deep_sky_itkontoret": "{palette.red.7}",
+            "default": "{palette.red.7}"
           }
         },
         "divider": {
@@ -973,11 +987,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.3}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [210, 7.69, 79.61]
-            }
+            },
+            "default": "{palette.blue.3}"
           }
         }
       },
@@ -988,8 +1002,8 @@
         },
         "platforms": ["PD"],
         "values": {
-          "default": "{palette.transparent.clear}",
-          "deep_sky_itkontoret": "{palette.transparent.clear}"
+          "deep_sky_itkontoret": "{palette.transparent.clear}",
+          "default": "{palette.transparent.clear}"
         }
       }
     },
@@ -1001,8 +1015,8 @@
         },
         "platforms": ["PD"],
         "values": {
-          "default": "{palette.blue.4}",
-          "deep_sky_itkontoret": "{palette.blue.4}"
+          "deep_sky_itkontoret": "{palette.blue.4}",
+          "default": "{palette.blue.4}"
         }
       },
       "error": {
@@ -1012,8 +1026,8 @@
         },
         "platforms": ["PD"],
         "values": {
-          "default": "{palette.red.4}",
-          "deep_sky_itkontoret": "{palette.red.4}"
+          "deep_sky_itkontoret": "{palette.red.4}",
+          "default": "{palette.red.4}"
         }
       },
       "primary": {
@@ -1023,8 +1037,8 @@
         },
         "platforms": ["PD"],
         "values": {
-          "default": "{palette.blue.4}",
-          "deep_sky_itkontoret": "{palette.blue.4}"
+          "deep_sky_itkontoret": "{palette.blue.4}",
+          "default": "{palette.blue.4}"
         }
       },
       "secondary": {
@@ -1034,8 +1048,8 @@
         },
         "platforms": ["PD"],
         "values": {
-          "default": "{palette.blue.4}",
-          "deep_sky_itkontoret": "{palette.blue.4}"
+          "deep_sky_itkontoret": "{palette.blue.4}",
+          "default": "{palette.blue.4}"
         }
       }
     },
@@ -1043,35 +1057,35 @@
       "onBrand": {
         "disabled": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:179:195"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.inverted.9}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.1}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.1}",
+            "default": "{palette.transparent.inverted.9}"
           }
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:52:2202"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.inverted.0}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.0}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.0}",
+            "default": "{palette.transparent.inverted.0}"
           }
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:179:196"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.inverted.4}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.4}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.4}",
+            "default": "{palette.transparent.inverted.4}"
           }
         }
       },
@@ -1083,8 +1097,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.inverted.7}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.7}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.7}",
+            "default": "{palette.transparent.inverted.7}"
           }
         },
         "primary": {
@@ -1094,8 +1108,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.inverted.0}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.0}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.0}",
+            "default": "{palette.transparent.inverted.0}"
           }
         },
         "secondary": {
@@ -1105,8 +1119,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.inverted.4}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.4}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.4}",
+            "default": "{palette.transparent.inverted.4}"
           }
         }
       },
@@ -1118,178 +1132,178 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.inverted.0}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.0}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.0}",
+            "default": "{palette.transparent.inverted.0}"
           }
         }
       },
       "onStatus": {
         "ai": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:1936:2682"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.violet.11}",
-            "deep_sky_itkontoret": "{palette.violet.11}"
+            "deep_sky_itkontoret": "{palette.violet.11}",
+            "default": "{palette.violet.11}"
           }
         },
         "critical": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1732"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.orange.11}",
-            "deep_sky_itkontoret": "{palette.orange.11}"
+            "deep_sky_itkontoret": "{palette.orange.11}",
+            "default": "{palette.orange.11}"
           }
         },
         "danger": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1731"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.red.11}",
-            "deep_sky_itkontoret": "{palette.red.11}"
+            "deep_sky_itkontoret": "{palette.red.11}",
+            "default": "{palette.red.11}"
           }
         },
         "disabled": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:151:43"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.3}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [210, 7.69, 79.61]
-            }
+            },
+            "default": "{palette.blue.3}"
           }
         },
         "info": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1735"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.electricblue.electricblue-11}",
-            "deep_sky_itkontoret": "{palette.electricblue.electricblue-11}"
+            "deep_sky_itkontoret": "{palette.electricblue.electricblue-11}",
+            "default": "{palette.electricblue.electricblue-11}"
           }
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:911:263464"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.grayscale.11}",
-            "deep_sky_itkontoret": "{palette.grayscale.11}"
+            "deep_sky_itkontoret": "{palette.grayscale.11}",
+            "default": "{palette.grayscale.11}"
           }
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:149:7"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.electricblue.electricblue-11}",
-            "deep_sky_itkontoret": "{palette.electricblue.electricblue-11}"
+            "deep_sky_itkontoret": "{palette.electricblue.electricblue-11}",
+            "default": "{palette.electricblue.electricblue-11}"
           }
         },
         "success": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1734"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.green.11}",
-            "deep_sky_itkontoret": "{palette.green.11}"
+            "deep_sky_itkontoret": "{palette.green.11}",
+            "default": "{palette.green.11}"
           }
         },
         "warning": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1733"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.yellow.11}",
-            "deep_sky_itkontoret": "{palette.yellow.11}"
+            "deep_sky_itkontoret": "{palette.yellow.11}",
+            "default": "{palette.yellow.11}"
           }
         }
       },
       "onSurface": {
         "brand": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:2463:54749"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.13}",
-            "deep_sky_itkontoret": "{palette.blue.13}"
+            "deep_sky_itkontoret": "{palette.blue.13}",
+            "default": "{palette.blue.13}"
           }
         },
         "destructive": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:143:8"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.red.7}",
-            "deep_sky_itkontoret": "{palette.red.7}"
+            "deep_sky_itkontoret": "{palette.red.7}",
+            "default": "{palette.red.7}"
           }
         },
         "disabled": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:56:1581"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.3}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [210, 7.69, 79.61]
-            }
+            },
+            "default": "{palette.blue.3}"
           }
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:1024:122"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.grayscale.4}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [210, 7.69, 79.61]
-            }
+            },
+            "default": "{palette.grayscale.4}"
           }
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:50:1436"
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.7}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [208.8, 15.53, 31.57]
-            }
+            },
+            "default": "{palette.blue.7}"
           }
         }
       }
@@ -1303,8 +1317,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.inverted.0}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.0}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.0}",
+            "default": "{palette.transparent.inverted.0}"
           }
         },
         "link": {
@@ -1314,8 +1328,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.7}",
-            "deep_sky_itkontoret": "{palette.blue.7}"
+            "deep_sky_itkontoret": "{palette.blue.7}",
+            "default": "{palette.blue.7}"
           }
         },
         "link-disabled": {
@@ -1325,8 +1339,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.inverted.1}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.1}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.1}",
+            "default": "{palette.transparent.inverted.1}"
           }
         },
         "link-hover": {
@@ -1336,8 +1350,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.5}",
-            "deep_sky_itkontoret": "{palette.blue.5}"
+            "deep_sky_itkontoret": "{palette.blue.5}",
+            "default": "{palette.blue.5}"
           }
         },
         "link-pressed": {
@@ -1347,8 +1361,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.3}",
-            "deep_sky_itkontoret": "{palette.blue.3}"
+            "deep_sky_itkontoret": "{palette.blue.3}",
+            "default": "{palette.blue.3}"
           }
         },
         "primary": {
@@ -1358,8 +1372,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.inverted.0}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.0}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.0}",
+            "default": "{palette.transparent.inverted.0}"
           }
         },
         "secondary": {
@@ -1369,8 +1383,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.inverted.4}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.4}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.4}",
+            "default": "{palette.transparent.inverted.4}"
           }
         }
       },
@@ -1382,8 +1396,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.inverted.7}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.7}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.7}",
+            "default": "{palette.transparent.inverted.7}"
           }
         },
         "primary": {
@@ -1393,8 +1407,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.inverted.0}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.0}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.0}",
+            "default": "{palette.transparent.inverted.0}"
           }
         }
       },
@@ -1406,8 +1420,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.light.inverted}",
-            "deep_sky_itkontoret": "{palette.transparent.light.inverted}"
+            "deep_sky_itkontoret": "{palette.transparent.light.inverted}",
+            "default": "{palette.transparent.light.inverted}"
           }
         },
         "link": {
@@ -1417,8 +1431,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.7}",
-            "deep_sky_itkontoret": "{palette.blue.7}"
+            "deep_sky_itkontoret": "{palette.blue.7}",
+            "default": "{palette.blue.7}"
           }
         },
         "link-hover": {
@@ -1428,8 +1442,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.5}",
-            "deep_sky_itkontoret": "{palette.blue.5}"
+            "deep_sky_itkontoret": "{palette.blue.5}",
+            "default": "{palette.blue.5}"
           }
         },
         "link-pressed": {
@@ -1439,8 +1453,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.3}",
-            "deep_sky_itkontoret": "{palette.blue.3}"
+            "deep_sky_itkontoret": "{palette.blue.3}",
+            "default": "{palette.blue.3}"
           }
         },
         "primary": {
@@ -1450,8 +1464,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.inverted.0}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.0}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.0}",
+            "default": "{palette.transparent.inverted.0}"
           }
         },
         "secondary": {
@@ -1461,8 +1475,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.transparent.inverted.4}",
-            "deep_sky_itkontoret": "{palette.transparent.inverted.4}"
+            "deep_sky_itkontoret": "{palette.transparent.inverted.4}",
+            "default": "{palette.transparent.inverted.4}"
           }
         }
       },
@@ -1474,8 +1488,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.violet.11}",
-            "deep_sky_itkontoret": "{palette.violet.11}"
+            "deep_sky_itkontoret": "{palette.violet.11}",
+            "default": "{palette.violet.11}"
           }
         },
         "critical": {
@@ -1485,8 +1499,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.orange.11}",
-            "deep_sky_itkontoret": "{palette.orange.11}"
+            "deep_sky_itkontoret": "{palette.orange.11}",
+            "default": "{palette.orange.11}"
           }
         },
         "danger": {
@@ -1496,8 +1510,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.red.11}",
-            "deep_sky_itkontoret": "{palette.red.11}"
+            "deep_sky_itkontoret": "{palette.red.11}",
+            "default": "{palette.red.11}"
           }
         },
         "info": {
@@ -1507,8 +1521,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.electricblue.electricblue-11}",
-            "deep_sky_itkontoret": "{palette.electricblue.electricblue-11}"
+            "deep_sky_itkontoret": "{palette.electricblue.electricblue-11}",
+            "default": "{palette.electricblue.electricblue-11}"
           }
         },
         "link": {
@@ -1518,8 +1532,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.electricblue.electricblue-11}",
-            "deep_sky_itkontoret": "{palette.electricblue.electricblue-11}"
+            "deep_sky_itkontoret": "{palette.electricblue.electricblue-11}",
+            "default": "{palette.electricblue.electricblue-11}"
           }
         },
         "link-disabled": {
@@ -1529,8 +1543,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.electricblue.electricblue-5}",
-            "deep_sky_itkontoret": "{palette.electricblue.electricblue-5}"
+            "deep_sky_itkontoret": "{palette.electricblue.electricblue-5}",
+            "default": "{palette.electricblue.electricblue-5}"
           }
         },
         "link-hover": {
@@ -1540,8 +1554,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.electricblue.electricblue-13}",
-            "deep_sky_itkontoret": "{palette.electricblue.electricblue-13}"
+            "deep_sky_itkontoret": "{palette.electricblue.electricblue-13}",
+            "default": "{palette.electricblue.electricblue-13}"
           }
         },
         "link-pressed": {
@@ -1551,8 +1565,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.electricblue.electricblue-14}",
-            "deep_sky_itkontoret": "{palette.electricblue.electricblue-14}"
+            "deep_sky_itkontoret": "{palette.electricblue.electricblue-14}",
+            "default": "{palette.electricblue.electricblue-14}"
           }
         },
         "neutral": {
@@ -1562,8 +1576,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.grayscale.11}",
-            "deep_sky_itkontoret": "{palette.grayscale.11}"
+            "deep_sky_itkontoret": "{palette.grayscale.11}",
+            "default": "{palette.grayscale.11}"
           }
         },
         "primary": {
@@ -1573,8 +1587,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.grayscale.14}",
-            "deep_sky_itkontoret": "{palette.grayscale.14}"
+            "deep_sky_itkontoret": "{palette.grayscale.14}",
+            "default": "{palette.grayscale.14}"
           }
         },
         "secondary": {
@@ -1584,8 +1598,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.grayscale.11}",
-            "deep_sky_itkontoret": "{palette.grayscale.11}"
+            "deep_sky_itkontoret": "{palette.grayscale.11}",
+            "default": "{palette.grayscale.11}"
           }
         },
         "success": {
@@ -1595,8 +1609,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.green.11}",
-            "deep_sky_itkontoret": "{palette.green.11}"
+            "deep_sky_itkontoret": "{palette.green.11}",
+            "default": "{palette.green.11}"
           }
         },
         "warning": {
@@ -1606,8 +1620,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.yellow.11}",
-            "deep_sky_itkontoret": "{palette.yellow.11}"
+            "deep_sky_itkontoret": "{palette.yellow.11}",
+            "default": "{palette.yellow.11}"
           }
         }
       },
@@ -1619,8 +1633,8 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.red.7}",
-            "deep_sky_itkontoret": "{palette.red.7}"
+            "deep_sky_itkontoret": "{palette.red.7}",
+            "default": "{palette.red.7}"
           }
         },
         "disabled": {
@@ -1630,11 +1644,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.grayscale.5}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [205.71, 14.58, 18.82]
-            }
+            },
+            "default": "{palette.grayscale.5}"
           }
         },
         "link": {
@@ -1644,11 +1658,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.7}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [208.8, 15.53, 31.57]
-            }
+            },
+            "default": "{palette.blue.7}"
           }
         },
         "link-disabled": {
@@ -1658,11 +1672,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.3}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [210, 7.69, 79.61]
-            }
+            },
+            "default": "{palette.blue.3}"
           }
         },
         "link-hover": {
@@ -1672,11 +1686,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.8}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [207, 15.63, 25.1]
-            }
+            },
+            "default": "{palette.blue.8}"
           }
         },
         "link-pressed": {
@@ -1686,11 +1700,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.blue.11}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [205.71, 14.58, 18.82]
-            }
+            },
+            "default": "{palette.blue.11}"
           }
         },
         "primary": {
@@ -1700,11 +1714,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.grayscale.14}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [208.8, 15.53, 31.57]
-            }
+            },
+            "default": "{palette.grayscale.14}"
           }
         },
         "secondary": {
@@ -1714,11 +1728,11 @@
           },
           "platforms": ["PD"],
           "values": {
-            "default": "{palette.grayscale.7}",
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
               "components": [207, 15.63, 25.1]
-            }
+            },
+            "default": "{palette.grayscale.7}"
           }
         }
       }
@@ -1735,7 +1749,7 @@
         },
         "platforms": ["PD"],
         "values": {
-          "default": [
+          "deep_sky_itkontoret": [
             {
               "color": {
                 "colorSpace": "hsl",
@@ -1751,7 +1765,7 @@
               "position": 1
             }
           ],
-          "deep_sky_itkontoret": [
+          "default": [
             {
               "color": {
                 "colorSpace": "hsl",
@@ -1777,7 +1791,7 @@
         },
         "platforms": ["PD"],
         "values": {
-          "default": [
+          "deep_sky_itkontoret": [
             {
               "color": {
                 "colorSpace": "hsl",
@@ -1793,7 +1807,7 @@
               "position": 1
             }
           ],
-          "deep_sky_itkontoret": [
+          "default": [
             {
               "color": {
                 "colorSpace": "hsl",
@@ -1819,7 +1833,7 @@
         },
         "platforms": ["PD"],
         "values": {
-          "default": [
+          "deep_sky_itkontoret": [
             {
               "color": {
                 "colorSpace": "hsl",
@@ -1835,7 +1849,7 @@
               "position": 1
             }
           ],
-          "deep_sky_itkontoret": [
+          "default": [
             {
               "color": {
                 "colorSpace": "hsl",
@@ -1861,7 +1875,7 @@
         },
         "platforms": ["PD"],
         "values": {
-          "default": [
+          "deep_sky_itkontoret": [
             {
               "color": {
                 "colorSpace": "hsl",
@@ -1877,7 +1891,7 @@
               "position": 1
             }
           ],
-          "deep_sky_itkontoret": [
+          "default": [
             {
               "color": {
                 "colorSpace": "hsl",

--- a/packages/tokens-pd/css/default.css
+++ b/packages/tokens-pd/css/default.css
@@ -69,6 +69,7 @@
   --ui-border-on-brand-border: light-dark(rgb(255 255 255 / 0.102), rgb(255 255 255 / 0.102));
   --ui-border-on-brand-border-active: light-dark(rgb(244 245 245), rgb(24 25 27));
   --ui-border-on-brand-divider: light-dark(rgb(255 255 255 / 0.102), rgb(255 255 255 / 0.102));
+  --ui-border-on-status-ai: light-dark(rgb(228 204 237), rgb(130 23 130));
   --ui-border-on-status-ai-strong: linear-gradient(90deg, rgb(56 73 224) 20%, rgb(252 45 241) 100%);
   --ui-border-on-status-critical: light-dark(rgb(255 204 153), rgb(153 69 0));
   --ui-border-on-status-critical-strong: light-dark(rgb(240 112 0), rgb(255 153 51));

--- a/packages/tokens-pd/dtcg/semantics-deep_sky_itkontoret.json
+++ b/packages/tokens-pd/dtcg/semantics-deep_sky_itkontoret.json
@@ -474,8 +474,7 @@
         "critical": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263451"
           },
@@ -485,8 +484,7 @@
         "critical-hover": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263452"
           },
@@ -496,8 +494,7 @@
         "critical-pressed": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263453"
           },
@@ -507,8 +504,7 @@
         "danger": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263454"
           },
@@ -518,8 +514,7 @@
         "danger-hover": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263455"
           },
@@ -529,8 +524,7 @@
         "danger-pressed": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263456"
           },
@@ -540,8 +534,7 @@
         "info": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263442"
           },
@@ -551,8 +544,7 @@
         "info-hover": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263443"
           },
@@ -562,8 +554,7 @@
         "info-pressed": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263444"
           },
@@ -573,8 +564,7 @@
         "neutral": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:911:263460"
           },
@@ -584,8 +574,7 @@
         "neutral-hover": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:911:263461"
           },
@@ -595,8 +584,7 @@
         "neutral-pressed": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:911:263462"
           },
@@ -606,8 +594,7 @@
         "success": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263445"
           },
@@ -617,8 +604,7 @@
         "success-hover": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263446"
           },
@@ -628,8 +614,7 @@
         "success-pressed": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263447"
           },
@@ -639,8 +624,7 @@
         "warning": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263448"
           },
@@ -650,8 +634,7 @@
         "warning-hover": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263449"
           },
@@ -661,8 +644,7 @@
         "warning-pressed": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263450"
           },
@@ -779,7 +761,17 @@
         }
       },
       "onStatus": {
-        "ai-strong": {
+        "ai": {
+          "$extensions": {
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.variableId": "VariableID:4313:50249"
+          },
+          "$type": "color",
+          "$value": "{palette.violet.4}"
+        },
+        "aiStrong": {
           "$extensions": {
             "com.figma.scopes": [],
             "com.figma.variableId": "VariableID:2277:437"
@@ -1029,8 +1021,7 @@
         "disabled": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:179:195"
           },
@@ -1040,8 +1031,7 @@
         "primary": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:52:2202"
           },
@@ -1051,8 +1041,7 @@
         "secondary": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:179:196"
           },
@@ -1112,8 +1101,7 @@
         "ai": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:1936:2682"
           },
@@ -1123,8 +1111,7 @@
         "critical": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:796:1732"
           },
@@ -1134,8 +1121,7 @@
         "danger": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:796:1731"
           },
@@ -1145,8 +1131,7 @@
         "disabled": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:151:43"
           },
@@ -1163,8 +1148,7 @@
         "info": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:796:1735"
           },
@@ -1174,8 +1158,7 @@
         "neutral": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:911:263464"
           },
@@ -1185,8 +1168,7 @@
         "primary": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:149:7"
           },
@@ -1196,8 +1178,7 @@
         "success": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:796:1734"
           },
@@ -1207,8 +1188,7 @@
         "warning": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:796:1733"
           },
@@ -1220,8 +1200,7 @@
         "brand": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:2463:54749"
           },
@@ -1231,8 +1210,7 @@
         "destructive": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:143:8"
           },
@@ -1242,8 +1220,7 @@
         "disabled": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:56:1581"
           },
@@ -1260,8 +1237,7 @@
         "neutral": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:1024:122"
           },
@@ -1278,8 +1254,7 @@
         "primary": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:50:1436"
           },

--- a/packages/tokens-pd/dtcg/semantics-default.json
+++ b/packages/tokens-pd/dtcg/semantics-default.json
@@ -404,8 +404,7 @@
         "critical": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263451"
           },
@@ -415,8 +414,7 @@
         "critical-hover": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263452"
           },
@@ -426,8 +424,7 @@
         "critical-pressed": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263453"
           },
@@ -437,8 +434,7 @@
         "danger": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263454"
           },
@@ -448,8 +444,7 @@
         "danger-hover": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263455"
           },
@@ -459,8 +454,7 @@
         "danger-pressed": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263456"
           },
@@ -470,8 +464,7 @@
         "info": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263442"
           },
@@ -481,8 +474,7 @@
         "info-hover": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263443"
           },
@@ -492,8 +484,7 @@
         "info-pressed": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263444"
           },
@@ -503,8 +494,7 @@
         "neutral": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:911:263460"
           },
@@ -514,8 +504,7 @@
         "neutral-hover": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:911:263461"
           },
@@ -525,8 +514,7 @@
         "neutral-pressed": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:911:263462"
           },
@@ -536,8 +524,7 @@
         "success": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263445"
           },
@@ -547,8 +534,7 @@
         "success-hover": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263446"
           },
@@ -558,8 +544,7 @@
         "success-pressed": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263447"
           },
@@ -569,8 +554,7 @@
         "warning": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263448"
           },
@@ -580,8 +564,7 @@
         "warning-hover": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263449"
           },
@@ -591,8 +574,7 @@
         "warning-pressed": {
           "$extensions": {
             "com.figma.scopes": [
-              "FRAME_FILL",
-              "SHAPE_FILL"
+              "FRAME_FILL"
             ],
             "com.figma.variableId": "VariableID:910:263450"
           },
@@ -688,7 +670,17 @@
         }
       },
       "onStatus": {
-        "ai-strong": {
+        "ai": {
+          "$extensions": {
+            "com.figma.scopes": [
+              "ALL_SCOPES"
+            ],
+            "com.figma.variableId": "VariableID:4313:50249"
+          },
+          "$type": "color",
+          "$value": "{palette.violet.4}"
+        },
+        "aiStrong": {
           "$extensions": {
             "com.figma.scopes": [],
             "com.figma.variableId": "VariableID:2277:437"
@@ -917,8 +909,7 @@
         "disabled": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:179:195"
           },
@@ -928,8 +919,7 @@
         "primary": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:52:2202"
           },
@@ -939,8 +929,7 @@
         "secondary": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:179:196"
           },
@@ -1000,8 +989,7 @@
         "ai": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:1936:2682"
           },
@@ -1011,8 +999,7 @@
         "critical": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:796:1732"
           },
@@ -1022,8 +1009,7 @@
         "danger": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:796:1731"
           },
@@ -1033,8 +1019,7 @@
         "disabled": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:151:43"
           },
@@ -1044,8 +1029,7 @@
         "info": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:796:1735"
           },
@@ -1055,8 +1039,7 @@
         "neutral": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:911:263464"
           },
@@ -1066,8 +1049,7 @@
         "primary": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:149:7"
           },
@@ -1077,8 +1059,7 @@
         "success": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:796:1734"
           },
@@ -1088,8 +1069,7 @@
         "warning": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:796:1733"
           },
@@ -1101,8 +1081,7 @@
         "brand": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:2463:54749"
           },
@@ -1112,8 +1091,7 @@
         "destructive": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:143:8"
           },
@@ -1123,8 +1101,7 @@
         "disabled": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:56:1581"
           },
@@ -1134,8 +1111,7 @@
         "neutral": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:1024:122"
           },
@@ -1145,8 +1121,7 @@
         "primary": {
           "$extensions": {
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:50:1436"
           },

--- a/packages/tokens-pd/tailwind/deep_sky_itkontoret/tokens.js
+++ b/packages/tokens-pd/tailwind/deep_sky_itkontoret/tokens.js
@@ -111,6 +111,7 @@ export default {
         "border-on-brand": "light-dark(rgb(255 255 255 / 0.102), rgb(255 255 255 / 0.102))",
         "on-brand-border-active": "light-dark(rgb(255 255 255), rgb(255 255 255))",
         "on-brand-divider": "light-dark(rgb(255 255 255 / 0.102), rgb(255 255 255 / 0.102))",
+        "on-status-ai": "light-dark(rgb(228 204 237), rgb(130 23 130))",
         "on-status-critical": "light-dark(rgb(255 204 153), rgb(153 69 0))",
         "on-status-critical-strong": "light-dark(rgb(240 112 0), rgb(255 153 51))",
         "on-status-danger": "light-dark(rgb(248 195 195), rgb(151 27 27))",

--- a/packages/tokens-pd/tailwind/default/tokens.js
+++ b/packages/tokens-pd/tailwind/default/tokens.js
@@ -111,6 +111,7 @@ export default {
         "border-on-brand": "light-dark(rgb(255 255 255 / 0.102), rgb(255 255 255 / 0.102))",
         "on-brand-border-active": "light-dark(rgb(244 245 245), rgb(24 25 27))",
         "on-brand-divider": "light-dark(rgb(255 255 255 / 0.102), rgb(255 255 255 / 0.102))",
+        "on-status-ai": "light-dark(rgb(228 204 237), rgb(130 23 130))",
         "on-status-critical": "light-dark(rgb(255 204 153), rgb(153 69 0))",
         "on-status-critical-strong": "light-dark(rgb(240 112 0), rgb(255 153 51))",
         "on-status-danger": "light-dark(rgb(248 195 195), rgb(151 27 27))",


### PR DESCRIPTION
# feat(design-tokens): add AI status semantic tokens

Adds AI-status semantic tokens covering background, border, glyph, and text on-status layers. Updates `gradients.ai.*` values (used by Button, Tag, SearchGlobal).

Full change details in `.changeset/sync-ai-status-tokens.md`.

**Depends on:** #514.
**Before merging:** once all dependencies above are merged into `chore/reformat-token-tiers`, rebase this branch: `git rebase origin/chore/reformat-token-tiers`.