### PR TITLE
chore(design-tokens): update Link.externalIcon.color token metadata

### DIFF
--- a/.changeset/sync-link-restructure.md
+++ b/.changeset/sync-link-restructure.md
@@ -1,0 +1,7 @@
+---
+'@acronis-platform/design-tokens': minor
+---
+
+Sync design tokens with Figma.
+
+Restructures Link component tokens into nested normal/inverse/\_global variant groups (24 tokens added, 18 deleted). The inverse variant references the new glyph.onBackdrop.screenPrimary semantic token.

--- a/.changeset/sync-link-restructure.md
+++ b/.changeset/sync-link-restructure.md
@@ -1,7 +1,7 @@
 ---
-'@acronis-platform/design-tokens': minor
+'@acronis-platform/design-tokens': patch
 ---
 
-Sync design tokens with Figma.
+Update metadata for `Link.externalIcon.color` state tokens.
 
-Restructures Link component tokens into nested normal/inverse/\_global variant groups (24 tokens added, 18 deleted). The inverse variant references the new glyph.onBackdrop.screenPrimary semantic token.
+Adds `com.figma.hiddenFromPublishing: true` and corrects Figma scope and variableId on `active`, `disabled`, `hover`, and `idle` — no token values changed.

--- a/packages/design-tokens/tiers/components.json
+++ b/packages/design-tokens/tiers/components.json
@@ -7596,8 +7596,9 @@
       "color": {
         "active": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
-            "com.figma.variableId": "VariableID:3741:877"
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP"],
+            "com.figma.variableId": "VariableID:3735:874"
           },
           "$type": "color",
           "platforms": ["PD"],
@@ -7608,8 +7609,9 @@
         },
         "disabled": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
-            "com.figma.variableId": "VariableID:3741:878"
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:3735:865"
           },
           "$type": "color",
           "platforms": ["PD"],
@@ -7620,8 +7622,9 @@
         },
         "hover": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
-            "com.figma.variableId": "VariableID:3741:876"
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:3735:863"
           },
           "$type": "color",
           "platforms": ["PD"],
@@ -7632,8 +7635,9 @@
         },
         "idle": {
           "$extensions": {
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
-            "com.figma.variableId": "VariableID:3740:875"
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:3735:862"
           },
           "$type": "color",
           "platforms": ["PD"],


### PR DESCRIPTION
Adds `com.figma.hiddenFromPublishing: true` and corrects Figma scope and variableId on `Link.externalIcon.color` state tokens (`active`, `disabled`, `hover`, `idle`) — metadata-only change, no token values affected.

**Depends on:** #517, #521.
**Before merging:** once all dependencies above are merged into `chore/reformat-token-tiers`, rebase this branch: `git rebase origin/chore/reformat-token-tiers`.