### PR TITLE
feat(design-tokens): update ButtonIcon tokens

### DIFF
--- a/.changeset/sync-buttonicon.md
+++ b/.changeset/sync-buttonicon.md
@@ -1,0 +1,7 @@
+---
+'@acronis-platform/design-tokens': minor
+---
+
+Sync design tokens with Figma.
+
+Adds one ButtonIcon token and updates 9 existing values. The secondary container border now references the new electricblue numeric palette.


### PR DESCRIPTION
# feat(design-tokens): update ButtonIcon tokens

Adds one `ButtonIcon` token and updates 9 values. Secondary container border references `palette.electricblue.3`.

Full change details in `.changeset/sync-buttonicon.md`.

**Depends on:** #517, #518.
**Before merging:** once all dependencies above are merged into `chore/reformat-token-tiers`, rebase this branch: `git rebase origin/chore/reformat-token-tiers`.