### PR TITLE
chore(design-tokens): update Figma extension metadata on component tokens

### DIFF
--- a/.changeset/sync-button-family.md
+++ b/.changeset/sync-button-family.md
@@ -1,0 +1,7 @@
+---
+'@acronis-platform/design-tokens': patch
+---
+
+Update Figma extension metadata on component tokens.
+
+Adds `com.figma.hiddenFromPublishing: true` and corrects scope and variableId fields on 12 tokens across `Button.ai.textStyle`, `errorMsg`, and `Link.externalIcon.color` — no token values changed.

--- a/.changeset/sync-button-family.md
+++ b/.changeset/sync-button-family.md
@@ -1,5 +1,6 @@
 ---
 '@acronis-platform/design-tokens': patch
+'@acronis-platform/tokens-pd': patch
 ---
 
 Update Figma extension metadata on component tokens.

--- a/packages/design-tokens/tiers/components.json
+++ b/packages/design-tokens/tiers/components.json
@@ -9538,7 +9538,7 @@
         "active": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": ["GAP"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:3735:874"
           },
           "$type": "color",
@@ -9553,7 +9553,7 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:3735:865"
           },
           "$type": "color",
@@ -9568,7 +9568,7 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:3735:863"
           },
           "$type": "color",
@@ -9583,7 +9583,7 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:3735:862"
           },
           "$type": "color",

--- a/packages/design-tokens/tiers/components.json
+++ b/packages/design-tokens/tiers/components.json
@@ -1410,9 +1410,8 @@
         "textStyle": {
           "active": {
             "$extensions": {
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3735:868"
             },
             "$type": "typography",
@@ -1426,9 +1425,8 @@
           },
           "disabled": {
             "$extensions": {
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3735:869"
             },
             "$type": "typography",
@@ -1442,9 +1440,8 @@
           },
           "hover": {
             "$extensions": {
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3735:867"
             },
             "$type": "typography",
@@ -1458,9 +1455,8 @@
           },
           "idle": {
             "$extensions": {
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3735:866"
             },
             "$type": "typography",
@@ -9128,9 +9124,8 @@
         "borderColor": {
           "hover": {
             "$extensions": {
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3689:2477"
             },
             "$type": "color",
@@ -9144,9 +9139,8 @@
           },
           "idle": {
             "$extensions": {
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3689:2476"
             },
             "$type": "color",
@@ -9163,9 +9157,8 @@
       "error": {
         "color": {
           "$extensions": {
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3689:2478"
           },
           "$type": "color",
@@ -9179,9 +9172,8 @@
         },
         "textStyle": {
           "$extensions": {
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3689:2479"
           },
           "$type": "typography",
@@ -9545,11 +9537,9 @@
       "color": {
         "active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
-            "com.figma.variableId": "VariableID:3741:877"
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP"],
+            "com.figma.variableId": "VariableID:3735:874"
           },
           "$type": "color",
           "platforms": [
@@ -9562,11 +9552,9 @@
         },
         "disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
-            "com.figma.variableId": "VariableID:3741:878"
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:3735:865"
           },
           "$type": "color",
           "platforms": [
@@ -9579,11 +9567,9 @@
         },
         "hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
-            "com.figma.variableId": "VariableID:3741:876"
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:3735:863"
           },
           "$type": "color",
           "platforms": [
@@ -9596,11 +9582,9 @@
         },
         "idle": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
-            "com.figma.variableId": "VariableID:3740:875"
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:3735:862"
           },
           "$type": "color",
           "platforms": [

--- a/packages/tokens-pd/dtcg/components-deep_sky_itkontoret.json
+++ b/packages/tokens-pd/dtcg/components-deep_sky_itkontoret.json
@@ -6387,7 +6387,7 @@
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
-              "GAP"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:3735:874"
           },
@@ -6398,7 +6398,7 @@
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
-              "ALL_SCOPES"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:3735:865"
           },
@@ -6409,7 +6409,7 @@
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
-              "ALL_SCOPES"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:3735:863"
           },
@@ -6420,7 +6420,7 @@
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
-              "ALL_SCOPES"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:3735:862"
           },

--- a/packages/tokens-pd/dtcg/components-deep_sky_itkontoret.json
+++ b/packages/tokens-pd/dtcg/components-deep_sky_itkontoret.json
@@ -930,6 +930,7 @@
         "textStyle": {
           "active": {
             "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
               "com.figma.scopes": [
                 "ALL_SCOPES"
               ],
@@ -940,6 +941,7 @@
           },
           "disabled": {
             "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
               "com.figma.scopes": [
                 "ALL_SCOPES"
               ],
@@ -950,6 +952,7 @@
           },
           "hover": {
             "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
               "com.figma.scopes": [
                 "ALL_SCOPES"
               ],
@@ -960,6 +963,7 @@
           },
           "idle": {
             "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
               "com.figma.scopes": [
                 "ALL_SCOPES"
               ],
@@ -6104,6 +6108,7 @@
         "borderColor": {
           "hover": {
             "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
               "com.figma.scopes": [
                 "STROKE_COLOR"
               ],
@@ -6114,6 +6119,7 @@
           },
           "idle": {
             "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
               "com.figma.scopes": [
                 "STROKE_COLOR"
               ],
@@ -6127,6 +6133,7 @@
       "error": {
         "color": {
           "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
               "ALL_SCOPES"
             ],
@@ -6137,6 +6144,7 @@
         },
         "textStyle": {
           "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
               "ALL_SCOPES"
             ],
@@ -6377,44 +6385,44 @@
       "color": {
         "active": {
           "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "GAP"
             ],
-            "com.figma.variableId": "VariableID:3741:877"
+            "com.figma.variableId": "VariableID:3735:874"
           },
           "$type": "color",
           "$value": "{colors.text.onSurface.link-pressed}"
         },
         "disabled": {
           "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "ALL_SCOPES"
             ],
-            "com.figma.variableId": "VariableID:3741:878"
+            "com.figma.variableId": "VariableID:3735:865"
           },
           "$type": "color",
           "$value": "{colors.text.onSurface.link-disabled}"
         },
         "hover": {
           "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "ALL_SCOPES"
             ],
-            "com.figma.variableId": "VariableID:3741:876"
+            "com.figma.variableId": "VariableID:3735:863"
           },
           "$type": "color",
           "$value": "{colors.text.onSurface.link-hover}"
         },
         "idle": {
           "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "ALL_SCOPES"
             ],
-            "com.figma.variableId": "VariableID:3740:875"
+            "com.figma.variableId": "VariableID:3735:862"
           },
           "$type": "color",
           "$value": "{colors.text.onSurface.link}"

--- a/packages/tokens-pd/dtcg/components-default.json
+++ b/packages/tokens-pd/dtcg/components-default.json
@@ -6387,7 +6387,7 @@
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
-              "GAP"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:3735:874"
           },
@@ -6398,7 +6398,7 @@
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
-              "ALL_SCOPES"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:3735:865"
           },
@@ -6409,7 +6409,7 @@
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
-              "ALL_SCOPES"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:3735:863"
           },
@@ -6420,7 +6420,7 @@
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
-              "ALL_SCOPES"
+              "SHAPE_FILL"
             ],
             "com.figma.variableId": "VariableID:3735:862"
           },

--- a/packages/tokens-pd/dtcg/components-default.json
+++ b/packages/tokens-pd/dtcg/components-default.json
@@ -930,6 +930,7 @@
         "textStyle": {
           "active": {
             "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
               "com.figma.scopes": [
                 "ALL_SCOPES"
               ],
@@ -940,6 +941,7 @@
           },
           "disabled": {
             "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
               "com.figma.scopes": [
                 "ALL_SCOPES"
               ],
@@ -950,6 +952,7 @@
           },
           "hover": {
             "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
               "com.figma.scopes": [
                 "ALL_SCOPES"
               ],
@@ -960,6 +963,7 @@
           },
           "idle": {
             "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
               "com.figma.scopes": [
                 "ALL_SCOPES"
               ],
@@ -6104,6 +6108,7 @@
         "borderColor": {
           "hover": {
             "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
               "com.figma.scopes": [
                 "STROKE_COLOR"
               ],
@@ -6114,6 +6119,7 @@
           },
           "idle": {
             "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
               "com.figma.scopes": [
                 "STROKE_COLOR"
               ],
@@ -6127,6 +6133,7 @@
       "error": {
         "color": {
           "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
               "ALL_SCOPES"
             ],
@@ -6137,6 +6144,7 @@
         },
         "textStyle": {
           "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
               "ALL_SCOPES"
             ],
@@ -6377,44 +6385,44 @@
       "color": {
         "active": {
           "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "GAP"
             ],
-            "com.figma.variableId": "VariableID:3741:877"
+            "com.figma.variableId": "VariableID:3735:874"
           },
           "$type": "color",
           "$value": "{colors.text.onSurface.link-pressed}"
         },
         "disabled": {
           "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "ALL_SCOPES"
             ],
-            "com.figma.variableId": "VariableID:3741:878"
+            "com.figma.variableId": "VariableID:3735:865"
           },
           "$type": "color",
           "$value": "{colors.text.onSurface.link-disabled}"
         },
         "hover": {
           "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "ALL_SCOPES"
             ],
-            "com.figma.variableId": "VariableID:3741:876"
+            "com.figma.variableId": "VariableID:3735:863"
           },
           "$type": "color",
           "$value": "{colors.text.onSurface.link-hover}"
         },
         "idle": {
           "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
+              "ALL_SCOPES"
             ],
-            "com.figma.variableId": "VariableID:3740:875"
+            "com.figma.variableId": "VariableID:3735:862"
           },
           "$type": "color",
           "$value": "{colors.text.onSurface.link}"


### PR DESCRIPTION
Adds `com.figma.hiddenFromPublishing: true` and corrects scope and variableId fields on 12 tokens across `Button.ai.textStyle`, `errorMsg`, and `Link.externalIcon.color` — no token values changed.

Absorbs #527 and #524.

**Depends on:** #515, #517, #518, #519, #521.
**Before merging:** once all dependencies above are merged into `chore/reformat-token-tiers`, rebase this branch: `git rebase origin/chore/reformat-token-tiers`.