### PR TITLE
fix(design-tokens): update input component token values

### DIFF
--- a/.changeset/sync-input-components.md
+++ b/.changeset/sync-input-components.md
@@ -1,0 +1,7 @@
+---
+'@acronis-platform/design-tokens': patch
+---
+
+Sync design tokens with Figma.
+
+Token value updates across InputText, InputTextArea, InputSearch, InputSelect, InputDatePicker, and SearchGlobal. No additions or deletions — updated references to revised semantic values.

--- a/packages/design-tokens/tiers/components.json
+++ b/packages/design-tokens/tiers/components.json
@@ -7267,6 +7267,7 @@
         "borderColor": {
           "hover": {
             "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
               "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3689:2477"
             },
@@ -7279,6 +7280,7 @@
           },
           "idle": {
             "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
               "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3689:2476"
             },
@@ -7294,6 +7296,7 @@
       "error": {
         "color": {
           "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3689:2478"
           },
@@ -7306,6 +7309,7 @@
         },
         "textStyle": {
           "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3689:2479"
           },


### PR DESCRIPTION
# fix(design-tokens): update input component token values

Token value updates across InputText, InputTextArea, InputSearch, InputSelect, InputDatePicker, and SearchGlobal. No additions or deletions.

Full change details in `.changeset/sync-input-components.md`.

**Depends on:** #517, #521.
**Before merging:** once all dependencies above are merged into `chore/reformat-token-tiers`, rebase this branch: `git rebase origin/chore/reformat-token-tiers`.