### PR TITLE
feat(design-tokens): update navigation component tokens

### DIFF
--- a/.changeset/sync-navigation-components.md
+++ b/.changeset/sync-navigation-components.md
@@ -1,0 +1,7 @@
+---
+'@acronis-platform/design-tokens': minor
+---
+
+Sync design tokens with Figma.
+
+Updates SidebarPrimary (23 tokens) and SidebarSecondary (32 tokens) values for the new branding system. Minor Breadcrumb updates (2 tokens). Removes 4 deprecated Resizable.bar.\* tokens.


### PR DESCRIPTION
# feat(design-tokens): update navigation component tokens

Updates SidebarPrimary (23) and SidebarSecondary (32) token values for the new branding system. Minor Breadcrumb updates (2). Removes 4 deprecated `Resizable.bar.*` tokens.

Full change details in `.changeset/sync-navigation-components.md`.

**Depends on:** #515, #521.
**Before merging:** once all dependencies above are merged into `chore/reformat-token-tiers`, rebase this branch: `git rebase origin/chore/reformat-token-tiers`.