### PR TITLE
feat(design-tokens): update form and display component tokens

### DIFF
--- a/.changeset/sync-form-display-components.md
+++ b/.changeset/sync-form-display-components.md
@@ -1,0 +1,7 @@
+---
+'@acronis-platform/design-tokens': minor
+---
+
+Sync design tokens with Figma.
+
+Updates Checkbox (adds border.borderRadius, removes legacy borderRadius), Radio (same), Switch, Avatar (adds/removes borderRadius), CardFilter, Table, Tag (gradients.ai), and Tooltip (now uses backdrop-inverse semantics).

--- a/.changeset/sync-form-display-components.md
+++ b/.changeset/sync-form-display-components.md
@@ -4,4 +4,6 @@
 
 Sync design tokens with Figma.
 
-Updates Checkbox (adds border.borderRadius, removes legacy borderRadius), Radio (same), Switch, Avatar (adds/removes borderRadius), CardFilter, Table, Tag (gradients.ai), and Tooltip (now uses backdrop-inverse semantics).
+- **Avatar**: moves `_global.borderRadius` into `_global.avatar.border.borderRadius` (aligns token path with the component structure).
+- **Checkbox**: renames `marginX` to `marginY`.
+- **Radio**: renames `marginX` to `marginY`.

--- a/.changeset/sync-form-display-components.md
+++ b/.changeset/sync-form-display-components.md
@@ -1,5 +1,7 @@
 ---
 '@acronis-platform/design-tokens': minor
+'@acronis-platform/tokens-pd': minor
+'@acronis-platform/ui-react': patch
 ---
 
 Sync design tokens with Figma.
@@ -7,3 +9,5 @@ Sync design tokens with Figma.
 - **Avatar**: moves `_global.borderRadius` into `_global.avatar.border.borderRadius` (aligns token path with the component structure).
 - **Checkbox**: renames `marginX` to `marginY`.
 - **Radio**: renames `marginX` to `marginY`.
+
+Regenerates tokens-pd and migrates the ui-react consumers (Avatar → `--ui-avatar-global-avatar-border-border-radius`, Checkbox → `--ui-checkbox-global-box-margin-y`) and their specs — like-for-like renames, no rendered change.

--- a/packages/design-tokens/tiers/components.json
+++ b/packages/design-tokens/tiers/components.json
@@ -31,6 +31,19 @@
     "_global": {
       "avatar": {
         "border": {
+          "borderRadius": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["CORNER_RADIUS"],
+              "com.figma.variableId": "VariableID:3111:188"
+            },
+            "$type": "dimension",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{palette.units.radius.radius-full}",
+              "default": "{palette.units.radius.radius-full}"
+            }
+          },
           "borderStyle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
@@ -3870,7 +3883,7 @@
             "default": "{units.stroke.1}"
           }
         },
-        "marginX": {
+        "marginY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
@@ -9789,7 +9802,7 @@
             "default": "{units.stroke.1}"
           }
         },
-        "marginX": {
+        "marginY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [

--- a/packages/design-tokens/tiers/components.json
+++ b/packages/design-tokens/tiers/components.json
@@ -40,8 +40,8 @@
             "$type": "dimension",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{palette.units.radius.radius-full}",
-              "default": "{palette.units.radius.radius-full}"
+              "deep_sky_itkontoret": "{units.radius.full}",
+              "default": "{units.radius.full}"
             }
           },
           "borderStyle": {

--- a/packages/design-tokens/tiers/components.json
+++ b/packages/design-tokens/tiers/components.json
@@ -96,23 +96,6 @@
             }
           }
         },
-        "borderRadius": {
-          "$extensions": {
-            "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
-            "com.figma.variableId": "VariableID:3111:188"
-          },
-          "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{units.radius.full}",
-            "default": "{units.radius.full}"
-          }
-        },
         "group": {
           "gap": {
             "$extensions": {

--- a/packages/tokens-pd/css/Avatar/default.css
+++ b/packages/tokens-pd/css/Avatar/default.css
@@ -9,10 +9,10 @@
   --ui-avatar-color-teal: light-dark(rgb(209 240 237), rgb(4 73 67));
   --ui-avatar-color-violet: light-dark(rgb(236 222 242), rgb(108 19 108));
   --ui-avatar-color-yellow: light-dark(rgb(255 238 178), rgb(138 99 0));
+  --ui-avatar-global-avatar-border-border-radius: 999px;
   --ui-avatar-global-avatar-border-border-style: solid;
   --ui-avatar-global-avatar-border-border-width: 2px;
   --ui-avatar-global-avatar-border-color: light-dark(rgb(255 255 255), rgb(31 32 34));
-  --ui-avatar-global-avatar-border-radius: 999px;
   --ui-avatar-global-avatar-group-gap: -6px;
   --ui-avatar-global-avatar-size: 32px;
   --ui-avatar-global-container-gap: 8px;

--- a/packages/tokens-pd/css/Checkbox/default.css
+++ b/packages/tokens-pd/css/Checkbox/default.css
@@ -18,7 +18,7 @@
   --ui-checkbox-checked-icon-color-idle: light-dark(rgb(255 255 255), rgb(255 255 255));
   --ui-checkbox-global-box-border-radius: 2px;
   --ui-checkbox-global-box-border-width: 1px;
-  --ui-checkbox-global-box-margin-x: 4px;
+  --ui-checkbox-global-box-margin-y: 4px;
   --ui-checkbox-global-box-size: 16px;
   --ui-checkbox-global-container-content-gap: 0px;
   --ui-checkbox-global-container-content-width-max: 632px;

--- a/packages/tokens-pd/css/Radio/default.css
+++ b/packages/tokens-pd/css/Radio/default.css
@@ -18,7 +18,7 @@
   --ui-radio-checked-icon-color-idle: light-dark(rgb(255 255 255), rgb(255 255 255));
   --ui-radio-global-box-border-radius: 999px;
   --ui-radio-global-box-border-width: 1px;
-  --ui-radio-global-box-margin-x: 4px;
+  --ui-radio-global-box-margin-y: 4px;
   --ui-radio-global-box-size: 16px;
   --ui-radio-global-container-content-gap: 0px;
   --ui-radio-global-container-content-width-max: 632px;

--- a/packages/tokens-pd/dtcg/components-deep_sky_itkontoret.json
+++ b/packages/tokens-pd/dtcg/components-deep_sky_itkontoret.json
@@ -3,6 +3,17 @@
     "_global": {
       "avatar": {
         "border": {
+          "borderRadius": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": [
+                "CORNER_RADIUS"
+              ],
+              "com.figma.variableId": "VariableID:3111:188"
+            },
+            "$type": "dimension",
+            "$value": "{units.radius.full}"
+          },
           "borderStyle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
@@ -36,17 +47,6 @@
             "$type": "color",
             "$value": "{palette.base}"
           }
-        },
-        "borderRadius": {
-          "$extensions": {
-            "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
-            "com.figma.variableId": "VariableID:3111:188"
-          },
-          "$type": "dimension",
-          "$value": "{units.radius.full}"
         },
         "group": {
           "gap": {
@@ -2576,7 +2576,7 @@
           "$type": "dimension",
           "$value": "{units.stroke.1}"
         },
-        "marginX": {
+        "marginY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
@@ -6533,7 +6533,7 @@
           "$type": "dimension",
           "$value": "{units.stroke.1}"
         },
-        "marginX": {
+        "marginY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [

--- a/packages/tokens-pd/dtcg/components-default.json
+++ b/packages/tokens-pd/dtcg/components-default.json
@@ -3,6 +3,17 @@
     "_global": {
       "avatar": {
         "border": {
+          "borderRadius": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": [
+                "CORNER_RADIUS"
+              ],
+              "com.figma.variableId": "VariableID:3111:188"
+            },
+            "$type": "dimension",
+            "$value": "{units.radius.full}"
+          },
           "borderStyle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
@@ -36,17 +47,6 @@
             "$type": "color",
             "$value": "{palette.base}"
           }
-        },
-        "borderRadius": {
-          "$extensions": {
-            "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
-            "com.figma.variableId": "VariableID:3111:188"
-          },
-          "$type": "dimension",
-          "$value": "{units.radius.full}"
         },
         "group": {
           "gap": {
@@ -2576,7 +2576,7 @@
           "$type": "dimension",
           "$value": "{units.stroke.1}"
         },
-        "marginX": {
+        "marginY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [
@@ -6533,7 +6533,7 @@
           "$type": "dimension",
           "$value": "{units.stroke.1}"
         },
-        "marginX": {
+        "marginY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
             "com.figma.scopes": [

--- a/packages/tokens-pd/tailwind/deep_sky_itkontoret/components/Avatar.js
+++ b/packages/tokens-pd/tailwind/deep_sky_itkontoret/components/Avatar.js
@@ -45,7 +45,7 @@ export default {
         "avatar-global-container-gap": "8px"
       },
       "borderRadius": {
-        "avatar-global-avatar-border-radius": "999px"
+        "avatar-global-avatar-border-border-radius": "999px"
       }
     },
   },

--- a/packages/tokens-pd/tailwind/deep_sky_itkontoret/components/Checkbox.js
+++ b/packages/tokens-pd/tailwind/deep_sky_itkontoret/components/Checkbox.js
@@ -71,7 +71,7 @@ export default {
       },
       "spacing": {
         "checkbox-global-box-border-width": "1px",
-        "checkbox-global-box-margin-x": "4px",
+        "checkbox-global-box-margin-y": "4px",
         "checkbox-global-box-size": "16px",
         "checkbox-global-container-gap": "8px",
         "checkbox-global-container-width-max": "632px",

--- a/packages/tokens-pd/tailwind/deep_sky_itkontoret/components/Radio.js
+++ b/packages/tokens-pd/tailwind/deep_sky_itkontoret/components/Radio.js
@@ -59,7 +59,7 @@ export default {
       },
       "spacing": {
         "radio-global-box-border-width": "1px",
-        "radio-global-box-margin-x": "4px",
+        "radio-global-box-margin-y": "4px",
         "radio-global-box-size": "16px",
         "radio-global-container-gap": "8px",
         "radio-global-container-width-max": "632px",

--- a/packages/tokens-pd/tailwind/default/components/Avatar.js
+++ b/packages/tokens-pd/tailwind/default/components/Avatar.js
@@ -45,7 +45,7 @@ export default {
         "avatar-global-container-gap": "8px"
       },
       "borderRadius": {
-        "avatar-global-avatar-border-radius": "999px"
+        "avatar-global-avatar-border-border-radius": "999px"
       }
     },
   },

--- a/packages/tokens-pd/tailwind/default/components/Checkbox.js
+++ b/packages/tokens-pd/tailwind/default/components/Checkbox.js
@@ -71,7 +71,7 @@ export default {
       },
       "spacing": {
         "checkbox-global-box-border-width": "1px",
-        "checkbox-global-box-margin-x": "4px",
+        "checkbox-global-box-margin-y": "4px",
         "checkbox-global-box-size": "16px",
         "checkbox-global-container-gap": "8px",
         "checkbox-global-container-width-max": "632px",

--- a/packages/tokens-pd/tailwind/default/components/Radio.js
+++ b/packages/tokens-pd/tailwind/default/components/Radio.js
@@ -59,7 +59,7 @@ export default {
       },
       "spacing": {
         "radio-global-box-border-width": "1px",
-        "radio-global-box-margin-x": "4px",
+        "radio-global-box-margin-y": "4px",
         "radio-global-box-size": "16px",
         "radio-global-container-gap": "8px",
         "radio-global-container-width-max": "632px",

--- a/packages/ui-react/src/components/ui/avatar/avatar.tsx
+++ b/packages/ui-react/src/components/ui/avatar/avatar.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils';
 
 // Wraps Base UI's Avatar primitive (Root / Image / Fallback), themed by the
 // dedicated next-gen `--ui-avatar-*` token tier from @acronis-platform/tokens-pd.
-// A 32px circle (`--ui-avatar-global-avatar-size` / `-border-radius`) with a 2px
+// A 32px circle (`--ui-avatar-global-avatar-size` / `-border-border-radius`) with a 2px
 // ring (`-border-border-width` / `-border-color`) — the ring is what visually
 // separates avatars when they overlap in an `AvatarGroup`. When no image is set
 // (or it fails to load) the `AvatarFallback` shows initials.
@@ -30,7 +30,7 @@ import { cn } from '@/lib/utils';
 // style baked into the design (`text-xs font-semibold leading-4`).
 const avatarVariants = cva(
   'relative inline-flex shrink-0 select-none items-center justify-center overflow-hidden ' +
-    'size-[var(--ui-avatar-global-avatar-size)] rounded-[var(--ui-avatar-global-avatar-border-radius)] ' +
+    'size-[var(--ui-avatar-global-avatar-size)] rounded-[var(--ui-avatar-global-avatar-border-border-radius)] ' +
     '[box-shadow:0_0_0_var(--ui-avatar-global-avatar-border-border-width)_var(--ui-avatar-global-avatar-border-color)] ' +
     'text-xs font-semibold leading-4',
   {

--- a/packages/ui-react/src/components/ui/checkbox/checkbox.tsx
+++ b/packages/ui-react/src/components/ui/checkbox/checkbox.tsx
@@ -24,7 +24,7 @@ import { cn } from '@/lib/utils';
 // optional label, and an optional description stacked beside it. When either is
 // present the whole row is a `<label>` (so clicking the text toggles the box — a
 // Base UI checkbox renders a labelable <button>), the box gets a top margin of
-// `--ui-checkbox-global-box-margin-x` (4px = (line-height 24 − box 16) / 2, the
+// `--ui-checkbox-global-box-margin-y` (4px = (line-height 24 − box 16) / 2, the
 // design's box alignment margin) to center it on the first text line, and the
 // box is wired to the text via aria-labelledby / aria-describedby. With neither,
 // the box renders on its own (name it with `aria-label`).
@@ -76,7 +76,7 @@ const Checkbox = React.forwardRef<
       aria-describedby={descriptionId}
       className={cn(
         boxClasses,
-        hasContent && 'mt-[var(--ui-checkbox-global-box-margin-x)]',
+        hasContent && 'mt-[var(--ui-checkbox-global-box-margin-y)]',
         className
       )}
       {...props}

--- a/packages/ui-spec/components/avatar/tokens.yaml
+++ b/packages/ui-spec/components/avatar/tokens.yaml
@@ -13,7 +13,7 @@ tokens:
   # ── Shared geometry / border (root) ──
   - name: --ui-avatar-global-avatar-size
     affects: root
-  - name: --ui-avatar-global-avatar-border-radius
+  - name: --ui-avatar-global-avatar-border-border-radius
     affects: root
   - name: --ui-avatar-global-avatar-border-border-width
     affects: root

--- a/packages/ui-spec/components/checkbox/tokens.yaml
+++ b/packages/ui-spec/components/checkbox/tokens.yaml
@@ -13,7 +13,7 @@ tokens:
   - { name: --ui-checkbox-global-box-size, affects: root }
   - { name: --ui-checkbox-global-box-border-radius, affects: root }
   - { name: --ui-checkbox-global-box-border-width, affects: root }
-  - { name: --ui-checkbox-global-box-margin-x, affects: root }
+  - { name: --ui-checkbox-global-box-margin-y, affects: root }
   - { name: --ui-checkbox-global-container-gap, affects: container }
   - { name: --ui-checkbox-global-container-width-min, affects: container }
   - { name: --ui-checkbox-global-container-width-max, affects: container }

--- a/packages/ui-spec/components/radio/tokens.yaml
+++ b/packages/ui-spec/components/radio/tokens.yaml
@@ -13,7 +13,7 @@ tokens:
   - { name: --ui-radio-global-box-size, affects: item }
   - { name: --ui-radio-global-box-border-radius, affects: item }
   - { name: --ui-radio-global-box-border-width, affects: item }
-  - { name: --ui-radio-global-box-margin-x, affects: item }
+  - { name: --ui-radio-global-box-margin-y, affects: item }
   - { name: --ui-radio-global-container-gap, affects: container }
   - { name: --ui-radio-global-container-width-min, affects: container }
   - { name: --ui-radio-global-container-width-max, affects: container }


### PR DESCRIPTION
# feat(design-tokens): update form and display component tokens

Updates Checkbox, Radio, Switch, Avatar, CardFilter, Table, Tag, and Tooltip. Tooltip now uses the backdrop-inverse semantics added in #516. Checkbox and Radio gain `border.borderRadius` (legacy `borderRadius` removed). Tag uses updated `gradients.ai.*`.

Full change details in `.changeset/sync-form-display-components.md`.

**Depends on:** #516, #518, #519, #520, #521.
**Before merging:** once all dependencies above are merged into `chore/reformat-token-tiers`, rebase this branch: `git rebase origin/chore/reformat-token-tiers`.