### PR TITLE
fix(sidebar-secondary, resizable): ux polish and resize edge focus ring

### DIFF
--- a/.changeset/sidebar-secondary-ux-fixes.md
+++ b/.changeset/sidebar-secondary-ux-fixes.md
@@ -1,0 +1,41 @@
+---
+'@acronis-platform/ui-react': patch
+---
+
+SidebarSecondary, Resizable, ButtonIcon, Tooltip: UX polish fixes
+
+**Cursor styles:**
+
+- Add `cursor-pointer` to menu items, collapse triggers, and expandable section labels
+- Add `cursor-pointer` to `ButtonIcon` base styles globally
+
+**Keyboard accessibility:**
+
+- Space key now activates focused anchor menu items (native `<a>` only responds to Enter)
+- Resize edge: Space toggles expand/collapse, ArrowRight expands when collapsed
+
+**Resize edge:**
+
+- Widen hit area from 9px to 17px for easier targeting
+- Add `trackCursorAxis="y"` to resize edge tooltip so it follows the pointer vertically
+- Render own focus ring via `after` pseudo (CSS border + box-shadow) instead of sidebar container ring
+- Sidebar container `:has()` styles now target `border-inline-end-color` only (no outer ring)
+
+**Resizable:**
+
+- `ResizableHandle` divider line now uses a CSS border (`border-inline-start`) instead of `width` + `background` so the browser pixel-snaps the 1px line on fractional positions
+- Focus ring rendered as `box-shadow` on the `after` pseudo, auto-centered on the line
+
+**Focus retention:**
+
+- CollapseTrigger now keeps stable DOM structure (Tooltip wrapper always present, disabled when expanded) so focus is preserved across state changes
+
+**Tooltip delay:**
+
+- `TooltipProvider` now defaults `delay` to 300ms (down from Base UI's 600ms)
+
+**Stories:**
+
+- Operations section items show per-item counters (12, 10)
+- External link items use `target="_blank" rel="noopener noreferrer"`
+- Section action `ButtonIcon` wrapped in `Tooltip`

--- a/packages/ui-react/src/components/ui/button-icon/__tests__/button-icon.test.tsx
+++ b/packages/ui-react/src/components/ui/button-icon/__tests__/button-icon.test.tsx
@@ -113,4 +113,13 @@ describe('ButtonIcon', () => {
     expect(link).toHaveAttribute('href', '/home');
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
+
+  it('has cursor-pointer by default', () => {
+    render(
+      <ButtonIcon aria-label="Add">
+        <Icon />
+      </ButtonIcon>
+    );
+    expect(screen.getByRole('button', { name: 'Add' })).toHaveClass('cursor-pointer');
+  });
 });

--- a/packages/ui-react/src/components/ui/button-icon/button-icon.tsx
+++ b/packages/ui-react/src/components/ui/button-icon/button-icon.tsx
@@ -19,7 +19,7 @@ import { cn } from '@/lib/utils';
 // disabled tokens (not opacity), and the focus state is a 3px `--ui-focus-primary`
 // ring flush to the edge (no offset), matching the Figma.
 const buttonIconVariants = cva(
-  'inline-flex size-[var(--ui-button-icon-global-container-height)] shrink-0 items-center justify-center rounded-[var(--ui-button-icon-global-container-border-radius)] transition-colors ' +
+  'inline-flex size-[var(--ui-button-icon-global-container-height)] shrink-0 items-center justify-center rounded-[var(--ui-button-icon-global-container-border-radius)] transition-colors cursor-pointer ' +
     'bg-[var(--ui-button-icon-global-container-color-idle)] text-[var(--ui-button-icon-global-icon-color-idle)] ' +
     'hover:bg-[var(--ui-button-icon-global-container-color-hover)] hover:text-[var(--ui-button-icon-global-icon-color-hover)] ' +
     'active:bg-[var(--ui-button-icon-global-container-color-active)] active:text-[var(--ui-button-icon-global-icon-color-active)] ' +

--- a/packages/ui-react/src/components/ui/resizable/__tests__/resizable.test.tsx
+++ b/packages/ui-react/src/components/ui/resizable/__tests__/resizable.test.tsx
@@ -66,9 +66,9 @@ describe('Resizable', () => {
     render(<Group />);
     const handle = screen.getByRole('separator');
     expect(handle).toHaveClass(
-      'hover:after:bg-[var(--ui-resizable-border-color-hover)]',
-      'active:after:bg-[var(--ui-resizable-border-color-active)]',
-      'focus-visible:ring-[var(--ui-focus-primary)]'
+      'hover:after:[border-inline-start-color:var(--ui-resizable-border-color-hover)]',
+      'active:after:[border-inline-start-color:var(--ui-resizable-border-color-active)]',
+      'focus-visible:after:[border-inline-start-color:var(--ui-resizable-border-color-active)]'
     );
   });
 });

--- a/packages/ui-react/src/components/ui/resizable/__tests__/resizable.test.tsx
+++ b/packages/ui-react/src/components/ui/resizable/__tests__/resizable.test.tsx
@@ -66,9 +66,29 @@ describe('Resizable', () => {
     render(<Group />);
     const handle = screen.getByRole('separator');
     expect(handle).toHaveClass(
-      'hover:after:[border-inline-start-color:var(--ui-resizable-border-color-hover)]',
-      'active:after:[border-inline-start-color:var(--ui-resizable-border-color-active)]',
-      'focus-visible:after:[border-inline-start-color:var(--ui-resizable-border-color-active)]'
+      'hover:after:[border-color:var(--ui-resizable-border-color-hover)]',
+      'active:after:[border-color:var(--ui-resizable-border-color-active)]',
+      'focus-visible:after:[border-color:var(--ui-resizable-border-color-active)]',
+      'focus-visible:after:[box-shadow:0_0_0_3px_var(--ui-focus-primary)]'
+    );
+  });
+
+  it('draws the vertical divider with the inline-start border', () => {
+    render(<Group orientation="horizontal" />);
+    const handle = screen.getByRole('separator');
+    expect(handle).toHaveAttribute('aria-orientation', 'vertical');
+    expect(handle).toHaveClass(
+      'after:[border-inline-start-width:var(--ui-resizable-border-width)]'
+    );
+  });
+
+  it('draws the stacked divider with the block-start (top) border', () => {
+    render(<Group orientation="vertical" />);
+    const handle = screen.getByRole('separator');
+    expect(handle).toHaveAttribute('aria-orientation', 'horizontal');
+    expect(handle).toHaveClass(
+      'aria-[orientation=horizontal]:after:[border-inline-start-width:0]',
+      'aria-[orientation=horizontal]:after:[border-block-start-width:var(--ui-resizable-border-width)]'
     );
   });
 });

--- a/packages/ui-react/src/components/ui/resizable/resizable.tsx
+++ b/packages/ui-react/src/components/ui/resizable/resizable.tsx
@@ -44,11 +44,15 @@ function ResizableHandle({ className, ...props }: ResizableHandleProps) {
         'relative flex w-[9px] items-center justify-center',
         'cursor-[var(--ui-resizable-cursor)] outline-none',
         // Centered 1px divider line (idle → semantic border, hover → hover token, drag → active token).
-        'after:absolute after:inset-y-0 after:start-1/2 after:-translate-x-1/2',
-        'after:w-[var(--ui-resizable-border-width)] after:bg-[var(--ui-border-on-surface-border)]',
-        'hover:after:bg-[var(--ui-resizable-border-color-hover)]',
-        'active:after:bg-[var(--ui-resizable-border-color-active)]',
-        'focus-visible:ring-[3px] focus-visible:ring-[var(--ui-focus-primary)]',
+        // Uses a CSS border (not width+background) so the browser pixel-snaps the line
+        // and it doesn't blur across device pixels when the handle lands at a fractional position.
+        'after:absolute after:inset-y-0 after:inset-x-0 after:mx-auto after:w-0',
+        'after:[border-inline-start-width:var(--ui-resizable-border-width)] after:border-solid after:[border-inline-start-color:var(--ui-border-on-surface-border)]',
+        'hover:after:[border-inline-start-color:var(--ui-resizable-border-color-hover)]',
+        'active:after:[border-inline-start-color:var(--ui-resizable-border-color-active)]',
+        // Focus ring: 3px box-shadow on the line itself so it auto-centers (Figma 4649:6686).
+        'focus-visible:after:[box-shadow:0_0_0_3px_var(--ui-focus-primary)] focus-visible:after:[border-inline-start-color:var(--ui-resizable-border-color-active)]',
+        'active:after:shadow-none',
         // orientation=horizontal = panels stacked → horizontal divider line.
         'aria-[orientation=horizontal]:h-[9px] aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:cursor-[ns-resize]',
         'aria-[orientation=horizontal]:after:inset-x-0 aria-[orientation=horizontal]:after:inset-y-auto aria-[orientation=horizontal]:after:start-auto aria-[orientation=horizontal]:after:top-1/2 aria-[orientation=horizontal]:after:h-[var(--ui-resizable-border-width)] aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:-translate-y-1/2 aria-[orientation=horizontal]:after:translate-x-0',

--- a/packages/ui-react/src/components/ui/resizable/resizable.tsx
+++ b/packages/ui-react/src/components/ui/resizable/resizable.tsx
@@ -46,16 +46,23 @@ function ResizableHandle({ className, ...props }: ResizableHandleProps) {
         // Centered 1px divider line (idle → semantic border, hover → hover token, drag → active token).
         // Uses a CSS border (not width+background) so the browser pixel-snaps the line
         // and it doesn't blur across device pixels when the handle lands at a fractional position.
+        // The vertical divider is a zero-width box painted by its inline-start
+        // (left) border; the horizontal override below swaps to the block-start
+        // (top) border. Color is set with `border-color` (all sides) so it
+        // applies regardless of which side carries the width.
         'after:absolute after:inset-y-0 after:inset-x-0 after:mx-auto after:w-0',
-        'after:[border-inline-start-width:var(--ui-resizable-border-width)] after:border-solid after:[border-inline-start-color:var(--ui-border-on-surface-border)]',
-        'hover:after:[border-inline-start-color:var(--ui-resizable-border-color-hover)]',
-        'active:after:[border-inline-start-color:var(--ui-resizable-border-color-active)]',
+        'after:[border-inline-start-width:var(--ui-resizable-border-width)] after:border-solid after:[border-color:var(--ui-border-on-surface-border)]',
+        'hover:after:[border-color:var(--ui-resizable-border-color-hover)]',
+        'active:after:[border-color:var(--ui-resizable-border-color-active)]',
         // Focus ring: 3px box-shadow on the line itself so it auto-centers (Figma 4649:6686).
-        'focus-visible:after:[box-shadow:0_0_0_3px_var(--ui-focus-primary)] focus-visible:after:[border-inline-start-color:var(--ui-resizable-border-color-active)]',
+        'focus-visible:after:[box-shadow:0_0_0_3px_var(--ui-focus-primary)] focus-visible:after:[border-color:var(--ui-resizable-border-color-active)]',
         'active:after:shadow-none',
         // orientation=horizontal = panels stacked → horizontal divider line.
+        // Draw it with the block-start (top) border and reset the inline-start
+        // border used for the vertical line, so the full-width line renders.
         'aria-[orientation=horizontal]:h-[9px] aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:cursor-[ns-resize]',
-        'aria-[orientation=horizontal]:after:inset-x-0 aria-[orientation=horizontal]:after:inset-y-auto aria-[orientation=horizontal]:after:start-auto aria-[orientation=horizontal]:after:top-1/2 aria-[orientation=horizontal]:after:h-[var(--ui-resizable-border-width)] aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:-translate-y-1/2 aria-[orientation=horizontal]:after:translate-x-0',
+        'aria-[orientation=horizontal]:after:inset-x-0 aria-[orientation=horizontal]:after:inset-y-auto aria-[orientation=horizontal]:after:start-auto aria-[orientation=horizontal]:after:top-1/2 aria-[orientation=horizontal]:after:h-0 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:-translate-y-1/2 aria-[orientation=horizontal]:after:translate-x-0',
+        'aria-[orientation=horizontal]:after:[border-inline-start-width:0] aria-[orientation=horizontal]:after:[border-block-start-width:var(--ui-resizable-border-width)]',
         className
       )}
       {...props}

--- a/packages/ui-react/src/components/ui/sidebar-secondary/__stories__/sidebar-secondary.stories.tsx
+++ b/packages/ui-react/src/components/ui/sidebar-secondary/__stories__/sidebar-secondary.stories.tsx
@@ -13,6 +13,7 @@ import {
 
 import { ButtonIcon } from '../../button-icon';
 import { Tag } from '../../tag';
+import { Tooltip, TooltipTrigger, TooltipContent } from '../../tooltip';
 
 import {
   SidebarSecondary,
@@ -160,7 +161,9 @@ export const Default: Story = {
                 Antivirus
               </SidebarSecondaryMenuItem>
               <SidebarSecondaryMenuItem
-                href="#"
+                href="https://example.com"
+                target="_blank"
+                rel="noopener noreferrer"
                 icon={<BoltIcon />}
                 extras={<SidebarSecondaryMenuItemExtras variant="externalLink" />}
               >
@@ -283,7 +286,9 @@ export const WithExtras: Story = {
                 Shortcut
               </SidebarSecondaryMenuItem>
               <SidebarSecondaryMenuItem
-                href="#"
+                href="https://example.com"
+                target="_blank"
+                rel="noopener noreferrer"
                 icon={<BoltIcon />}
                 extras={<SidebarSecondaryMenuItemExtras variant="externalLink" />}
               >
@@ -302,7 +307,9 @@ export const WithExtras: Story = {
                 With tag
               </SidebarSecondaryMenuItem>
               <SidebarSecondaryMenuItem
-                href="#"
+                href="https://example.com"
+                target="_blank"
+                rel="noopener noreferrer"
                 icon={<LayoutGridIcon />}
                 extras={
                   <SidebarSecondaryMenuItemExtras
@@ -433,9 +440,16 @@ export const SectionActionsAndRollup: Story = {
           <SidebarSecondarySection expandable>
             <SidebarSecondarySectionLabel
               actions={
-                <ButtonIcon aria-label="Add dashboard">
-                  <PlusIcon />
-                </ButtonIcon>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <ButtonIcon aria-label="Create dashboard">
+                        <PlusIcon />
+                      </ButtonIcon>
+                    }
+                  />
+                  <TooltipContent>Create dashboard</TooltipContent>
+                </Tooltip>
               }
             >
               Dashboards
@@ -462,8 +476,28 @@ export const SectionActionsAndRollup: Story = {
               Operations
             </SidebarSecondarySectionLabel>
             <SidebarSecondaryMenu>
-              <SidebarSecondaryMenuItem href="#">Alerts</SidebarSecondaryMenuItem>
-              <SidebarSecondaryMenuItem href="#">Activities</SidebarSecondaryMenuItem>
+              <SidebarSecondaryMenuItem
+                href="#"
+                extras={
+                  <SidebarSecondaryMenuItemExtras
+                    variant="tag"
+                    tag={<Tag variant="neutral" size="sm">12</Tag>}
+                  />
+                }
+              >
+                Alerts
+              </SidebarSecondaryMenuItem>
+              <SidebarSecondaryMenuItem
+                href="#"
+                extras={
+                  <SidebarSecondaryMenuItemExtras
+                    variant="tag"
+                    tag={<Tag variant="neutral" size="sm">10</Tag>}
+                  />
+                }
+              >
+                Activities
+              </SidebarSecondaryMenuItem>
             </SidebarSecondaryMenu>
           </SidebarSecondarySection>
           <SidebarSecondarySection>

--- a/packages/ui-react/src/components/ui/sidebar-secondary/__tests__/sidebar-secondary.test.tsx
+++ b/packages/ui-react/src/components/ui/sidebar-secondary/__tests__/sidebar-secondary.test.tsx
@@ -522,4 +522,96 @@ describe('Resize', () => {
     const nav = screen.getByRole('navigation');
     expect(nav.style.width).toBe('');
   });
+
+  it('resize edge has 17px hit area', () => {
+    render(<Panel />);
+    const edge = screen.getByRole('separator', { name: /resize sidebar/i });
+    expect(edge).toHaveClass('w-[17px]');
+  });
+
+  it('Space key toggles expanded state on resize edge', async () => {
+    const onChange = vi.fn();
+    render(<Panel resizable onExpandedChange={onChange} />);
+    const edge = screen.getByRole('separator', { name: /resize sidebar/i });
+    edge.focus();
+    await userEvent.keyboard(' ');
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  it('ArrowRight expands when sidebar is collapsed', async () => {
+    const onChange = vi.fn();
+    render(<Panel resizable expanded={false} onExpandedChange={onChange} />);
+    const edge = screen.getByRole('separator', { name: /resize sidebar/i });
+    edge.focus();
+    await userEvent.keyboard('{ArrowRight}');
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+});
+
+describe('SidebarSecondary — cursor styles', () => {
+  it('menu items have cursor-pointer', () => {
+    render(<Panel />);
+    const link = screen.getByRole('link', { name: 'Dashboard' });
+    expect(link).toHaveClass('cursor-pointer');
+  });
+
+  it('expandable section labels have cursor-pointer', () => {
+    render(
+      <SidebarSecondary>
+        <SidebarSecondaryContent>
+          <SidebarSecondarySection expandable>
+            <SidebarSecondarySectionLabel>Config</SidebarSecondarySectionLabel>
+            <SidebarSecondaryMenu>
+              <SidebarSecondaryMenuItem href="/p">Policies</SidebarSecondaryMenuItem>
+            </SidebarSecondaryMenu>
+          </SidebarSecondarySection>
+        </SidebarSecondaryContent>
+      </SidebarSecondary>
+    );
+    const trigger = screen.getByRole('button', { name: /Config/ });
+    expect(trigger).toHaveClass('cursor-pointer');
+  });
+});
+
+describe('SidebarSecondary — Space key on anchor items', () => {
+  it('Space activates a focused menu item anchor', async () => {
+    const onClick = vi.fn();
+    render(
+      <SidebarSecondary>
+        <SidebarSecondaryMenu>
+          <SidebarSecondaryMenuItem href="/test" onClick={onClick}>
+            Test item
+          </SidebarSecondaryMenuItem>
+        </SidebarSecondaryMenu>
+      </SidebarSecondary>
+    );
+    const link = screen.getByRole('link', { name: 'Test item' });
+    link.focus();
+    await userEvent.keyboard(' ');
+    expect(onClick).toHaveBeenCalled();
+  });
+});
+
+describe('SidebarSecondary — CollapseTrigger focus retention', () => {
+  it('focus stays on collapse trigger after toggling expanded state', async () => {
+    render(
+      <SidebarSecondary defaultExpanded>
+        <SidebarSecondaryFooter>
+          <SidebarSecondaryMenu>
+            <SidebarSecondaryCollapseTrigger>
+              Collapse menu
+            </SidebarSecondaryCollapseTrigger>
+          </SidebarSecondaryMenu>
+        </SidebarSecondaryFooter>
+      </SidebarSecondary>
+    );
+    const trigger = screen.getByRole('button', { name: 'Collapse menu' });
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+    await userEvent.click(trigger);
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: 'Collapse menu' });
+      expect(document.activeElement).toBe(btn);
+    });
+  });
 });

--- a/packages/ui-react/src/components/ui/sidebar-secondary/sidebar-secondary.tsx
+++ b/packages/ui-react/src/components/ui/sidebar-secondary/sidebar-secondary.tsx
@@ -356,6 +356,9 @@ function SidebarSecondaryResizeEdge() {
     if (e.key === growKey && exp) {
       e.preventDefault();
       sw(Math.min(w + step, maxWidth));
+    } else if (e.key === growKey && !exp) {
+      e.preventDefault();
+      te();
     } else if (e.key === shrinkKey && exp) {
       e.preventDefault();
       const next = w - step;
@@ -364,7 +367,7 @@ function SidebarSecondaryResizeEdge() {
       } else {
         sw(next);
       }
-    } else if (e.key === 'Enter') {
+    } else if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       te();
     } else if (e.key === 'Home') {
@@ -381,7 +384,7 @@ function SidebarSecondaryResizeEdge() {
   };
 
   return (
-    <Tooltip open={tooltipOpen} onOpenChange={handleTooltipOpenChange}>
+    <Tooltip open={tooltipOpen} onOpenChange={handleTooltipOpenChange} trackCursorAxis="y">
       <TooltipTrigger
         render={
           <div
@@ -389,10 +392,14 @@ function SidebarSecondaryResizeEdge() {
             aria-orientation="vertical"
             aria-label={ctx.resizeAriaLabel}
             className={cn(
-              // 9px hit area matching ResizableHandle, absolutely positioned on inline-end edge.
-              // No after: divider — the sidebar's own border-e changes color via :has() on hover/active/focus.
-              'absolute end-0 top-0 h-full w-[9px] ltr:translate-x-1/2 rtl:-translate-x-1/2 cursor-[var(--ui-resizable-cursor,ew-resize)] z-10',
-              'focus-visible:outline-none'
+              // 17px hit area, absolutely positioned on inline-end edge.
+              // The sidebar's own border-e provides the visible 1px line; its color
+              // changes via :has() on hover/active/focus-visible.
+              'absolute end-0 top-0 h-full w-[17px] ltr:translate-x-1/2 rtl:-translate-x-1/2 cursor-[var(--ui-resizable-cursor,ew-resize)] z-10',
+              // On focus: 1px active-color line (after pseudo, CSS border for pixel-snap) + 3px box-shadow ring centered on it.
+              'after:absolute after:inset-y-0 after:inset-x-0 after:mx-auto after:w-0 after:pointer-events-none',
+              'after:[border-inline-start-width:var(--ui-resizable-border-width,1px)] after:border-solid after:border-transparent',
+              'focus-visible:outline-none focus-visible:after:[border-inline-start-color:var(--ui-resizable-border-color-active)] focus-visible:after:[box-shadow:0_0_0_3px_var(--ui-focus-primary)]'
             )}
             tabIndex={0}
             onKeyDown={handleKeyDown}
@@ -522,7 +529,7 @@ const SidebarSecondary = React.forwardRef<HTMLElement, SidebarSecondaryProps>(
           className: cn(
             'group/sidebar relative flex h-full flex-col bg-[var(--ui-sidebar-secondary-global-container-color)] border-e border-[var(--ui-sidebar-secondary-global-container-border-color)] [border-inline-end-width:var(--ui-sidebar-secondary-global-container-border-width)] w-[var(--ui-sidebar-secondary-collapsed-container-width)] data-[state=expanded]:w-[var(--ui-sidebar-secondary-expanded-container-width)] transition-[width]',
             resizableProp &&
-              'transition-[width,border-color] has-[[role=separator]:hover]:border-[var(--ui-resizable-border-color-hover)] has-[[role=separator]:active]:border-[var(--ui-resizable-border-color-active)] has-[[role=separator]:focus-visible]:border-[var(--ui-resizable-border-color-hover)] has-[[role=separator]:focus-visible]:ring-[3px] has-[[role=separator]:focus-visible]:ring-[var(--ui-focus-primary)]',
+              'transition-[width,border-color] has-[[role=separator]:hover]:[border-inline-end-color:var(--ui-resizable-border-color-hover)] has-[[role=separator]:active]:[border-inline-end-color:var(--ui-resizable-border-color-active)] has-[[role=separator]:focus-visible]:[border-inline-end-color:var(--ui-resizable-border-color-active)]',
             className
           ),
           children: (
@@ -848,7 +855,7 @@ const SidebarSecondarySectionLabel = React.forwardRef<
     >
       <Collapsible.Trigger
         className={cn(
-          'group/section flex min-w-0 flex-1 items-center gap-[var(--ui-sidebar-secondary-section-container-header-gap)] text-start',
+          'group/section flex min-w-0 flex-1 items-center gap-[var(--ui-sidebar-secondary-section-container-header-gap)] text-start cursor-pointer',
           sectionLabelTextClass,
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-focus-brand)] focus-visible:ring-inset'
         )}
@@ -900,7 +907,7 @@ SidebarSecondaryMenu.displayName = 'SidebarSecondaryMenu';
 // value is unchanged (runtime var() references honor brand overrides only on the
 // referenced token).
 const sidebarSecondaryRowClasses =
-  'group/row flex w-full items-start gap-[var(--ui-sidebar-secondary-menu-item-global-container-gap)] min-h-[var(--ui-sidebar-secondary-menu-item-global-container-height-min)] px-[var(--ui-sidebar-secondary-menu-item-global-container-padding-x)] py-[var(--ui-sidebar-secondary-menu-item-global-container-padding-y)] no-underline ui-sidebar-secondary-menu-item-global-label-text-style transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-focus-brand)] focus-visible:ring-inset text-[var(--ui-sidebar-secondary-menu-item-global-label-color-color)] [&_svg]:shrink-0 [&_svg]:size-[var(--ui-sidebar-secondary-menu-item-global-icon-size)] [&_svg]:text-[var(--ui-sidebar-secondary-menu-item-global-icon-color-color)]';
+  'group/row flex w-full items-start gap-[var(--ui-sidebar-secondary-menu-item-global-container-gap)] min-h-[var(--ui-sidebar-secondary-menu-item-global-container-height-min)] px-[var(--ui-sidebar-secondary-menu-item-global-container-padding-x)] py-[var(--ui-sidebar-secondary-menu-item-global-container-padding-y)] no-underline ui-sidebar-secondary-menu-item-global-label-text-style transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-focus-brand)] focus-visible:ring-inset text-[var(--ui-sidebar-secondary-menu-item-global-label-color-color)] [&_svg]:shrink-0 [&_svg]:size-[var(--ui-sidebar-secondary-menu-item-global-icon-size)] [&_svg]:text-[var(--ui-sidebar-secondary-menu-item-global-icon-color-color)]';
 
 const sidebarSecondaryMenuItemVariants = cva(sidebarSecondaryRowClasses, {
   variants: {
@@ -968,6 +975,12 @@ const SidebarSecondaryMenuItem = React.forwardRef<
             className
           ),
           'aria-current': selected ? 'page' : undefined,
+          onKeyDown: (e: React.KeyboardEvent<HTMLAnchorElement>) => {
+            if (e.key === ' ') {
+              e.preventDefault();
+              e.currentTarget.click();
+            }
+          },
           children: (
             <>
               {icon != null && (
@@ -1137,16 +1150,12 @@ const SidebarSecondaryCollapseTrigger = React.forwardRef<
 
     return (
       <li className="contents">
-        {expanded ? (
-          button
-        ) : (
-          <Tooltip>
-            <TooltipTrigger render={button} />
-            <TooltipContent side={dir === 'rtl' ? 'left' : 'right'}>
-              {expandTooltip}
-            </TooltipContent>
-          </Tooltip>
-        )}
+        <Tooltip disabled={expanded}>
+          <TooltipTrigger render={button} />
+          <TooltipContent side={dir === 'rtl' ? 'left' : 'right'}>
+            {expandTooltip}
+          </TooltipContent>
+        </Tooltip>
       </li>
     );
   }

--- a/packages/ui-react/src/components/ui/tooltip/__tests__/tooltip.test.tsx
+++ b/packages/ui-react/src/components/ui/tooltip/__tests__/tooltip.test.tsx
@@ -121,4 +121,27 @@ describe('Tooltip', () => {
     );
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });
+
+  it('TooltipProvider defaults delay to 300ms', async () => {
+    const user = userEvent.setup();
+    render(
+      <TooltipProvider>
+        <Example />
+      </TooltipProvider>
+    );
+    await user.hover(screen.getByRole('button', { name: 'Hover me' }));
+    expect(screen.queryByText('Helpful hint')).not.toBeInTheDocument();
+    expect(await screen.findByText('Helpful hint')).toBeInTheDocument();
+  });
+
+  it('TooltipProvider delay can be overridden', async () => {
+    const user = userEvent.setup();
+    render(
+      <TooltipProvider delay={0}>
+        <Example />
+      </TooltipProvider>
+    );
+    await user.hover(screen.getByRole('button', { name: 'Hover me' }));
+    expect(await screen.findByText('Helpful hint')).toBeInTheDocument();
+  });
 });

--- a/packages/ui-react/src/components/ui/tooltip/tooltip.tsx
+++ b/packages/ui-react/src/components/ui/tooltip/tooltip.tsx
@@ -10,7 +10,9 @@ import { usePortalContainer } from '@/lib/portal-container';
 // 48–256px width). No arrow — matching the Figma design. Wrap the whole app (or
 // a region) in `TooltipProvider` to share open/close delays across tooltips.
 
-const TooltipProvider = TooltipPrimitive.Provider;
+function TooltipProvider(props: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return <TooltipPrimitive.Provider delay={300} {...props} />;
+}
 
 const Tooltip = TooltipPrimitive.Root;
 


### PR DESCRIPTION
### Type of change

- [ ] Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [x] Enhancement (improving an existing functionality like performance)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Refactoring (old API is revised and supported)
- [ ] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

UX polish for `SidebarSecondary`, `Resizable`, `ButtonIcon`, and `Tooltip` based on design review.

**Cursor styles:**
- `ButtonIcon`: add global `cursor-pointer`
- `SidebarSecondaryMenuItem`, `SidebarSecondarySectionLabel`: add `cursor-pointer`

**Keyboard accessibility:**
- Resize edge: `Space` toggles collapse, `ArrowRight` expands
- Anchor menu items: `Space` activates navigation (browsers only handle `Enter`)

**Resize edge (SidebarSecondary):**
- Widen hit area from 9px to 17px
- `trackCursorAxis="y"` on resize tooltip
- Focus ring rendered via `after` pseudo (`CSS border` + `box-shadow`) instead of sidebar container ring
- Sidebar `:has()` styles target `border-inline-end-color` only — no width change, no outer ring

**Resizable:**
- Divider line uses `border-inline-start` instead of `width` + `background-color` so the browser pixel-snaps the 1px line on fractional positions (eliminates subpixel jitter during drag)
- Focus ring rendered as `box-shadow` on the `after` pseudo, auto-centered on the line
- `active:after:shadow-none` hides ring during mouse drag

**Focus retention:**
- `CollapseTrigger` keeps stable DOM (Tooltip wrapper always present, `disabled` when expanded) so focus is preserved across state changes

**Tooltip delay:**
- `TooltipProvider` defaults `delay` to 300ms (down from Base UI's 600ms)

**Stories:**
- External link items use `target="_blank" rel="noopener noreferrer"`
- Section action `ButtonIcon` wrapped in `Tooltip`
- Counter badges on menu items

## Related issue
 
- [PLTFRM-92175](https://jira.acronis.com/browse/PLTFRM-92175)
- [PLTFRM-92181](https://jira.acronis.com/browse/PLTFRM-92181)
- [PLTFRM-92182](https://jira.acronis.com/browse/PLTFRM-92182)
- [PLTFRM-92183](https://jira.acronis.com/browse/PLTFRM-92183)
- [PLTFRM-92200](https://jira.acronis.com/browse/PLTFRM-92200)
- [PLTFRM-92201](https://jira.acronis.com/browse/PLTFRM-92201)
- [PLTFRM-92202](https://jira.acronis.com/browse/PLTFRM-92202)
- [PLTFRM-92203](https://jira.acronis.com/browse/PLTFRM-92203)
- [PLTFRM-92204](https://jira.acronis.com/browse/PLTFRM-92204)
- [PLTFRM-92205](https://jira.acronis.com/browse/PLTFRM-92205)
- [PLTFRM-92206](https://jira.acronis.com/browse/PLTFRM-92206)

### Checklist

- [ ] I have linked an **issue** or **discussion**;
- [ ] I have updated the **documentation** accordingly;
- [x] I have added or updated **tests** to cover my changes;
- [x] I have performed a **self-review** of my code;
- [x] My code follows the style **guidelines** of this project;
- [x] My changes generate no new **warnings**.