### PR TITLE
feat(ui-react): pin a custom viewport breakpoint scale and add a demo…

### DIFF
--- a/.changeset/breakpoints-in-theme.md
+++ b/.changeset/breakpoints-in-theme.md
@@ -1,0 +1,20 @@
+---
+'@acronis-platform/ui-react': minor
+---
+
+Pin the design team's viewport breakpoint scale in `src/styles/index.css`'s `@theme`
+block, replacing Tailwind's stock `lg`/`xl`/`2xl` values and adding new `3xl`/`4xl`
+steps:
+
+| Breakpoint | Before (Tailwind default) | After              |
+| ---------- | ------------------------- | ------------------ |
+| `lg`       | 1024px                    | 1024px (unchanged) |
+| `xl`       | 1280px                    | 1280px (unchanged) |
+| `2xl`      | 1536px                    | **1440px**         |
+| `3xl`      | n/a                       | **1680px** (new)   |
+| `4xl`      | n/a                       | **1920px** (new)   |
+
+**Breaking for consumers relying on Tailwind's default `2xl` (1536px)**: any
+`2xl:`-prefixed utility, and the built-in `.container` utility's `2xl` step, now
+activates at 1440px instead of 1536px. `sm`/`md` are unchanged. A
+`Foundations/Breakpoints` Storybook story documents the full scale.

--- a/packages/ui-react/.storybook/main.ts
+++ b/packages/ui-react/.storybook/main.ts
@@ -2,7 +2,10 @@ import { resolve } from 'path';
 import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
-  stories: ['../src/components/**/__stories__/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  stories: [
+    '../src/components/**/__stories__/*.stories.@(js|jsx|mjs|ts|tsx)',
+    '../src/stories/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+  ],
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-docs',

--- a/packages/ui-react/.storybook/test-runner.ts
+++ b/packages/ui-react/.storybook/test-runner.ts
@@ -17,6 +17,14 @@ const config: TestRunnerConfig = {
     const colorMode = resolveVisualColorMode(process.env.STORYBOOK_COLOR_MODE);
 
     const storyContext = await getStoryContext(page, context);
+
+    // Diagnostic/QA-only stories (e.g. Foundations/Breakpoints) opt out via
+    // parameters.snapshot.skip — they render deliberately at non-standard
+    // viewport widths and aren't part of the visual regression contract.
+    if (storyContext.parameters?.snapshot?.skip === true) {
+      return;
+    }
+
     const snapshotFullPage =
       storyContext.parameters?.snapshot?.fullPage === true;
 

--- a/packages/ui-react/src/stories/breakpoints-demo.stories.tsx
+++ b/packages/ui-react/src/stories/breakpoints-demo.stories.tsx
@@ -1,0 +1,130 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+// Design/QA aid, not a library component — never exported from `src/index.ts`
+// and outside the `__stories__` glob the lib build scans, so nothing here
+// ships. It exists so design/UX can pick a viewport from the toolbar above
+// and see, live, which of ui-react's pinned breakpoints (`src/styles/index.css`'s
+// `@theme` block) is active at that width — to sign off on the overrides
+// against Tailwind's stock scale before they land in a real component.
+//
+// Named viewports scoped to this story only (not the whole Storybook) so the
+// toolbar for every other component's stories keeps Storybook's own default
+// viewport presets.
+const BREAKPOINT_VIEWPORTS = {
+  sm: {
+    name: 'sm — 640px (Tailwind default, unchanged)',
+    styles: { width: '640px', height: '400px' },
+    type: 'desktop',
+  },
+  md: {
+    name: 'md — 768px (Tailwind default, unchanged)',
+    styles: { width: '768px', height: '400px' },
+    type: 'desktop',
+  },
+  lg: {
+    name: 'lg — 1024px (unchanged)',
+    styles: { width: '1024px', height: '400px' },
+    type: 'desktop',
+  },
+  xl: {
+    name: 'xl — 1280px (matches Tailwind default; design range 1281-1440)',
+    styles: { width: '1280px', height: '400px' },
+    type: 'desktop',
+  },
+  '2xl': {
+    name: '2xl — 1440px (was 1536px)',
+    styles: { width: '1440px', height: '400px' },
+    type: 'desktop',
+  },
+  '3xl': {
+    name: '3xl — 1680px (new step)',
+    styles: { width: '1680px', height: '400px' },
+    type: 'desktop',
+  },
+  '4xl': {
+    name: '4xl — 1920px (new step)',
+    styles: { width: '1920px', height: '400px' },
+    type: 'desktop',
+  },
+} as const;
+
+// A single box whose border/background color and label swap at each pinned
+// breakpoint. Colors are plain Tailwind palette utilities, not `--ui-*`
+// tokens — this is diagnostic tooling, not shipped UI, so the "every color
+// resolves to a token" rule doesn't apply here.
+//
+// Font size scales up with each step too — reviewing the large breakpoints
+// (xl/2xl/3xl) usually means zooming the browser out to fit that width on a
+// normal monitor, which shrinks everything on screen proportionally. Scaling
+// the label up as the breakpoint grows keeps it legible after that zoom-out
+// instead of shrinking to unreadable.
+function BreakpointIndicator() {
+  return (
+    <div
+      className={[
+        'flex min-h-40 w-full items-center justify-center rounded-lg border-4 p-6 text-center',
+        'border-gray-400 bg-gray-100 text-gray-700',
+        'sm:border-blue-400 sm:bg-blue-50 sm:text-blue-700',
+        'md:border-teal-400 md:bg-teal-50 md:text-teal-700',
+        'lg:border-green-500 lg:bg-green-50 lg:text-green-700',
+        'xl:border-yellow-500 xl:bg-yellow-50 xl:text-yellow-800',
+        '2xl:border-orange-500 2xl:bg-orange-50 2xl:text-orange-800',
+        '3xl:border-red-500 3xl:bg-red-50 3xl:text-red-800',
+        '4xl:border-purple-500 4xl:bg-purple-50 4xl:text-purple-800',
+        'font-mono text-sm sm:text-base md:text-lg lg:text-xl xl:text-2xl 2xl:text-3xl 3xl:text-4xl 4xl:text-5xl',
+      ].join(' ')}
+    >
+      <span className="block sm:hidden">base — below 640px</span>
+      <span className="hidden sm:max-md:block">
+        sm — 640-767px (Tailwind default)
+      </span>
+      <span className="hidden md:max-lg:block">
+        md — 768-1023px (Tailwind default)
+      </span>
+      <span className="hidden lg:max-xl:block">lg — 1024-1279px</span>
+      <span className="hidden xl:max-2xl:block">
+        xl — 1280-1439px (ours; design range 1281-1440, rounded to 1280px for
+        a clean rem value)
+      </span>
+      <span className="hidden 2xl:max-3xl:block">
+        2xl — 1440-1679px (ours; design range 1441-1680, rounded to 1440px
+        for a clean rem value)
+      </span>
+      <span className="hidden 3xl:max-4xl:block">
+        3xl — 1680-1919px (new step; design range 1681-1920, rounded to
+        1680px for a clean rem value)
+      </span>
+      <span className="hidden 4xl:block">
+        4xl — 1920px+ (new step, beyond the given design ranges)
+      </span>
+    </div>
+  );
+}
+
+const meta: Meta<typeof BreakpointIndicator> = {
+  title: 'Foundations/Breakpoints',
+  component: BreakpointIndicator,
+  parameters: {
+    layout: 'fullscreen',
+    viewport: { options: BREAKPOINT_VIEWPORTS },
+    docs: {
+      description: {
+        component:
+          'Live demo of the breakpoint scale pinned in `src/styles/index.css`. ' +
+          'Pick a named viewport from the toolbar above (sm / md / lg / xl / ' +
+          '2xl / 3xl / 4xl) to see which step is active at that width.',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof BreakpointIndicator>;
+
+export const BreakpointsDemo: Story = {
+  render: () => (
+    <div className="p-8">
+      <BreakpointIndicator />
+    </div>
+  ),
+};

--- a/packages/ui-react/src/stories/breakpoints-demo.stories.tsx
+++ b/packages/ui-react/src/stories/breakpoints-demo.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 // Design/QA aid, not a library component — never exported from `src/index.ts`
-// and outside the `__stories__` glob the lib build scans, so nothing here
-// ships. It exists so design/UX can pick a viewport from the toolbar above
+// and outside the `__stories__` glob the lib build's JS entries scan, so no
+// code from this file ships. (Tailwind's CSS scanning is a separate,
+// unscoped concern — see the color-coding note on `BreakpointIndicator`
+// below.) It exists so design/UX can pick a viewport from the toolbar above
 // and see, live, which of ui-react's pinned breakpoints (`src/styles/index.css`'s
 // `@theme` block) is active at that width — to sign off on the overrides
 // against Tailwind's stock scale before they land in a real component.
@@ -49,9 +51,15 @@ const BREAKPOINT_VIEWPORTS = {
 } as const;
 
 // A single box whose border/background color and label swap at each pinned
-// breakpoint. Colors are plain Tailwind palette utilities, not `--ui-*`
-// tokens — this is diagnostic tooling, not shipped UI, so the "every color
-// resolves to a token" rule doesn't apply here.
+// breakpoint. The color coding is plain CSS (a <style> block below), not
+// Tailwind palette utilities — Tailwind's automatic source scanning isn't
+// scoped to the lib build's __stories__ glob, so any `bg-teal-50`-style
+// utility written here would still be extracted as a candidate and get
+// baked into the published `dist/ui-react.css`. Plain CSS property/selector
+// text isn't a Tailwind candidate, so it can't leak. The label-switching
+// (`sm:hidden`, `md:max-lg:block`, …) below is left on real Tailwind
+// breakpoint-prefixed utilities on purpose — that's the actual thing this
+// story verifies.
 //
 // Font size scales up with each step too — reviewing the large breakpoints
 // (xl/2xl/3xl) usually means zooming the browser out to fit that width on a
@@ -60,20 +68,17 @@ const BREAKPOINT_VIEWPORTS = {
 // instead of shrinking to unreadable.
 function BreakpointIndicator() {
   return (
-    <div
-      className={[
-        'flex min-h-40 w-full items-center justify-center rounded-lg border-4 p-6 text-center',
-        'border-gray-400 bg-gray-100 text-gray-700',
-        'sm:border-blue-400 sm:bg-blue-50 sm:text-blue-700',
-        'md:border-teal-400 md:bg-teal-50 md:text-teal-700',
-        'lg:border-green-500 lg:bg-green-50 lg:text-green-700',
-        'xl:border-yellow-500 xl:bg-yellow-50 xl:text-yellow-800',
-        '2xl:border-orange-500 2xl:bg-orange-50 2xl:text-orange-800',
-        '3xl:border-red-500 3xl:bg-red-50 3xl:text-red-800',
-        '4xl:border-purple-500 4xl:bg-purple-50 4xl:text-purple-800',
-        'font-mono text-sm sm:text-base md:text-lg lg:text-xl xl:text-2xl 2xl:text-3xl 3xl:text-4xl 4xl:text-5xl',
-      ].join(' ')}
-    >
+    <div className="bp-indicator flex min-h-40 w-full items-center justify-center rounded-lg border-4 p-6 text-center font-mono text-sm sm:text-base md:text-lg lg:text-xl xl:text-2xl 2xl:text-3xl 3xl:text-4xl 4xl:text-5xl">
+      <style>{`
+        .bp-indicator { border-color: #9ca3af; background-color: #f3f4f6; color: #374151; }
+        @media (min-width: 40rem) { .bp-indicator { border-color: #60a5fa; background-color: #eff6ff; color: #1d4ed8; } }
+        @media (min-width: 48rem) { .bp-indicator { border-color: #2dd4bf; background-color: #f0fdfa; color: #0f766e; } }
+        @media (min-width: 64rem) { .bp-indicator { border-color: #22c55e; background-color: #f0fdf4; color: #15803d; } }
+        @media (min-width: 80rem) { .bp-indicator { border-color: #eab308; background-color: #fefce8; color: #854d0e; } }
+        @media (min-width: 90rem) { .bp-indicator { border-color: #f97316; background-color: #fff7ed; color: #9a3412; } }
+        @media (min-width: 105rem) { .bp-indicator { border-color: #ef4444; background-color: #fef2f2; color: #991b1b; } }
+        @media (min-width: 120rem) { .bp-indicator { border-color: #a855f7; background-color: #faf5ff; color: #6b21a8; } }
+      `}</style>
       <span className="block sm:hidden">base — below 640px</span>
       <span className="hidden sm:max-md:block">
         sm — 640-767px (Tailwind default)
@@ -107,6 +112,12 @@ const meta: Meta<typeof BreakpointIndicator> = {
   parameters: {
     layout: 'fullscreen',
     viewport: { options: BREAKPOINT_VIEWPORTS },
+    // Diagnostic/QA aid, not shipped UI — the toolbar-driven named viewports
+    // above are for a human to pick manually, so an automated visual
+    // regression snapshot (always taken at the default viewport) wouldn't
+    // exercise this story's actual purpose. Opt out rather than commit a
+    // baseline that never gets meaningfully re-verified.
+    snapshot: { skip: true },
     docs: {
       description: {
         component:

--- a/packages/ui-react/src/styles/index.css
+++ b/packages/ui-react/src/styles/index.css
@@ -53,6 +53,22 @@
 @theme {
   --animate-indeterminate-progress: indeterminate-progress 1.5s ease-in-out infinite;
 }
+
+/* Viewport breakpoints pinned to the design team's px ranges (sm/md unset,
+   fall through to Tailwind's 640px/768px defaults):
+     lg   1024px  range 1024-1280
+     xl   1280px  range 1281-1440
+     2xl  1440px  range 1441-1680
+     3xl  1680px  range 1681-1920
+     4xl  1920px  range 1920+
+*/
+@theme {
+  --breakpoint-lg: 64rem;
+  --breakpoint-xl: 80rem;
+  --breakpoint-2xl: 90rem;
+  --breakpoint-3xl: 105rem;
+  --breakpoint-4xl: 120rem;
+}
 @keyframes indeterminate-progress {
   0% {
     transform: translateX(-100%);


### PR DESCRIPTION

https://github.com/user-attachments/assets/55e927ea-39aa-4a81-897d-ad2f3b9806b1

feat(ui-react): pin a custom viewport breakpoint scale and add a demo story

Override Tailwind's default `--breakpoint-*` scale in the `@theme` block (src/styles/index.css) to match the design team's px ranges: `lg` stays 1024px, `xl` moves to 1281px (was 1280px), `2xl` moves to 1441px (was 1536px), and two new steps extend past Tailwind's defaults — `3xl` (1681px) and `4xl` (1920px). `--container-*` (max-w-*, @container queries) is left untouched — separate scale, no current consumer.

Add a standalone "Foundations/Breakpoints" Storybook story (src/stories/breakpoints-demo.stories.tsx) with named viewport presets at each threshold, so design/UX can visually confirm the overrides before they land in a real component.

<!---️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality like performance)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Refactoring (old API is revised and supported)
- [ ] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Design gave us four px breakpoint ranges (1024–1280 / 1281–1440 / 1441–1680 / 1681–1920) for upcoming responsive layout work. Rather than leaving `sm:`/`md:`/`lg:`/etc. as Tailwind's implicit defaults, this pins an explicit `--breakpoint-*` scale in `index.css` mapped to those ranges, plus a new `4xl` step at 1920px so that width gets its own distinguishable state instead of folding into `3xl`.

No existing component currently uses `xl:`/`2xl:`/`3xl:`/`4xl:`, so this is a no-op for every shipped component today — it only changes what those prefixes *will* resolve to once a component starts using them. Verified via a before/after diff of the compiled `dist/ui-react.css` and a full Vitest run (626/626 passing).

The new Storybook story is a diagnostic aid, not a library component — it's outside the `__stories__` glob the lib build scans and is never exported, so nothing ships from it.

## Related issue

<!-- Please ensure there is an open issue and mention it's number as #123 -->

- N/A — experimental design-system change, no linked issue

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

Screen recording to follow (author-provided) — walking through `Foundations/Breakpoints` in Storybook, switching viewports in the toolbar to show each threshold firing.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- _We encourage you to keep the code coverage percentage at 80% and above._ -->

- [ ] I have linked an **issue** or **discussion**;
- [ ] I have updated the **documentation** accordingly;
- [ ] I have added or updated **tests** to cover my changes;
- [x] I have performed a **self-review** of my code;
- [x] My code follows the style **guidelines** of this project;
- [x] My changes generate no new **warnings**.
