### PR TITLE
feat(design-tokens): add virtuozzo mode fills and new semantic tokens

### DIFF
--- a/.changeset/design-tokens-semantics-sync.md
+++ b/.changeset/design-tokens-semantics-sync.md
@@ -1,0 +1,5 @@
+---
+'@acronis-platform/design-tokens': minor
+---
+
+Add virtuozzo mode values across all semantic color, glyph, border, focus, and gradient tokens (159 updates). Add new tokens: `colors.glyph.onStatusStrong.primary`, `colors.glyph.onSurface.neutral-dark`, `typography.headings.display-numeric`, and `colors.text.onBrand/onStatus/onSurface.link-idle` (in preparation for the link → link-idle rename).

--- a/packages/design-tokens/tiers/semantics.json
+++ b/packages/design-tokens/tiers/semantics.json
@@ -17,885 +17,710 @@
         "element": {
           "primary": {
             "$extensions": {
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:202:38"
             },
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.transparent.white.inverse-95}",
-              "default": "{palette.transparent.white.inverse-95}"
+              "default": "{palette.transparent.white.inverse-95}",
+              "virtuozzo": "{palette.transparent.white.inverse-95}"
             }
           },
           "secondary": {
             "$extensions": {
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:4370:2956"
             },
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.transparent.blue.inverse-95}",
-              "default": "{palette.transparent.blue.inverse-95}"
+              "default": "{palette.transparent.blue.inverse-95}",
+              "virtuozzo": "{palette.transparent.blue.inverse-95}"
             }
           }
         },
         "screen": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1433"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.dark.fixed-90}",
-            "default": "{palette.transparent.dark.fixed-90}"
+            "default": "{palette.transparent.dark.fixed-90}",
+            "virtuozzo": "{palette.transparent.dark.fixed-90}"
           }
         }
       },
       "brand": {
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1428"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.SidebarPrimary.idle}",
-            "default": "{palette.blue.13}"
+            "default": "{palette.blue.13}",
+            "virtuozzo": "{branding.virtuozzo.SidebarPrimary.idle}"
           }
         },
         "primary-active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:143:3"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.SidebarPrimary.active}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{branding.virtuozzo.SidebarPrimary.active}"
           }
         },
         "primary-disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:383:39"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.SidebarPrimary.disabled}",
-            "default": "{palette.blue.5}"
+            "default": "{palette.blue.5}",
+            "virtuozzo": "{branding.virtuozzo.SidebarPrimary.disabled}"
           }
         },
         "primary-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:143:2"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.SidebarPrimary.hover}",
-            "default": "{palette.blue.12}"
+            "default": "{palette.blue.12}",
+            "virtuozzo": "{branding.virtuozzo.SidebarPrimary.hover}"
           }
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1429"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.ButtonPrimary.idle}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{branding.virtuozzo.ButtonPrimary.idle}"
           }
         },
         "secondary-active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:265:59"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.ButtonPrimary.active}",
-            "default": "{palette.blue.9}"
+            "default": "{palette.blue.9}",
+            "virtuozzo": "{branding.virtuozzo.ButtonPrimary.active}"
           }
         },
         "secondary-disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:227:24"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.ButtonPrimary.disabled}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{branding.virtuozzo.ButtonPrimary.disabled}"
           }
         },
         "secondary-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:265:58"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.ButtonPrimary.hover}",
-            "default": "{palette.blue.8}"
+            "default": "{palette.blue.8}",
+            "virtuozzo": "{branding.virtuozzo.ButtonPrimary.hover}"
           }
         }
       },
       "inverse": {
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:3665:6953"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.dark.inverse-100}",
-            "default": "{palette.transparent.dark.inverse-100}"
+            "default": "{palette.transparent.dark.inverse-100}",
+            "virtuozzo": "{palette.transparent.dark.inverse-100}"
           }
         }
       },
       "status": {
         "ai": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2277:406"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.1}",
-            "default": "{palette.violet.1}"
+            "default": "{palette.violet.1}",
+            "virtuozzo": "{palette.violet.1}"
           }
         },
         "ai-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2277:407"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.2}",
-            "default": "{palette.violet.2}"
+            "default": "{palette.violet.2}",
+            "virtuozzo": "{palette.violet.2}"
           }
         },
         "ai-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2277:408"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.3}",
-            "default": "{palette.violet.3}"
+            "default": "{palette.violet.3}",
+            "virtuozzo": "{palette.violet.3}"
           }
         },
         "critical": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:14"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.1}",
-            "default": "{palette.orange.1}"
+            "default": "{palette.orange.1}",
+            "virtuozzo": "{palette.orange.1}"
           }
         },
         "critical-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:15"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.2}",
-            "default": "{palette.orange.2}"
+            "default": "{palette.orange.2}",
+            "virtuozzo": "{palette.orange.2}"
           }
         },
         "critical-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:16"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.3}",
-            "default": "{palette.orange.3}"
+            "default": "{palette.orange.3}",
+            "virtuozzo": "{palette.orange.3}"
           }
         },
         "danger": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:16"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.1}",
-            "default": "{palette.red.1}"
+            "default": "{palette.red.1}",
+            "virtuozzo": "{palette.red.1}"
           }
         },
         "danger-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:17"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.2}",
-            "default": "{palette.red.2}"
+            "default": "{palette.red.2}",
+            "virtuozzo": "{palette.red.2}"
           }
         },
         "danger-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:18"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.3}",
-            "default": "{palette.red.3}"
+            "default": "{palette.red.3}",
+            "virtuozzo": "{palette.red.3}"
           }
         },
         "info": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:8"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.1}",
-            "default": "{palette.electricblue.1}"
+            "default": "{palette.electricblue.1}",
+            "virtuozzo": "{palette.electricblue.1}"
           }
         },
         "info-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:9"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.2}",
-            "default": "{palette.electricblue.2}"
+            "default": "{palette.electricblue.2}",
+            "virtuozzo": "{palette.electricblue.2}"
           }
         },
         "info-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:10"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.3}",
-            "default": "{palette.electricblue.3}"
+            "default": "{palette.electricblue.3}",
+            "virtuozzo": "{palette.electricblue.3}"
           }
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263457"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.base}",
-            "default": "{palette.base}"
+            "default": "{palette.base}",
+            "virtuozzo": "{palette.base}"
           }
         },
         "neutral-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263458"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.1}",
-            "default": "{palette.grayscale.1}"
+            "default": "{palette.grayscale.1}",
+            "virtuozzo": "{palette.grayscale.1}"
           }
         },
         "neutral-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263459"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.2}",
-            "default": "{palette.grayscale.2}"
+            "default": "{palette.grayscale.2}",
+            "virtuozzo": "{palette.grayscale.2}"
           }
         },
         "off": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:1205:160"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.3}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.grayscale.3}"
           }
         },
         "on": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:1205:161"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.6}",
-            "default": "{palette.green.6}"
+            "default": "{palette.green.6}",
+            "virtuozzo": "{palette.green.6}"
           }
         },
         "success": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:10"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.1}",
-            "default": "{palette.green.1}"
+            "default": "{palette.green.1}",
+            "virtuozzo": "{palette.green.1}"
           }
         },
         "success-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:11"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.2}",
-            "default": "{palette.green.2}"
+            "default": "{palette.green.2}",
+            "virtuozzo": "{palette.green.2}"
           }
         },
         "success-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:12"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.3}",
-            "default": "{palette.green.3}"
+            "default": "{palette.green.3}",
+            "virtuozzo": "{palette.green.3}"
           }
         },
         "warning": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:12"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.1}",
-            "default": "{palette.yellow.1}"
+            "default": "{palette.yellow.1}",
+            "virtuozzo": "{palette.yellow.1}"
           }
         },
         "warning-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:13"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.2}",
-            "default": "{palette.yellow.2}"
+            "default": "{palette.yellow.2}",
+            "virtuozzo": "{palette.yellow.2}"
           }
         },
         "warning-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:14"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.3}",
-            "default": "{palette.yellow.3}"
+            "default": "{palette.yellow.3}",
+            "virtuozzo": "{palette.yellow.3}"
           }
         }
       },
       "statusStrong": {
         "critical": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263451"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.7}",
-            "default": "{palette.orange.7}"
+            "default": "{palette.orange.7}",
+            "virtuozzo": "{palette.orange.7}"
           }
         },
         "critical-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263452"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.8}",
-            "default": "{palette.orange.8}"
+            "default": "{palette.orange.8}",
+            "virtuozzo": "{palette.orange.8}"
           }
         },
         "critical-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263453"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.9}",
-            "default": "{palette.orange.9}"
+            "default": "{palette.orange.9}",
+            "virtuozzo": "{palette.orange.9}"
           }
         },
         "danger": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263454"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.7}",
-            "default": "{palette.red.7}"
+            "default": "{palette.red.7}",
+            "virtuozzo": "{palette.red.7}"
           }
         },
         "danger-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263455"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.9}",
-            "default": "{palette.red.9}"
+            "default": "{palette.red.9}",
+            "virtuozzo": "{palette.red.9}"
           }
         },
         "danger-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263456"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.10}",
-            "default": "{palette.red.10}"
+            "default": "{palette.red.10}",
+            "virtuozzo": "{palette.red.10}"
           }
         },
         "info": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263442"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.7}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{palette.blue.7}"
           }
         },
         "info-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263443"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.8}",
-            "default": "{palette.blue.8}"
+            "default": "{palette.blue.8}",
+            "virtuozzo": "{palette.blue.8}"
           }
         },
         "info-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263444"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.9}",
-            "default": "{palette.blue.9}"
+            "default": "{palette.blue.9}",
+            "virtuozzo": "{palette.blue.9}"
           }
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263460"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.7}",
-            "default": "{palette.grayscale.7}"
+            "default": "{palette.grayscale.7}",
+            "virtuozzo": "{palette.grayscale.7}"
           }
         },
         "neutral-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263461"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.8}",
-            "default": "{palette.grayscale.8}"
+            "default": "{palette.grayscale.8}",
+            "virtuozzo": "{palette.grayscale.8}"
           }
         },
         "neutral-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263462"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.9}",
-            "default": "{palette.grayscale.9}"
+            "default": "{palette.grayscale.9}",
+            "virtuozzo": "{palette.grayscale.9}"
           }
         },
         "success": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263445"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.7}",
-            "default": "{palette.green.7}"
+            "default": "{palette.green.7}",
+            "virtuozzo": "{palette.green.7}"
           }
         },
         "success-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263446"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.8}",
-            "default": "{palette.green.8}"
+            "default": "{palette.green.8}",
+            "virtuozzo": "{palette.green.8}"
           }
         },
         "success-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263447"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.9}",
-            "default": "{palette.green.9}"
+            "default": "{palette.green.9}",
+            "virtuozzo": "{palette.green.9}"
           }
         },
         "warning": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263448"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.7}",
-            "default": "{palette.yellow.7}"
+            "default": "{palette.yellow.7}",
+            "virtuozzo": "{palette.yellow.7}"
           }
         },
         "warning-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263449"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.8}",
-            "default": "{palette.yellow.8}"
+            "default": "{palette.yellow.8}",
+            "virtuozzo": "{palette.yellow.8}"
           }
         },
         "warning-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263450"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.9}",
-            "default": "{palette.yellow.9}"
+            "default": "{palette.yellow.9}",
+            "virtuozzo": "{palette.yellow.9}"
           }
         }
       },
       "surface": {
         "active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:141:276"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.2}",
-            "default": "{palette.blue.2}"
+            "default": "{palette.blue.2}",
+            "virtuozzo": "{palette.grayscale.2}"
           }
         },
         "hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:141:275"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.1}",
-            "default": "{palette.blue.1}"
+            "default": "{palette.blue.1}",
+            "virtuozzo": "{palette.grayscale.1}"
           }
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1426"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.base}",
-            "default": "{palette.base}"
+            "default": "{palette.base}",
+            "virtuozzo": "{palette.base}"
           }
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1427"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.0}",
-            "default": "{palette.blue.0}"
+            "default": "{palette.blue.0}",
+            "virtuozzo": "{palette.grayscale.0}"
           }
         }
       },
       "transparent": {
         "$extensions": {
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.variableId": "VariableID:2500:145417"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.transparent.clear}",
-          "default": "{palette.transparent.clear}"
+          "default": "{palette.transparent.clear}",
+          "virtuozzo": "{palette.transparent.clear}"
         }
       }
     },
@@ -903,64 +728,52 @@
       "onBrand": {
         "border": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:52:1377"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-10}",
-            "default": "{palette.transparent.white.fixed-10}"
+            "default": "{palette.transparent.white.fixed-10}",
+            "virtuozzo": "{palette.transparent.white.fixed-10}"
           }
         },
         "border-active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:139:5"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.0}",
-            "default": "{palette.grayscale.0}"
+            "default": "{palette.grayscale.0}",
+            "virtuozzo": "{palette.grayscale.0}"
           }
         },
         "divider": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:52:1378"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-10}",
-            "default": "{palette.transparent.white.fixed-10}"
+            "default": "{palette.transparent.white.fixed-10}",
+            "virtuozzo": "{palette.transparent.white.fixed-10}"
           }
         }
       },
       "onStatus": {
         "ai": {
           "$extensions": {
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:4313:50249"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.4}",
-            "default": "{palette.violet.4}"
+            "default": "{palette.violet.4}",
+            "virtuozzo": "{palette.violet.4}"
           }
         },
         "aiStrong": {
@@ -969,332 +782,268 @@
             "com.figma.variableId": "VariableID:2277:437"
           },
           "$type": "gradient",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{gradients.ai.idle}",
-            "default": "{gradients.ai.idle}"
+            "default": "{gradients.ai.idle}",
+            "virtuozzo": "{gradients.ai.idle}"
           }
         },
         "critical": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:41"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.4}",
-            "default": "{palette.orange.4}"
+            "default": "{palette.orange.4}",
+            "virtuozzo": "{palette.orange.4}"
           }
         },
         "criticalStrong": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2005"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.8}",
-            "default": "{palette.orange.8}"
+            "default": "{palette.orange.8}",
+            "virtuozzo": "{palette.orange.8}"
           }
         },
         "danger": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:42"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.4}",
-            "default": "{palette.red.4}"
+            "default": "{palette.red.4}",
+            "virtuozzo": "{palette.red.4}"
           }
         },
         "dangerStrong": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2004"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.8}",
-            "default": "{palette.red.8}"
+            "default": "{palette.red.8}",
+            "virtuozzo": "{palette.red.8}"
           }
         },
         "info": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:38"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
-            "default": "{palette.electricblue.4}"
+            "default": "{palette.electricblue.4}",
+            "virtuozzo": "{palette.electricblue.4}"
           }
         },
         "infoStrong": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2008"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.8}",
-            "default": "{palette.electricblue.8}"
+            "default": "{palette.electricblue.8}",
+            "virtuozzo": "{palette.electricblue.8}"
           }
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:911:263463"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.4}",
-            "default": "{palette.grayscale.4}"
+            "default": "{palette.grayscale.4}",
+            "virtuozzo": "{palette.grayscale.4}"
           }
         },
         "neutralStrong": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:912:268723"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.8}",
-            "default": "{palette.grayscale.8}"
+            "default": "{palette.grayscale.8}",
+            "virtuozzo": "{palette.grayscale.8}"
           }
         },
         "success": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:39"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.4}",
-            "default": "{palette.green.4}"
+            "default": "{palette.green.4}",
+            "virtuozzo": "{palette.green.4}"
           }
         },
         "successStrong": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2007"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.8}",
-            "default": "{palette.green.8}"
+            "default": "{palette.green.8}",
+            "virtuozzo": "{palette.green.8}"
           }
         },
         "warning": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:40"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.4}",
-            "default": "{palette.yellow.4}"
+            "default": "{palette.yellow.4}",
+            "virtuozzo": "{palette.yellow.4}"
           }
         },
         "warningStrong": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2006"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.8}",
-            "default": "{palette.yellow.8}"
+            "default": "{palette.yellow.8}",
+            "virtuozzo": "{palette.yellow.8}"
           }
         }
       },
       "onSurface": {
         "border": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:50:1437"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.3}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.grayscale.3}"
           }
         },
         "border-active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:138:187"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.7}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{palette.grayscale.7}"
           }
         },
         "border-error": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:1234:100"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.7}",
-            "default": "{palette.red.7}"
+            "default": "{palette.red.7}",
+            "virtuozzo": "{palette.red.7}"
           }
         },
         "divider": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:50:1438"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.3}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.grayscale.3}"
           }
         }
       },
       "transparent": {
         "$extensions": {
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2500:145418"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.transparent.clear}",
-          "default": "{palette.transparent.clear}"
+          "default": "{palette.transparent.clear}",
+          "virtuozzo": "{palette.transparent.clear}"
         }
       }
     },
     "focus": {
       "brand": {
         "$extensions": {
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:1838:1394"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.blue.4}",
-          "default": "{palette.blue.4}"
+          "default": "{palette.blue.4}",
+          "virtuozzo": "{palette.blue.4}"
         }
       },
       "error": {
         "$extensions": {
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:1828:1379"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.red.4}",
-          "default": "{palette.red.4}"
+          "default": "{palette.red.4}",
+          "virtuozzo": "{palette.red.4}"
         }
       },
       "primary": {
         "$extensions": {
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:1828:1378"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.blue.4}",
-          "default": "{palette.blue.4}"
+          "default": "{palette.blue.4}",
+          "virtuozzo": "{palette.blue.4}"
         }
       },
       "secondary": {
         "$extensions": {
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:1838:1393"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.blue.4}",
-          "default": "{palette.blue.4}"
+          "default": "{palette.blue.4}",
+          "virtuozzo": "{palette.blue.4}"
         }
       }
     },
@@ -1302,478 +1051,410 @@
       "onBackdrop": {
         "elementPrimary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:3931:8751"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.7}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{palette.grayscale.7}"
           }
         },
         "screenPrimary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:143:179"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         }
       },
       "onBrand": {
         "disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:179:195"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-10}",
-            "default": "{palette.transparent.white.fixed-10}"
+            "default": "{palette.transparent.white.fixed-10}",
+            "virtuozzo": "{palette.transparent.white.fixed-10}"
           }
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:52:2202"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:179:196"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
-            "default": "{palette.transparent.white.fixed-60}"
+            "default": "{palette.transparent.white.fixed-60}",
+            "virtuozzo": "{palette.transparent.white.fixed-60}"
           }
         }
       },
       "onInverse": {
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:305:125"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         }
       },
       "onStatus": {
         "ai": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:1936:2682"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.11}",
-            "default": "{palette.violet.11}"
+            "default": "{palette.violet.11}",
+            "virtuozzo": "{palette.violet.11}"
           }
         },
         "critical": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1732"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.11}",
-            "default": "{palette.orange.11}"
+            "default": "{palette.orange.11}",
+            "virtuozzo": "{palette.orange.11}"
           }
         },
         "danger": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1731"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.11}",
-            "default": "{palette.red.11}"
+            "default": "{palette.red.11}",
+            "virtuozzo": "{palette.red.11}"
           }
         },
         "disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:151:43"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.3}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.grayscale.3}"
           }
         },
         "info": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1735"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.11}",
-            "default": "{palette.electricblue.11}"
+            "default": "{palette.electricblue.11}",
+            "virtuozzo": "{palette.electricblue.11}"
           }
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:911:263464"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.11}",
-            "default": "{palette.grayscale.11}"
+            "default": "{palette.grayscale.11}",
+            "virtuozzo": "{palette.grayscale.11}"
           }
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:149:7"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.11}",
-            "default": "{palette.electricblue.11}"
+            "default": "{palette.electricblue.11}",
+            "virtuozzo": "{palette.electricblue.11}"
           }
         },
         "success": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1734"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.11}",
-            "default": "{palette.green.11}"
+            "default": "{palette.green.11}",
+            "virtuozzo": "{palette.green.11}"
           }
         },
         "warning": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1733"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.11}",
-            "default": "{palette.yellow.11}"
+            "default": "{palette.yellow.11}",
+            "virtuozzo": "{palette.yellow.11}"
+          }
+        }
+      },
+      "onStatusStrong": {
+        "primary": {
+          "$extensions": {
+            "com.figma.scopes": ["SHAPE_FILL"],
+            "com.figma.variableId": "VariableID:4169:6903"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         }
       },
       "onSurface": {
         "brand": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:2463:54749"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.13}",
-            "default": "{palette.blue.13}"
+            "default": "{palette.blue.13}",
+            "virtuozzo": "{palette.blue.13}"
           }
         },
         "destructive": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:143:8"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.7}",
-            "default": "{palette.red.7}"
+            "default": "{palette.red.7}",
+            "virtuozzo": "{palette.red.7}"
           }
         },
         "disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:56:1581"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.5}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.grayscale.5}"
           }
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:1024:122"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.4}",
-            "default": "{palette.grayscale.4}"
+            "default": "{palette.grayscale.4}",
+            "virtuozzo": "{palette.grayscale.4}"
+          }
+        },
+        "neutral-dark": {
+          "$extensions": {
+            "com.figma.scopes": ["SHAPE_FILL"],
+            "com.figma.variableId": "VariableID:6540:20828"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.10}",
+            "default": "{palette.grayscale.10}",
+            "virtuozzo": "{palette.grayscale.10}"
           }
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:50:1436"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.10}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{palette.grayscale.10}"
           }
         }
       }
     },
     "text": {
       "onBackdrop": {
-        "elementPrimary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:3931:7751"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.transparent.dark.inverse-100}",
-            "default": "{palette.transparent.dark.inverse-100}"
-          }
-        },
-        "screenPrimary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:3931:7747"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
-          }
-        },
-        "screenSecondary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:3931:7754"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
-            "default": "{palette.transparent.white.fixed-60}"
-          }
-        },
         "elementLink-active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3939:3396"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
-            "default": "{palette.electricblue.4}"
+            "default": "{palette.electricblue.4}",
+            "virtuozzo": "{palette.electricblue.4}"
           }
         },
         "elementLink-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3939:3395"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
-            "default": "{palette.electricblue.4}"
+            "default": "{palette.electricblue.4}",
+            "virtuozzo": "{palette.electricblue.4}"
           }
         },
         "elementLink-idle": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3939:3394"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.7}",
-            "default": "{palette.electricblue.7}"
+            "default": "{palette.electricblue.7}",
+            "virtuozzo": "{palette.electricblue.7}"
+          }
+        },
+        "elementPrimary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:3931:7751"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.transparent.dark.inverse-100}",
+            "default": "{palette.transparent.dark.inverse-100}",
+            "virtuozzo": "{palette.transparent.dark.inverse-100}"
           }
         },
         "screenLink-active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:8760"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
-            "default": "{palette.electricblue.4}"
+            "default": "{palette.electricblue.4}",
+            "virtuozzo": "{palette.electricblue.4}"
           }
         },
         "screenLink-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:8759"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
-            "default": "{palette.electricblue.4}"
+            "default": "{palette.electricblue.4}",
+            "virtuozzo": "{palette.electricblue.4}"
           }
         },
         "screenLink-idle": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:8758"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
-            "default": "{palette.electricblue.4}"
+            "default": "{palette.electricblue.4}",
+            "virtuozzo": "{palette.electricblue.4}"
+          }
+        },
+        "screenPrimary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:3931:7747"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
+          }
+        },
+        "screenSecondary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:3931:7754"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
+            "default": "{palette.transparent.white.fixed-60}",
+            "virtuozzo": "{palette.transparent.white.fixed-60}"
           }
         }
       },
       "onBrand": {
         "disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:52:1358"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-30}",
-            "default": "{palette.transparent.white.fixed-30}"
+            "default": "{palette.transparent.white.fixed-30}",
+            "virtuozzo": "{palette.transparent.white.fixed-30}"
           }
         },
         "link": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:169"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.7}",
             "default": "{palette.blue.7}"
@@ -1781,608 +1462,503 @@
         },
         "link-disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:172"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-30}",
-            "default": "{palette.transparent.white.fixed-30}"
+            "default": "{palette.transparent.white.fixed-30}",
+            "virtuozzo": "{palette.transparent.white.fixed-30}"
           }
         },
         "link-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:170"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.5}",
-            "default": "{palette.blue.5}"
+            "default": "{palette.blue.5}",
+            "virtuozzo": "{palette.blue.5}"
+          }
+        },
+        "link-idle": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:169"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.blue.7}",
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{palette.blue.7}"
           }
         },
         "link-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:171"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.3}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.blue.3}"
           }
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:52:1353"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:52:1354"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
-            "default": "{palette.transparent.white.fixed-60}"
-          }
-        }
-      },
-      "onStatus": {
-        "ai": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:912:266569"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.violet.11}",
-            "default": "{palette.violet.11}"
-          }
-        },
-        "critical": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:201:20"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.orange.11}",
-            "default": "{palette.orange.11}"
-          }
-        },
-        "danger": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:201:19"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.red.11}",
-            "default": "{palette.red.11}"
-          }
-        },
-        "info": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:201:17"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.electricblue.11}",
-            "default": "{palette.electricblue.11}"
-          }
-        },
-        "link": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:149:4"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.electricblue.11}",
-            "default": "{palette.electricblue.11}"
-          }
-        },
-        "link-disabled": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:149:8"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.electricblue.5}",
-            "default": "{palette.electricblue.5}"
-          }
-        },
-        "link-hover": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:149:5"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.electricblue.13}",
-            "default": "{palette.electricblue.13}"
-          }
-        },
-        "link-pressed": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:149:6"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.electricblue.14}",
-            "default": "{palette.electricblue.14}"
-          }
-        },
-        "neutral": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:911:263465"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.grayscale.11}",
-            "default": "{palette.grayscale.11}"
-          }
-        },
-        "primary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:149:2"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.grayscale.14}",
-            "default": "{palette.grayscale.14}"
-          }
-        },
-        "secondary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:149:3"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.grayscale.11}",
-            "default": "{palette.grayscale.11}"
-          }
-        },
-        "success": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:201:21"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.green.11}",
-            "default": "{palette.green.11}"
-          }
-        },
-        "warning": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:201:18"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.yellow.11}",
-            "default": "{palette.yellow.11}"
-          }
-        }
-      },
-      "onSurface": {
-        "destructive": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:139:150"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.red.7}",
-            "default": "{palette.red.7}"
-          }
-        },
-        "disabled": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:52:1357"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": {
-              "colorSpace": "hsl",
-              "components": [
-                205.71,
-                14.58,
-                18.82
-              ]
-            },
-            "default": "{palette.grayscale.5}"
-          }
-        },
-        "link": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:139:155"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": {
-              "colorSpace": "hsl",
-              "components": [
-                208.8,
-                15.53,
-                31.57
-              ]
-            },
-            "default": "{palette.blue.7}"
-          }
-        },
-        "link-disabled": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:139:160"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.grayscale.3}",
-            "default": "{palette.blue.3}"
-          }
-        },
-        "link-hover": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:139:156"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.grayscale.11}",
-            "default": "{palette.blue.8}"
-          }
-        },
-        "link-pressed": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:139:159"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.grayscale.12}",
-            "default": "{palette.blue.11}"
-          }
-        },
-        "primary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:50:1425"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": {
-              "colorSpace": "hsl",
-              "components": [
-                208.8,
-                15.53,
-                31.57
-              ]
-            },
-            "default": "{palette.grayscale.14}"
-          }
-        },
-        "secondary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:50:1434"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": {
-              "colorSpace": "hsl",
-              "components": [
-                207,
-                15.63,
-                25.1
-              ]
-            },
-            "default": "{palette.grayscale.7}"
+            "default": "{palette.transparent.white.fixed-60}",
+            "virtuozzo": "{palette.transparent.white.fixed-60}"
           }
         }
       },
       "onInverse": {
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:305:127"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "deep_sky_itkontoret": "{palette.transparent.white.inverse-100}",
+            "default": "{palette.transparent.white.inverse-100}",
+            "virtuozzo": "{palette.transparent.white.inverse-100}"
           }
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:4363:6331"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
-            "default": "{palette.transparent.white.fixed-60}"
+            "default": "{palette.transparent.white.fixed-60}",
+            "virtuozzo": "{palette.transparent.white.fixed-60}"
+          }
+        }
+      },
+      "onStatus": {
+        "ai": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:912:266569"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.violet.11}",
+            "default": "{palette.violet.11}",
+            "virtuozzo": "{palette.violet.11}"
+          }
+        },
+        "critical": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:201:20"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.orange.11}",
+            "default": "{palette.orange.11}",
+            "virtuozzo": "{palette.orange.11}"
+          }
+        },
+        "danger": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:201:19"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.red.11}",
+            "default": "{palette.red.11}",
+            "virtuozzo": "{palette.red.11}"
+          }
+        },
+        "info": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:201:17"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.electricblue.11}",
+            "default": "{palette.electricblue.11}",
+            "virtuozzo": "{palette.electricblue.11}"
+          }
+        },
+        "link": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:149:4"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.electricblue.11}",
+            "default": "{palette.electricblue.11}"
+          }
+        },
+        "link-disabled": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:149:8"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.electricblue.5}",
+            "default": "{palette.electricblue.5}",
+            "virtuozzo": "{palette.electricblue.5}"
+          }
+        },
+        "link-hover": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:149:5"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.electricblue.13}",
+            "default": "{palette.electricblue.13}",
+            "virtuozzo": "{palette.electricblue.13}"
+          }
+        },
+        "link-idle": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:149:4"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.electricblue.11}",
+            "default": "{palette.electricblue.11}",
+            "virtuozzo": "{palette.electricblue.11}"
+          }
+        },
+        "link-pressed": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:149:6"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.electricblue.14}",
+            "default": "{palette.electricblue.14}",
+            "virtuozzo": "{palette.electricblue.14}"
+          }
+        },
+        "neutral": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:911:263465"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.11}",
+            "default": "{palette.grayscale.11}",
+            "virtuozzo": "{palette.grayscale.11}"
+          }
+        },
+        "primary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:149:2"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.14}",
+            "default": "{palette.grayscale.14}",
+            "virtuozzo": "{palette.grayscale.14}"
+          }
+        },
+        "secondary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:149:3"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.11}",
+            "default": "{palette.grayscale.11}",
+            "virtuozzo": "{palette.grayscale.11}"
+          }
+        },
+        "success": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:201:21"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.green.11}",
+            "default": "{palette.green.11}",
+            "virtuozzo": "{palette.green.11}"
+          }
+        },
+        "warning": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:201:18"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.yellow.11}",
+            "default": "{palette.yellow.11}",
+            "virtuozzo": "{palette.yellow.11}"
           }
         }
       },
       "onStatusStrong": {
         "ai": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12115"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "critical": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12112"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "danger": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12113"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "info": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12109"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "link": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12116"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.11}",
-            "default": "{palette.electricblue.11}"
+            "default": "{palette.electricblue.11}",
+            "virtuozzo": "{palette.electricblue.11}"
           }
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12114"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12107"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.0}",
-            "default": "{palette.grayscale.0}"
+            "default": "{palette.grayscale.0}",
+            "virtuozzo": "{palette.grayscale.0}"
           }
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12108"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.2}",
-            "default": "{palette.grayscale.2}"
+            "default": "{palette.grayscale.2}",
+            "virtuozzo": "{palette.grayscale.2}"
           }
         },
         "success": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12110"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "warning": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12111"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
+          }
+        }
+      },
+      "onSurface": {
+        "destructive": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:150"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.red.7}",
+            "default": "{palette.red.7}",
+            "virtuozzo": "{palette.red.7}"
+          }
+        },
+        "disabled": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:52:1357"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.5}",
+            "default": "{palette.grayscale.5}",
+            "virtuozzo": "{palette.grayscale.5}"
+          }
+        },
+        "link": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:155"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": {
+              "colorSpace": "hsl",
+              "components": [208.8, 15.53, 31.57]
+            },
+            "default": "{palette.blue.7}"
+          }
+        },
+        "link-disabled": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:160"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.3}",
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.grayscale.3}"
+          }
+        },
+        "link-hover": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:156"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.11}",
+            "default": "{palette.blue.8}",
+            "virtuozzo": "{palette.grayscale.11}"
+          }
+        },
+        "link-idle": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:155"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.10}",
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{palette.grayscale.10}"
+          }
+        },
+        "link-pressed": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:159"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.12}",
+            "default": "{palette.blue.11}",
+            "virtuozzo": "{palette.grayscale.12}"
+          }
+        },
+        "primary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:50:1425"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.14}",
+            "default": "{palette.grayscale.14}",
+            "virtuozzo": "{palette.grayscale.14}"
+          }
+        },
+        "secondary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:50:1434"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.7}",
+            "default": "{palette.grayscale.7}",
+            "virtuozzo": "{palette.grayscale.7}"
           }
         }
       }
@@ -2397,30 +1973,20 @@
           "com.figma.scopes": [],
           "com.figma.variableId": "VariableID:2277:28"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": [
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  234.11,
-                  56.57,
-                  38.82
-                ]
+                "components": [234.11, 56.57, 38.82]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.09,
-                  69.78,
-                  27.25
-                ]
+                "components": [303.09, 69.78, 27.25]
               },
               "position": 1
             }
@@ -2429,22 +1995,30 @@
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  234.11,
-                  56.57,
-                  38.82
-                ]
+                "components": [234.11, 56.57, 38.82]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.09,
-                  69.78,
-                  27.25
-                ]
+                "components": [303.09, 69.78, 27.25]
+              },
+              "position": 1
+            }
+          ],
+          "virtuozzo": [
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [234.11, 56.57, 38.82]
+              },
+              "position": 0.2
+            },
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [303.09, 69.78, 27.25]
               },
               "position": 1
             }
@@ -2457,30 +2031,20 @@
           "com.figma.scopes": [],
           "com.figma.variableId": "VariableID:2277:29"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": [
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  234.38,
-                  100,
-                  93.73
-                ]
+                "components": [234.38, 100, 93.73]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.24,
-                  100,
-                  92.75
-                ]
+                "components": [303.24, 100, 92.75]
               },
               "position": 1
             }
@@ -2489,22 +2053,30 @@
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  234.38,
-                  100,
-                  93.73
-                ]
+                "components": [234.38, 100, 93.73]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.24,
-                  100,
-                  92.75
-                ]
+                "components": [303.24, 100, 92.75]
+              },
+              "position": 1
+            }
+          ],
+          "virtuozzo": [
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [234.38, 100, 93.73]
+              },
+              "position": 0.2
+            },
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [303.24, 100, 92.75]
               },
               "position": 1
             }
@@ -2517,30 +2089,20 @@
           "com.figma.scopes": [],
           "com.figma.variableId": "VariableID:2277:27"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": [
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  233.75,
-                  58.54,
-                  48.24
-                ]
+                "components": [233.75, 58.54, 48.24]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.22,
-                  69.3,
-                  42.16
-                ]
+                "components": [303.22, 69.3, 42.16]
               },
               "position": 1
             }
@@ -2549,22 +2111,30 @@
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  233.75,
-                  58.54,
-                  48.24
-                ]
+                "components": [233.75, 58.54, 48.24]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.22,
-                  69.3,
-                  42.16
-                ]
+                "components": [303.22, 69.3, 42.16]
+              },
+              "position": 1
+            }
+          ],
+          "virtuozzo": [
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [233.75, 58.54, 48.24]
+              },
+              "position": 0.2
+            },
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [303.22, 69.3, 42.16]
               },
               "position": 1
             }
@@ -2577,30 +2147,20 @@
           "com.figma.scopes": [],
           "com.figma.variableId": "VariableID:2277:21"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": [
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  233.93,
-                  73.04,
-                  54.9
-                ]
+                "components": [233.93, 73.04, 54.9]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.19,
-                  97.18,
-                  58.24
-                ]
+                "components": [303.19, 97.18, 58.24]
               },
               "position": 1
             }
@@ -2609,22 +2169,30 @@
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  233.93,
-                  73.04,
-                  54.9
-                ]
+                "components": [233.93, 73.04, 54.9]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.19,
-                  97.18,
-                  58.24
-                ]
+                "components": [303.19, 97.18, 58.24]
+              },
+              "position": 1
+            }
+          ],
+          "virtuozzo": [
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [233.93, 73.04, 54.9]
+              },
+              "position": 0.2
+            },
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [303.19, 97.18, 58.24]
               },
               "position": 1
             }
@@ -2647,9 +2215,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "default": {
         "$extensions": {
@@ -2662,9 +2228,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "form-label": {
         "$extensions": {
@@ -2677,9 +2241,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "heading": {
         "$extensions": {
@@ -2693,9 +2255,7 @@
           "letterSpacing": "{font.letter-spacing.0-3}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "strong": {
         "$extensions": {
@@ -2708,9 +2268,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       }
     },
     "caption": {
@@ -2725,9 +2283,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "default": {
         "$extensions": {
@@ -2740,9 +2296,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "strong": {
         "$extensions": {
@@ -2755,9 +2309,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       }
     },
     "fineprint": {
@@ -2772,9 +2324,7 @@
           "letterSpacing": "{font.letter-spacing.1}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       }
     },
     "headings": {
@@ -2789,9 +2339,20 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.40}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
+      },
+      "display-numeric": {
+        "$extensions": {
+          "com.figma.styleId": "S:3a1abe681039f062b989ad383b761ae7c964035b,"
+        },
+        "$value": {
+          "fontFamily": "{font.font-family.default}",
+          "fontSize": "{font.font-size.32}",
+          "fontWeight": "{font.font-weight.regular}",
+          "letterSpacing": "{font.letter-spacing.0}",
+          "lineHeight": "{font.line-height.40}"
+        },
+        "platforms": ["PD"]
       },
       "lead": {
         "$extensions": {
@@ -2804,9 +2365,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "title": {
         "$extensions": {
@@ -2819,9 +2378,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.32}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "title-accent": {
         "$extensions": {
@@ -2834,9 +2391,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.32}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       }
     },
     "link": {
@@ -2851,9 +2406,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "default-underline": {
         "$extensions": {
@@ -2867,9 +2420,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "strong": {
         "$extensions": {
@@ -2882,9 +2433,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "strong-underline": {
         "$extensions": {
@@ -2898,9 +2447,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       }
     },
     "note": {
@@ -2915,9 +2462,7 @@
           "letterSpacing": "{font.letter-spacing.1}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "heading": {
         "$extensions": {
@@ -2931,9 +2476,7 @@
           "letterSpacing": "{font.letter-spacing.1}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       }
     }
   }


### PR DESCRIPTION
# PR 2 — Semantics: virtuozzo mode fills + new tokens

**Branch:** `design-tokens/figma-sync-semantics` → `main`  
**Changeset:** `minor` (`@acronis-platform/design-tokens`)  
**Merge order:** Independent — no dependencies, can merge at any time (before or after PR 1).

---

## What changed

### Virtuozzo mode — 159 mode value fills

All existing semantic color tokens receive a `virtuozzo` mode value. Previously these were `∅` (absent), which meant the virtuozzo theme fell back to the default. Now each token has an explicit value authored in Figma.

Affected groups:

| Group | Tokens |
|---|---|
| `colors.background` | 35 tokens (backdrop, brand, inverse, status, statusStrong, surface, transparent) |
| `colors.text` | 33 tokens (onBackdrop, onBrand, onInverse, onStatus, onStatusStrong, onSurface) |
| `colors.glyph` | 21 tokens (onBackdrop, onBrand, onInverse, onStatus, onStatusStrong, onSurface) |
| `colors.border` | 21 tokens (onBrand, onStatus, onSurface, transparent) |
| `colors.focus` | 4 tokens (brand, error, primary, secondary) |
| `gradients.ai` | 4 tokens (idle, hover, active, disabled) |

Additionally, two `deep_sky_itkontoret` mode values are updated (raw HSL values → correct palette aliases):
- `colors.text.onInverse.primary` — `fixed-100` → `inverse-100`
- `colors.text.onSurface.disabled/primary/secondary` — raw HSL → `{palette.grayscale.*}` refs

### New semantic tokens — 6 additions

| Token | Notes |
|---|---|
| `colors.glyph.onStatusStrong.primary` | New glyph color for strong status backgrounds |
| `colors.glyph.onSurface.neutral-dark` | New glyph color variant for neutral-dark on surface |
| `colors.text.onBrand.link-idle` | Rename preparation (replaces bare `link` — see PR 3) |
| `colors.text.onStatus.link-idle` | Rename preparation |
| `colors.text.onSurface.link-idle` | Rename preparation |
| `typography.headings.display-numeric` | New typography style token |

> **Note on `link-idle`:** These tokens are added here alongside the existing `link` tokens (both coexist after this PR). The old `link` tokens are removed in PR 3. This two-step approach keeps each PR independently valid.

---

## Reviewer notes

- All changes are additive (mode fills and new tokens only) — no existing token values are removed or broken.
- After this PR merges, `*.link` and `*.link-idle` temporarily coexist in semantics. PR 3 removes the old `*.link` tokens and updates components.
- `typography.headings.display-numeric` is a new style token derived from Figma text styles.