### PR TITLE
feat(design-tokens): sync with Figma (2026-07-21)

### DIFF
--- a/.changeset/design-tokens-figma-sync.md
+++ b/.changeset/design-tokens-figma-sync.md
@@ -1,0 +1,7 @@
+---
+'@acronis-platform/design-tokens': minor
+---
+
+Sync design tokens with Figma (snapshot 2026-07-21).
+
+Adds branding palette tokens for `red_home_pl` (ButtonPrimary and SidebarPrimary ramps, 8 tokens), new size units 76px and 320px, and fixes `palette.blue.10` dark-mode value. Adds virtuozzo mode values across all semantic color, glyph, border, focus, and gradient tokens (159 updates), and adds new semantic tokens `colors.glyph.onStatusStrong.primary`, `colors.glyph.onSurface.neutral-dark`, and `typography.headings.display-numeric`. Renames `colors.text.onBrand/onStatus/onSurface.link` to `*.link-idle` and updates all referencing component tokens (Button, ButtonMenu, CardFilter, Chip, Link).

--- a/packages/design-tokens/tiers/components.json
+++ b/packages/design-tokens/tiers/components.json
@@ -47,15 +47,11 @@
           "borderStyle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3332:5669"
             },
             "$type": "string",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "solid",
               "default": "solid"
@@ -64,15 +60,11 @@
           "borderWidth": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_FLOAT"
-              ],
+              "com.figma.scopes": ["STROKE_FLOAT"],
               "com.figma.variableId": "VariableID:3332:5667"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.stroke.2}",
               "default": "{units.stroke.2}"
@@ -81,15 +73,11 @@
           "color": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3332:5666"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.base}",
               "default": "{palette.base}"
@@ -100,15 +88,11 @@
           "gap": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP"
-              ],
+              "com.figma.scopes": ["GAP"],
               "com.figma.variableId": "VariableID:3332:5664"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.neg-6}",
               "default": "{units.gap.neg-6}"
@@ -118,15 +102,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3111:187"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -137,15 +117,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3332:5663"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -156,15 +132,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3332:4997"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.strong}",
             "default": "{typography.caption.strong}"
@@ -175,15 +147,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3332:5000"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -192,15 +160,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3332:4999"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -212,15 +176,11 @@
       "orange": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "FRAME_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL"],
           "com.figma.variableId": "VariableID:3332:1733"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.orange.3}",
           "default": "{palette.orange.3}"
@@ -229,15 +189,11 @@
       "red": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "FRAME_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL"],
           "com.figma.variableId": "VariableID:3332:1732"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.red.3}",
           "default": "{palette.red.3}"
@@ -246,15 +202,11 @@
       "teal": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "FRAME_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL"],
           "com.figma.variableId": "VariableID:3332:1730"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.teal.3}",
           "default": "{palette.teal.3}"
@@ -263,15 +215,11 @@
       "violet": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "FRAME_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL"],
           "com.figma.variableId": "VariableID:3332:1731"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.violet.3}",
           "default": "{palette.violet.3}"
@@ -280,15 +228,11 @@
       "yellow": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "FRAME_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL"],
           "com.figma.variableId": "VariableID:3332:1734"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.yellow.3}",
           "default": "{palette.yellow.3}"
@@ -300,15 +244,11 @@
         "orange": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3332:1764"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.11}",
             "default": "{palette.orange.11}"
@@ -317,15 +257,11 @@
         "red": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3332:1763"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.11}",
             "default": "{palette.red.11}"
@@ -334,15 +270,11 @@
         "teal": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3111:189"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.teal.11}",
             "default": "{palette.teal.11}"
@@ -351,15 +283,11 @@
         "violet": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3332:1753"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.11}",
             "default": "{palette.violet.11}"
@@ -368,15 +296,11 @@
         "yellow": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3332:1765"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.11}",
             "default": "{palette.yellow.11}"
@@ -392,15 +316,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:44254"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -409,15 +329,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:44253"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -426,15 +342,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:44252"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -448,9 +360,7 @@
             "com.figma.variableId": "VariableID:2504:141807"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.link.default}",
             "default": "{typography.link.default}"
@@ -463,15 +373,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2238:44256"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -484,9 +390,7 @@
             "com.figma.variableId": "VariableID:2238:44260"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -499,16 +403,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2238:44257"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.neutral}",
             "default": "{colors.glyph.onSurface.neutral}"
@@ -517,16 +416,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:141812"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -538,16 +432,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2238:44258"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
           "default": "{units.gap.4}"
@@ -561,16 +450,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:91027"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
             "default": "{units.radius.4}"
@@ -579,16 +463,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:91024"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -597,16 +476,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:91026"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -615,16 +489,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:91025"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -635,16 +504,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:91028"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -659,9 +523,7 @@
             "com.figma.variableId": "VariableID:2468:91029"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
             "default": "{typography.body.strong}"
@@ -679,9 +541,7 @@
               "com.figma.variableId": "VariableID:2277:441"
             },
             "$type": "string",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{gradients.ai.active}",
               "default": "{gradients.ai.active}"
@@ -694,9 +554,7 @@
               "com.figma.variableId": "VariableID:2277:442"
             },
             "$type": "string",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{gradients.ai.disabled}",
               "default": "{gradients.ai.disabled}"
@@ -709,9 +567,7 @@
               "com.figma.variableId": "VariableID:2277:440"
             },
             "$type": "string",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{gradients.ai.hover}",
               "default": "{gradients.ai.hover}"
@@ -724,9 +580,7 @@
               "com.figma.variableId": "VariableID:2277:439"
             },
             "$type": "string",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{gradients.ai.idle}",
               "default": "{gradients.ai.idle}"
@@ -736,16 +590,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5655"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -754,16 +603,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5654"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.64}",
             "default": "{units.size.64}"
@@ -775,16 +619,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6862"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -793,16 +632,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6863"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -811,16 +645,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6861"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -829,16 +658,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6860"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -851,15 +675,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7498"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
               "default": "{colors.text.onBrand.primary}"
@@ -868,15 +688,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7499"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.disabled}",
               "default": "{colors.text.onBrand.disabled}"
@@ -885,15 +701,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7497"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
               "default": "{colors.text.onBrand.primary}"
@@ -902,15 +714,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7496"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
               "default": "{colors.text.onBrand.primary}"
@@ -925,15 +733,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5620"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.statusStrong.danger-pressed}",
               "default": "{colors.background.statusStrong.danger-pressed}"
@@ -942,15 +746,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5621"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.danger}",
               "default": "{colors.background.status.danger}"
@@ -959,15 +759,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5619"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.statusStrong.danger-hover}",
               "default": "{colors.background.statusStrong.danger-hover}"
@@ -976,15 +772,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5618"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.statusStrong.danger}",
               "default": "{colors.background.statusStrong.danger}"
@@ -994,16 +786,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5625"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -1012,16 +799,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5624"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.64}",
             "default": "{units.size.64}"
@@ -1033,16 +815,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6858"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onInverse.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -1051,16 +828,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6859"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onInverse.primary}",
               "default": "{colors.glyph.onBrand.disabled}"
@@ -1069,16 +841,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6857"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onInverse.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -1087,16 +854,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6856"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onInverse.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -1109,15 +871,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7494"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onInverse.primary}",
               "default": "{colors.text.onBrand.primary}"
@@ -1126,15 +884,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7495"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.disabled}",
               "default": "{colors.text.onBrand.disabled}"
@@ -1143,15 +897,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7493"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onInverse.primary}",
               "default": "{colors.text.onBrand.primary}"
@@ -1160,15 +910,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7492"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onInverse.primary}",
               "default": "{colors.text.onBrand.primary}"
@@ -1182,16 +928,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2238:6462"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -1203,16 +944,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6854"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -1221,16 +957,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6855"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -1239,16 +970,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6853"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -1257,16 +983,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6852"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -1279,15 +1000,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2236:5611"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
               "default": "{colors.text.onSurface.link-pressed}"
@@ -1296,15 +1013,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2236:5612"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
               "default": "{colors.text.onSurface.link-disabled}"
@@ -1313,15 +1026,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2236:5610"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
               "default": "{colors.text.onSurface.link-hover}"
@@ -1330,18 +1039,15 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2236:5609"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-              "default": "{colors.text.onSurface.link}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+              "default": "{colors.text.onSurface.link-idle}",
+              "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           }
         },
@@ -1353,9 +1059,7 @@
               "com.figma.variableId": "VariableID:2236:5615"
             },
             "$type": "string",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "none",
               "default": "none"
@@ -1368,9 +1072,7 @@
               "com.figma.variableId": "VariableID:2236:5616"
             },
             "$type": "string",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "none",
               "default": "none"
@@ -1383,9 +1085,7 @@
               "com.figma.variableId": "VariableID:2236:5614"
             },
             "$type": "string",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "underline",
               "default": "underline"
@@ -1398,9 +1098,7 @@
               "com.figma.variableId": "VariableID:2236:5613"
             },
             "$type": "string",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "none",
               "default": "none"
@@ -1415,9 +1113,7 @@
               "com.figma.variableId": "VariableID:3735:868"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.link.strong}",
               "default": "{typography.link.strong}"
@@ -1430,9 +1126,7 @@
               "com.figma.variableId": "VariableID:3735:869"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.link.strong}",
               "default": "{typography.link.strong}"
@@ -1445,9 +1139,7 @@
               "com.figma.variableId": "VariableID:3735:867"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.link.strong-underline}",
               "default": "{typography.link.strong-underline}"
@@ -1460,9 +1152,7 @@
               "com.figma.variableId": "VariableID:3735:866"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.link.strong}",
               "default": "{typography.link.strong}"
@@ -1477,15 +1167,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5578"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
               "default": "{colors.background.brand.secondary-active}"
@@ -1494,15 +1180,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5579"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-disabled}",
               "default": "{colors.background.brand.secondary-disabled}"
@@ -1511,15 +1193,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5577"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
               "default": "{colors.background.brand.secondary-hover}"
@@ -1528,15 +1206,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5576"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary}",
               "default": "{colors.background.brand.secondary}"
@@ -1546,16 +1220,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5583"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -1564,16 +1233,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5582"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.64}",
             "default": "{units.size.64}"
@@ -1585,16 +1249,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6846"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -1603,16 +1262,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6847"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.disabled}",
               "default": "{colors.glyph.onBrand.disabled}"
@@ -1621,16 +1275,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6845"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -1639,16 +1288,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6844"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -1661,15 +1305,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7486"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
               "default": "{colors.text.onBrand.primary}"
@@ -1678,15 +1318,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7487"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.disabled}",
               "default": "{colors.text.onBrand.disabled}"
@@ -1695,15 +1331,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7485"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
               "default": "{colors.text.onBrand.primary}"
@@ -1712,15 +1344,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7484"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
               "default": "{colors.text.onBrand.primary}"
@@ -1735,15 +1363,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2468:91032"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -1752,15 +1376,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2468:91033"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -1769,15 +1389,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2468:91031"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -1786,15 +1402,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2468:91030"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -1808,9 +1420,7 @@
             "com.figma.variableId": "VariableID:2236:5590"
           },
           "$type": "string",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
             "default": "solid"
@@ -1819,16 +1429,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5591"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -1838,15 +1443,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5595"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.active}"
@@ -1855,15 +1456,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5596"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -1872,15 +1469,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5594"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
               "default": "{colors.background.surface.hover}"
@@ -1889,15 +1482,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5593"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -1907,16 +1496,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5600"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -1925,16 +1509,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5599"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.64}",
             "default": "{units.size.64}"
@@ -1946,16 +1525,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6850"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -1964,16 +1538,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6851"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -1982,16 +1551,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6849"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -2000,16 +1564,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6848"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -2022,32 +1581,25 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7490"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
-              "default": "{colors.text.onSurface.link}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+              "default": "{colors.text.onSurface.link-idle}",
+              "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           },
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7491"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
               "default": "{colors.text.onSurface.link-disabled}"
@@ -2056,35 +1608,29 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7489"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
-              "default": "{colors.text.onSurface.link}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+              "default": "{colors.text.onSurface.link-idle}",
+              "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           },
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7488"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-              "default": "{colors.text.onSurface.link}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+              "default": "{colors.text.onSurface.link-idle}",
+              "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           }
         }
@@ -2097,16 +1643,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5672"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
             "default": "{units.radius.4}"
@@ -2116,15 +1657,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5664"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.active}"
@@ -2133,15 +1670,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5665"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.transparent}",
               "default": "{colors.background.transparent}"
@@ -2150,15 +1683,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5663"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
               "default": "{colors.background.surface.hover}"
@@ -2167,15 +1696,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5662"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.transparent}",
               "default": "{colors.background.transparent}"
@@ -2185,16 +1710,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5673"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -2203,16 +1723,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5675"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -2224,16 +1739,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2236:5679"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -2242,16 +1752,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2236:5680"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -2260,16 +1765,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2236:5678"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -2278,16 +1778,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2236:5677"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -2297,16 +1792,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5681"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.24}",
             "default": "{units.size.24}"
@@ -2320,15 +1810,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2236:5670"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.transparent}",
               "default": "{colors.border.transparent}"
@@ -2337,15 +1823,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2236:5671"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -2354,15 +1836,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2236:5669"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.transparent}",
               "default": "{colors.border.transparent}"
@@ -2371,15 +1849,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2236:5668"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -2393,9 +1867,7 @@
             "com.figma.variableId": "VariableID:2236:5666"
           },
           "$type": "string",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
             "default": "solid"
@@ -2404,16 +1876,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5667"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -2428,15 +1895,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:3202:1157"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
             "default": "{colors.border.onSurface.border-active}"
@@ -2445,15 +1908,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS"],
             "com.figma.variableId": "VariableID:3202:1154"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
             "default": "{units.radius.4}"
@@ -2462,15 +1921,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT"],
             "com.figma.variableId": "VariableID:3202:1156"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -2479,15 +1934,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:3202:1152"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
             "default": "{colors.background.surface.primary}"
@@ -2496,15 +1947,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:1155"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -2513,15 +1960,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:1151"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -2530,15 +1973,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:1153"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -2552,15 +1991,11 @@
           "color": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:3202:1246"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -2573,15 +2008,11 @@
           "color": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3202:1248"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -2590,15 +2021,11 @@
           "textStyle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3202:1247"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.body.default}",
               "default": "{typography.body.default}"
@@ -2613,15 +2040,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3202:1239"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.active}"
@@ -2630,15 +2053,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3202:1240"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.hover}"
@@ -2647,15 +2066,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3202:1241"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.primary}"
@@ -2665,15 +2080,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:1199"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -2682,15 +2093,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3202:1200"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.40}",
             "default": "{units.size.40}"
@@ -2699,15 +2106,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:1198"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -2716,15 +2119,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:1197"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -2735,15 +2134,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:3202:1187"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
             "default": "{colors.glyph.onSurface.primary}"
@@ -2754,18 +2149,15 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3202:1244"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-            "default": "{colors.text.onSurface.link}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+            "default": "{colors.text.onSurface.link-idle}",
+            "virtuozzo": "{colors.text.onSurface.link-idle}"
           }
         },
         "textStyle": {
@@ -2775,9 +2167,7 @@
             "com.figma.variableId": "VariableID:3202:1242"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "String value",
             "default": "{typography.body.strong}"
@@ -2790,15 +2180,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:3202:1171"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
             "default": "{colors.border.onSurface.border}"
@@ -2807,16 +2193,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:3202:1172"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -2825,15 +2206,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:1266"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -2842,15 +2219,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:1173"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -2861,15 +2234,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:1163"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -2882,15 +2251,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS"],
             "com.figma.variableId": "VariableID:2542:191"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
             "default": "{units.radius.4}"
@@ -2899,15 +2264,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2542:190"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -2916,15 +2277,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2542:188"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -2933,15 +2290,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2542:194"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -2950,15 +2303,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2542:189"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -2967,15 +2316,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2542:195"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.64}",
             "default": "{units.size.64}"
@@ -2986,15 +2331,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2542:192"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -3009,9 +2350,7 @@
             "com.figma.variableId": "VariableID:2542:193"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
             "default": "{typography.body.strong}"
@@ -3025,15 +2364,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2542:198"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
               "default": "{colors.background.brand.secondary-active}"
@@ -3042,15 +2377,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2542:199"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-disabled}",
               "default": "{colors.background.brand.secondary-disabled}"
@@ -3059,15 +2390,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2542:197"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
               "default": "{colors.background.brand.secondary-hover}"
@@ -3076,15 +2403,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2542:196"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary}",
               "default": "{colors.background.brand.secondary}"
@@ -3096,16 +2419,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2542:200"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
             "default": "{colors.glyph.onBrand.primary}"
@@ -3116,15 +2434,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2542:204"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
             "default": "{colors.text.onBrand.primary}"
@@ -3138,15 +2452,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2542:218"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -3155,15 +2465,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2542:219"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -3172,15 +2478,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2542:217"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -3189,15 +2491,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2542:216"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -3211,9 +2509,7 @@
             "com.figma.variableId": "VariableID:2542:210"
           },
           "$type": "string",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
             "default": "solid"
@@ -3222,15 +2518,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT"],
             "com.figma.variableId": "VariableID:2542:211"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -3240,15 +2532,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2542:214"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.active}"
@@ -3257,15 +2545,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2542:215"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -3274,15 +2558,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2542:213"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
               "default": "{colors.background.surface.hover}"
@@ -3291,15 +2571,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2542:212"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -3312,16 +2588,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2542:222"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -3330,16 +2601,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2542:223"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -3348,16 +2614,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2542:221"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -3366,16 +2627,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2542:220"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -3388,32 +2644,25 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2542:226"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-              "default": "{colors.text.onSurface.link}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+              "default": "{colors.text.onSurface.link-idle}",
+              "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           },
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2542:227"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
               "default": "{colors.text.onSurface.link-disabled}"
@@ -3422,35 +2671,29 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2542:225"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-              "default": "{colors.text.onSurface.link}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+              "default": "{colors.text.onSurface.link-idle}",
+              "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           },
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2542:224"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-              "default": "{colors.text.onSurface.link}"
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+              "default": "{colors.text.onSurface.link-idle}",
+              "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           }
         }
@@ -3463,15 +2706,11 @@
         "active": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:3269:2772"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
             "default": "{colors.border.onSurface.border}"
@@ -3480,15 +2719,11 @@
         "focused": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:3269:2773"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
             "default": "{colors.border.onSurface.border}"
@@ -3497,15 +2732,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:3269:2771"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
             "default": "{colors.border.onSurface.border}"
@@ -3514,15 +2745,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:3269:2770"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
             "default": "{colors.border.onSurface.border}"
@@ -3533,15 +2760,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS"],
             "com.figma.variableId": "VariableID:3269:8302"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.8}",
             "default": "{units.radius.8}"
@@ -3550,15 +2773,11 @@
         "borderStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3269:8303"
           },
           "$type": "string",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
             "default": "solid"
@@ -3567,15 +2786,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT"],
             "com.figma.variableId": "VariableID:3269:8351"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -3585,15 +2800,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3297:6379"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.active}"
@@ -3602,15 +2813,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3297:6378"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.hover}"
@@ -3619,15 +2826,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3269:2774"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}"
@@ -3637,15 +2840,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3269:2559"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.64}",
             "default": "{units.size.64}"
@@ -3654,15 +2853,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3269:8304"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
             "default": "{units.gap.16}"
@@ -3671,15 +2866,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3269:8305"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -3690,15 +2881,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3297:6281"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -3709,15 +2896,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3269:8298"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -3726,15 +2909,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3269:8301"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
             "default": "{typography.caption.default}"
@@ -3745,15 +2924,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3297:7246"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.headings.title-accent}",
             "default": "{typography.headings.title-accent}"
@@ -3766,18 +2941,15 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3297:7249"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-            "default": "{colors.text.onSurface.link}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+            "default": "{colors.text.onSurface.link-idle}",
+            "virtuozzo": "{colors.text.onSurface.link-idle}"
           }
         }
       }
@@ -3788,15 +2960,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3330:1825"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -3805,15 +2973,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3297:7244"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -3829,16 +2993,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:22902"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.2}",
             "default": "{units.radius.2}"
@@ -3847,16 +3006,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:22903"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -3865,16 +3019,11 @@
         "marginY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:22904"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -3883,16 +3032,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:22901"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -3903,16 +3047,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:22896"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -3921,16 +3060,11 @@
         "widthMax": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:22898"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.632}",
             "default": "{units.size.632}"
@@ -3939,16 +3073,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:22897"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -3959,16 +3088,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:22899"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -3977,16 +3101,11 @@
         "widthMax": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:22900"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.632}",
             "default": "{units.size.632}"
@@ -3997,15 +3116,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2504:22907"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -4018,9 +3133,7 @@
             "com.figma.variableId": "VariableID:2504:22908"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -4031,15 +3144,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2504:22905"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -4052,9 +3161,7 @@
             "com.figma.variableId": "VariableID:2504:22906"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -4068,15 +3175,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7105"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4085,15 +3188,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7106"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -4102,15 +3201,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7104"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4119,15 +3214,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7103"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4138,15 +3229,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7101"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
               "default": "{colors.background.brand.secondary-active}"
@@ -4155,15 +3242,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7102"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -4172,15 +3255,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7100"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
               "default": "{colors.background.brand.secondary-hover}"
@@ -4189,15 +3268,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7099"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary}",
               "default": "{colors.background.brand.secondary}"
@@ -4210,16 +3285,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2504:22911"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -4228,16 +3298,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2504:22912"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -4246,16 +3311,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2504:22910"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -4264,16 +3324,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2504:22909"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -4288,15 +3343,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7113"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4305,15 +3356,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7114"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -4322,15 +3369,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7112"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4339,15 +3382,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7111"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4358,15 +3397,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7109"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
               "default": "{colors.background.brand.secondary-active}"
@@ -4375,15 +3410,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7110"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -4392,15 +3423,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7108"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
               "default": "{colors.background.brand.secondary-hover}"
@@ -4409,15 +3436,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7107"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary}",
               "default": "{colors.background.brand.secondary}"
@@ -4430,16 +3453,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2504:22915"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -4448,16 +3466,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2504:22916"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -4466,16 +3479,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2504:22914"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -4484,16 +3492,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2504:22913"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -4508,15 +3511,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7097"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4525,15 +3524,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7098"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.divider}",
               "default": "{colors.border.onSurface.divider}"
@@ -4542,15 +3537,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7096"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4559,15 +3550,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7095"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -4578,15 +3565,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7093"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.active}"
@@ -4595,15 +3578,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7094"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -4612,15 +3591,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7092"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
               "default": "{colors.background.surface.hover}"
@@ -4629,15 +3604,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7091"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}"
@@ -4654,15 +3625,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3795:1056"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4671,15 +3638,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3795:1055"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4688,15 +3651,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3767:4115"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.electricblue.3}",
               "default": "{palette.electricblue.3}"
@@ -4706,15 +3665,11 @@
         "radius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS"],
             "com.figma.variableId": "VariableID:3767:4111"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.12}",
             "default": "{units.radius.12}"
@@ -4723,15 +3678,11 @@
         "style": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3767:4109"
           },
           "$type": "string",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
             "default": "solid"
@@ -4740,15 +3691,11 @@
         "width": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT"],
             "com.figma.variableId": "VariableID:3767:4108"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -4760,15 +3707,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3767:4114"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.active}"
@@ -4777,15 +3720,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3767:4113"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
               "default": "{colors.background.surface.hover}"
@@ -4794,15 +3733,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3767:4112"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -4812,15 +3747,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3767:4119"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -4829,15 +3760,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3767:4104"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.24}",
             "default": "{units.size.24}"
@@ -4846,15 +3773,11 @@
         "marginY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3929:3831"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -4863,15 +3786,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3767:4105"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -4880,15 +3799,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3799:201"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.48}",
             "default": "{units.size.48}"
@@ -4899,15 +3814,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3767:4266"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
             "default": "{colors.glyph.onSurface.primary}"
@@ -4916,15 +3827,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3767:4110"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -4937,32 +3844,25 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:4090:4824"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-            "default": "{colors.text.onSurface.link}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+            "default": "{colors.text.onSurface.link-idle}",
+            "virtuozzo": "{colors.text.onSurface.link-idle}"
           }
         },
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:4090:4825"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.link.strong}",
             "default": "{typography.link.strong}"
@@ -4975,15 +3875,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3767:4116"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -4992,14 +3888,10 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ]
+            "com.figma.scopes": ["ALL_SCOPES"]
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -5012,15 +3904,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:4090:12305"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -5029,14 +3917,10 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ]
+            "com.figma.scopes": ["ALL_SCOPES"]
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -5051,15 +3935,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS"],
             "com.figma.variableId": "VariableID:3022:650"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
             "default": "{units.radius.4}"
@@ -5068,15 +3948,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT"],
             "com.figma.variableId": "VariableID:3022:651"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -5086,15 +3962,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3022:664"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -5103,15 +3975,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3022:663"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}"
@@ -5120,15 +3988,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3022:662"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}"
@@ -5138,15 +4002,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3022:646"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -5155,15 +4015,11 @@
         "gapRange": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3105:1377"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -5172,15 +4028,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3022:649"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -5189,15 +4041,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3022:647"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -5206,15 +4054,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3022:648"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -5225,15 +4069,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3022:643"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -5242,15 +4082,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3022:644"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.128}",
             "default": "{units.size.128}"
@@ -5261,15 +4097,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3022:645"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -5281,15 +4113,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:654"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -5298,15 +4126,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:653"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -5315,15 +4139,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:652"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -5333,15 +4153,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3105:1317"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.form-label}",
             "default": "{typography.body.form-label}"
@@ -5353,15 +4169,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:658"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -5370,15 +4182,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:657"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -5387,15 +4195,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:656"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -5405,15 +4209,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3105:1320"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -5424,15 +4224,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3022:655"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
             "default": "{colors.text.onSurface.destructive}"
@@ -5441,15 +4237,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3105:1316"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
             "default": "{typography.caption.default}"
@@ -5461,15 +4253,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3105:1407"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -5478,15 +4266,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3105:1406"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -5495,15 +4279,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:665"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -5513,15 +4293,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3105:1319"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -5533,15 +4309,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:661"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -5550,15 +4322,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:660"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -5567,15 +4335,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:659"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -5585,15 +4349,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3105:1318"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -5607,15 +4367,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3105:1323"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
               "default": "{colors.border.onSurface.border-error}"
@@ -5624,15 +4380,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:676"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
               "default": "{colors.border.onSurface.border-error}"
@@ -5641,15 +4393,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:675"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
               "default": "{colors.border.onSurface.border-error}"
@@ -5661,15 +4409,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3022:679"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
             "default": "{colors.text.onSurface.destructive}"
@@ -5678,15 +4422,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3105:1322"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
             "default": "{typography.caption.default}"
@@ -5698,16 +4438,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:678"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.destructive}",
               "default": "{colors.glyph.onSurface.destructive}"
@@ -5716,16 +4451,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:677"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.destructive}",
               "default": "{colors.glyph.onSurface.destructive}"
@@ -5740,15 +4470,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3075:2661"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -5757,15 +4483,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:668"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -5774,15 +4496,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:667"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -5791,15 +4509,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:666"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -5812,15 +4526,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:674"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -5829,15 +4539,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:673"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -5846,15 +4552,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:672"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -5864,15 +4566,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3105:1321"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
             "default": "{typography.caption.default}"
@@ -5884,16 +4582,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:671"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -5902,16 +4595,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:670"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -5920,16 +4608,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:669"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -5944,15 +4627,11 @@
       "disabled": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2605:95"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border}",
           "default": "{colors.border.onSurface.border}"
@@ -5961,15 +4640,11 @@
       "hover": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2605:93"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
           "default": "{colors.border.onSurface.border-active}"
@@ -5978,15 +4653,11 @@
       "idle": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2605:92"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border}",
           "default": "{colors.border.onSurface.border}"
@@ -5997,16 +4668,11 @@
       "borderRadius": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "CORNER_RADIUS",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2605:86"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.radius.4}",
           "default": "{units.radius.4}"
@@ -6015,16 +4681,11 @@
       "borderWidth": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_FLOAT",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2605:87"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.stroke.1}",
           "default": "{units.stroke.1}"
@@ -6034,15 +4695,11 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2605:91"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.secondary}",
             "default": "{colors.background.surface.secondary}"
@@ -6051,15 +4708,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2605:89"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
             "default": "{colors.background.surface.primary}"
@@ -6068,15 +4721,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2605:88"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
             "default": "{colors.background.surface.primary}"
@@ -6086,16 +4735,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2605:85"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
           "default": "{units.gap.8}"
@@ -6104,16 +4748,11 @@
       "height": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2605:82"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.32}",
           "default": "{units.size.32}"
@@ -6122,16 +4761,11 @@
       "paddingX": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2605:83"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.12}",
           "default": "{units.gap.12}"
@@ -6140,16 +4774,11 @@
       "paddingY": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2605:84"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
           "default": "{units.gap.4}"
@@ -6160,16 +4789,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2605:115"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
           "default": "{colors.glyph.onSurface.primary}"
@@ -6180,15 +4804,11 @@
       "disabled": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:2605:78"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
           "default": "{colors.text.onSurface.disabled}"
@@ -6197,15 +4817,11 @@
       "hover": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:2605:76"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
           "default": "{colors.text.onSurface.primary}"
@@ -6214,15 +4830,11 @@
       "idle": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:2605:75"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
           "default": "{colors.text.onSurface.primary}"
@@ -6233,16 +4845,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2605:72"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
           "default": "{units.gap.4}"
@@ -6251,16 +4858,11 @@
       "widthMin": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2605:73"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.128}",
           "default": "{units.size.128}"
@@ -6271,16 +4873,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2605:74"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
           "default": "{units.gap.4}"
@@ -6292,16 +4889,11 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2649:11863"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
             "default": "{colors.glyph.onSurface.disabled}"
@@ -6310,16 +4902,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2649:11862"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
             "default": "{colors.glyph.onSurface.primary}"
@@ -6328,16 +4915,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2614:120"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
             "default": "{colors.glyph.onSurface.primary}"
@@ -6353,9 +4935,7 @@
           "com.figma.variableId": "VariableID:2605:79"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.form-label}",
           "default": "{typography.body.form-label}"
@@ -6367,15 +4947,11 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2954:3288"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
             "default": "{colors.text.onSurface.disabled}"
@@ -6384,15 +4960,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2954:3287"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -6401,15 +4973,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2610:121"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -6421,15 +4989,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:2605:80"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
           "default": "{colors.text.onSurface.destructive}"
@@ -6442,9 +5006,7 @@
           "com.figma.variableId": "VariableID:2605:81"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
           "default": "{typography.body.default}"
@@ -6456,15 +5018,11 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2649:11867"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
             "default": "{colors.text.onSurface.disabled}"
@@ -6473,15 +5031,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2649:11866"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -6490,15 +5044,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2610:122"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -6512,9 +5062,7 @@
           "com.figma.variableId": "VariableID:2605:111"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
           "default": "{typography.body.default}"
@@ -6528,15 +5076,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:816"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -6547,15 +5091,11 @@
             "placeholder": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "TEXT_FILL"
-                ],
+                "com.figma.scopes": ["TEXT_FILL"],
                 "com.figma.variableId": "VariableID:3202:828"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
                 "default": "{colors.text.onSurface.secondary}"
@@ -6564,15 +5104,11 @@
             "value": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "TEXT_FILL"
-                ],
+                "com.figma.scopes": ["TEXT_FILL"],
                 "com.figma.variableId": "VariableID:3202:829"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
                 "default": "{colors.text.onSurface.primary}"
@@ -6586,9 +5122,7 @@
               "com.figma.variableId": "VariableID:3202:827"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.body.default}",
               "default": "{typography.body.default}"
@@ -6598,15 +5132,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:814"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -6615,15 +5145,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:815"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -6634,15 +5160,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2634:18031"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
             "default": "{colors.border.onSurface.border-active}"
@@ -6651,15 +5173,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS"],
             "com.figma.variableId": "VariableID:2634:18033"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
             "default": "{units.radius.4}"
@@ -6668,15 +5186,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT"],
             "com.figma.variableId": "VariableID:2634:18032"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -6685,15 +5199,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2634:18030"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
             "default": "{colors.background.surface.primary}"
@@ -6702,15 +5212,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:708"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -6719,15 +5225,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:707"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -6736,15 +5238,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2634:18034"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -6755,15 +5253,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:824"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.8}",
             "default": "{units.gap.8}"
@@ -6772,15 +5266,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:823"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
             "default": "{units.gap.16}"
@@ -6789,15 +5279,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:822"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.gap.16}"
@@ -6806,15 +5292,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3202:825"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.128}",
             "default": "{units.size.128}"
@@ -6828,15 +5310,11 @@
           "gap": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP"
-              ],
+              "com.figma.scopes": ["GAP"],
               "com.figma.variableId": "VariableID:3202:916"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
               "default": "{units.gap.8}"
@@ -6845,15 +5323,11 @@
           "height": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "WIDTH_HEIGHT"
-              ],
+              "com.figma.scopes": ["WIDTH_HEIGHT"],
               "com.figma.variableId": "VariableID:2634:18043"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.40}",
               "default": "{units.size.40}"
@@ -6862,15 +5336,11 @@
           "paddingX": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP"
-              ],
+              "com.figma.scopes": ["GAP"],
               "com.figma.variableId": "VariableID:2634:18044"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.12}",
               "default": "{units.gap.12}"
@@ -6879,15 +5349,11 @@
           "paddingY": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP"
-              ],
+              "com.figma.scopes": ["GAP"],
               "com.figma.variableId": "VariableID:2634:18045"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
               "default": "{units.gap.8}"
@@ -6897,15 +5363,11 @@
         "iconChecked": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:3064:21377"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.glyph.onSurface.primary}"
@@ -6914,15 +5376,11 @@
         "iconCollapse": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:3202:923"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.glyph.onSurface.primary}"
@@ -6931,15 +5389,11 @@
         "iconTenant": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:3202:917"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.glyph.onSurface.primary}"
@@ -6949,15 +5403,11 @@
           "color": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2634:18046"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -6971,15 +5421,11 @@
             "disabled": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2634:18054"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.secondary}",
                 "default": "{colors.background.surface.secondary}"
@@ -6988,15 +5434,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2634:18053"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.active}",
                 "default": "{colors.background.surface.active}"
@@ -7005,15 +5447,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2634:18052"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.active}",
                 "default": "{colors.background.surface.active}"
@@ -7028,15 +5466,11 @@
             "disabled": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2634:18051"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.secondary}",
                 "default": "{colors.background.surface.secondary}"
@@ -7045,15 +5479,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2634:18050"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.hover}",
                 "default": "{colors.background.surface.hover}"
@@ -7062,15 +5492,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2634:18049"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.primary}",
                 "default": "{colors.background.surface.primary}"
@@ -7085,15 +5511,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2634:18037"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
             "default": "{colors.border.onSurface.border}"
@@ -7102,16 +5524,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18038"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -7120,15 +5537,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2634:18036"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -7139,15 +5552,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2634:18039"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -7156,15 +5565,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2634:18040"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -7175,15 +5580,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2634:18041"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -7196,9 +5597,7 @@
             "com.figma.variableId": "VariableID:3202:826"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
             "default": "{typography.body.strong}"
@@ -7209,15 +5608,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2634:18042"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -7230,16 +5625,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18013"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
             "default": "{units.radius.4}"
@@ -7248,16 +5638,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18014"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -7267,15 +5652,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2634:18017"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -7284,15 +5665,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2634:18016"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}"
@@ -7301,15 +5678,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2634:18015"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}"
@@ -7319,16 +5692,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18009"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.8}"
@@ -7337,16 +5705,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18012"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -7355,16 +5718,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18010"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -7373,16 +5731,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18011"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -7393,16 +5746,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18002"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -7411,16 +5759,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18003"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.128}",
             "default": "{units.size.128}"
@@ -7431,16 +5774,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18004"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -7452,15 +5790,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2634:18007"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -7469,15 +5803,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2634:18006"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -7486,15 +5816,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2634:18005"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -7508,9 +5834,7 @@
             "com.figma.variableId": "VariableID:2649:11857"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.form-label}",
             "default": "{typography.body.form-label}"
@@ -7522,15 +5846,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2951:3282"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -7539,15 +5859,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2951:3281"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -7556,15 +5872,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2634:18021"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -7576,15 +5888,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2634:18008"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
             "default": "{colors.text.onSurface.destructive}"
@@ -7597,9 +5905,7 @@
             "com.figma.variableId": "VariableID:2649:11858"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -7611,15 +5917,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2649:11869"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -7628,15 +5930,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2649:11868"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -7645,15 +5943,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2634:18022"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -7667,9 +5961,7 @@
             "com.figma.variableId": "VariableID:2649:11861"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -7683,15 +5975,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2634:18028"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
               "default": "{colors.border.onSurface.border-error}"
@@ -7700,15 +5988,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2634:18027"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
               "default": "{colors.border.onSurface.border-error}"
@@ -7720,15 +6004,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2634:18029"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
             "default": "{colors.text.onSurface.destructive}"
@@ -7741,9 +6021,7 @@
             "com.figma.variableId": "VariableID:2649:11860"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
             "default": "{typography.caption.default}"
@@ -7755,15 +6033,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:3299:9036"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.glyph.onSurface.destructive}"
@@ -7772,15 +6046,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:3299:9035"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.glyph.onSurface.destructive}"
@@ -7793,15 +6063,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:2634:18020"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -7810,15 +6076,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:2634:18019"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.destructive}"
@@ -7827,15 +6089,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:2634:18018"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.destructive}"
@@ -7850,15 +6108,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2634:18025"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -7867,15 +6121,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2634:18024"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -7884,15 +6134,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2634:18023"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -7905,15 +6151,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2951:3284"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -7922,15 +6164,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2951:3283"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -7939,15 +6177,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2634:18026"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -7961,9 +6195,7 @@
             "com.figma.variableId": "VariableID:2649:11859"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
             "default": "{typography.caption.default}"
@@ -7975,15 +6207,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:3299:8951"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -7992,15 +6220,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:3299:8950"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -8009,15 +6233,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:3299:8949"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -8030,15 +6250,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:2881:9672"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -8047,15 +6263,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:2881:9671"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -8064,15 +6276,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:2881:9670"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -8088,16 +6296,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2289:2867"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
             "default": "{units.radius.4}"
@@ -8106,16 +6309,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2289:2868"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -8125,15 +6323,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2289:2873"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -8142,15 +6336,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2289:2870"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}"
@@ -8159,15 +6349,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2289:2869"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}"
@@ -8177,16 +6363,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2289:2866"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -8195,16 +6376,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2289:2863"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -8213,16 +6389,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2289:2864"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -8231,16 +6402,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2289:2865"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -8251,16 +6417,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2624:92"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
             "default": "{colors.glyph.onSurface.primary}"
@@ -8271,16 +6432,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2289:2852"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -8289,16 +6445,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2289:2853"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.128}",
             "default": "{units.size.128}"
@@ -8309,16 +6460,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2289:2854"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -8330,15 +6476,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2289:2859"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -8347,15 +6489,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2289:2856"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -8364,15 +6502,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2289:2855"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -8386,9 +6520,7 @@
             "com.figma.variableId": "VariableID:2289:2860"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.form-label}",
             "default": "{typography.body.form-label}"
@@ -8400,15 +6532,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2848:680"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.disabled}"
@@ -8417,15 +6545,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2848:679"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -8434,15 +6558,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2289:2914"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -8454,15 +6574,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2289:2861"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
             "default": "{colors.text.onSurface.destructive}"
@@ -8475,9 +6591,7 @@
             "com.figma.variableId": "VariableID:2289:2862"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -8489,15 +6603,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2649:11865"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -8506,15 +6616,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2649:11864"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -8523,15 +6629,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2289:2919"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -8545,9 +6647,7 @@
             "com.figma.variableId": "VariableID:2289:2924"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -8561,15 +6661,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2289:2906"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
               "default": "{colors.border.onSurface.border-error}"
@@ -8578,15 +6674,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2289:2905"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
               "default": "{colors.border.onSurface.border-error}"
@@ -8598,15 +6690,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2289:2910"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
             "default": "{colors.text.onSurface.destructive}"
@@ -8619,9 +6707,7 @@
             "com.figma.variableId": "VariableID:2289:2911"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
             "default": "{typography.caption.default}"
@@ -8635,15 +6721,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2289:2878"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -8652,15 +6734,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2289:2875"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -8669,15 +6747,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2289:2874"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -8690,15 +6764,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2954:3286"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -8707,15 +6777,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2954:3285"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -8724,15 +6790,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2289:2881"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -8746,9 +6808,7 @@
             "com.figma.variableId": "VariableID:2289:2882"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
             "default": "{typography.caption.default}"
@@ -8762,15 +6822,11 @@
       "disabled": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2795:688"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border}",
           "default": "{colors.border.onSurface.border}"
@@ -8779,15 +6835,11 @@
       "focus": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2951:3243"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
           "default": "{colors.border.onSurface.border-active}"
@@ -8796,15 +6848,11 @@
       "hover": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2795:686"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
           "default": "{colors.border.onSurface.border-active}"
@@ -8813,15 +6861,11 @@
       "idle": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2795:685"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border}",
           "default": "{colors.border.onSurface.border}"
@@ -8832,16 +6876,11 @@
       "borderRadius": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "CORNER_RADIUS",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2795:679"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.radius.4}",
           "default": "{units.radius.4}"
@@ -8850,16 +6889,11 @@
       "borderWidth": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_FLOAT",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2795:680"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.stroke.1}",
           "default": "{units.stroke.1}"
@@ -8869,15 +6903,11 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2795:684"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.secondary}",
             "default": "{colors.background.surface.secondary}"
@@ -8886,15 +6916,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2795:682"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
             "default": "{colors.background.surface.primary}"
@@ -8903,15 +6929,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2795:681"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
             "default": "{colors.background.surface.primary}"
@@ -8921,16 +6943,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2795:678"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.12}",
           "default": "{units.gap.12}"
@@ -8939,16 +6956,11 @@
       "heightMin": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2795:675"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.96}",
           "default": "{units.size.96}"
@@ -8957,16 +6969,11 @@
       "paddingX": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2795:676"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.12}",
           "default": "{units.gap.12}"
@@ -8975,16 +6982,11 @@
       "paddingY": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2795:677"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
           "default": "{units.gap.8}"
@@ -8995,16 +6997,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2795:665"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
           "default": "{units.gap.4}"
@@ -9013,16 +7010,11 @@
       "widthMin": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2795:666"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.256}",
           "default": "{units.size.256}"
@@ -9033,16 +7025,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2795:667"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
           "default": "{units.gap.4}"
@@ -9054,15 +7041,11 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2845:739"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
             "default": "{colors.text.onSurface.disabled}"
@@ -9071,15 +7054,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2845:738"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -9088,15 +7067,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2795:695"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -9110,9 +7085,7 @@
           "com.figma.variableId": "VariableID:2795:696"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.caption.default}",
           "default": "{typography.caption.default}"
@@ -9129,9 +7102,7 @@
               "com.figma.variableId": "VariableID:3689:2477"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
               "default": "{colors.border.onSurface.border-error}"
@@ -9144,9 +7115,7 @@
               "com.figma.variableId": "VariableID:3689:2476"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
               "default": "{colors.border.onSurface.border-error}"
@@ -9162,9 +7131,7 @@
             "com.figma.variableId": "VariableID:3689:2478"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
             "default": "{colors.text.onSurface.destructive}"
@@ -9177,9 +7144,7 @@
             "com.figma.variableId": "VariableID:3689:2479"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
             "default": "{typography.caption.default}"
@@ -9192,15 +7157,11 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2795:671"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
             "default": "{colors.text.onSurface.disabled}"
@@ -9209,15 +7170,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2795:669"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -9226,15 +7183,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2795:668"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -9248,9 +7201,7 @@
           "com.figma.variableId": "VariableID:2795:672"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.form-label}",
           "default": "{typography.body.form-label}"
@@ -9262,15 +7213,11 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2845:737"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
             "default": "{colors.text.onSurface.disabled}"
@@ -9279,15 +7226,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2845:736"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -9296,15 +7239,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2795:689"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -9318,9 +7257,7 @@
           "com.figma.variableId": "VariableID:2818:1200"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
           "default": "{typography.body.default}"
@@ -9331,15 +7268,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:2795:673"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
           "default": "{colors.text.onSurface.destructive}"
@@ -9352,9 +7285,7 @@
           "com.figma.variableId": "VariableID:2795:674"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
           "default": "{typography.body.default}"
@@ -9366,15 +7297,11 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2795:693"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
             "default": "{colors.text.onSurface.disabled}"
@@ -9383,15 +7310,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2795:691"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -9400,15 +7323,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2795:690"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -9422,9 +7341,7 @@
           "com.figma.variableId": "VariableID:2795:694"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
           "default": "{typography.body.default}"
@@ -9436,15 +7353,11 @@
     "color": {
       "active": {
         "$extensions": {
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:3735:859"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
           "default": "{colors.text.onSurface.link-pressed}"
@@ -9452,15 +7365,11 @@
       },
       "disabled": {
         "$extensions": {
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:3735:860"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
           "default": "{colors.text.onSurface.link-disabled}"
@@ -9468,15 +7377,11 @@
       },
       "hover": {
         "$extensions": {
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:3735:858"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
           "default": "{colors.text.onSurface.link-hover}"
@@ -9484,33 +7389,25 @@
       },
       "idle": {
         "$extensions": {
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:3735:857"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
-          "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-          "default": "{colors.text.onSurface.link}"
+          "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+          "default": "{colors.text.onSurface.link-idle}"
         }
       }
     },
     "container": {
       "gap": {
         "$extensions": {
-          "com.figma.scopes": [
-            "GAP"
-          ],
+          "com.figma.scopes": ["GAP"],
           "com.figma.variableId": "VariableID:3735:874"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
           "default": "{units.gap.4}"
@@ -9518,15 +7415,11 @@
       },
       "height": {
         "$extensions": {
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:3735:873"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.32}",
           "default": "{units.size.32}"
@@ -9542,9 +7435,7 @@
             "com.figma.variableId": "VariableID:3735:874"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
             "default": "{colors.text.onSurface.link-pressed}"
@@ -9557,9 +7448,7 @@
             "com.figma.variableId": "VariableID:3735:865"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
             "default": "{colors.text.onSurface.link-disabled}"
@@ -9572,9 +7461,7 @@
             "com.figma.variableId": "VariableID:3735:863"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
             "default": "{colors.text.onSurface.link-hover}"
@@ -9587,12 +7474,10 @@
             "com.figma.variableId": "VariableID:3735:862"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-            "default": "{colors.text.onSurface.link}"
+            "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+            "default": "{colors.text.onSurface.link-idle}"
           }
         }
       }
@@ -9600,15 +7485,11 @@
     "textDecoration": {
       "active": {
         "$extensions": {
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3735:864"
         },
         "$type": "string",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "none",
           "default": "none"
@@ -9616,15 +7497,11 @@
       },
       "disabled": {
         "$extensions": {
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3735:865"
         },
         "$type": "string",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "none",
           "default": "none"
@@ -9632,15 +7509,11 @@
       },
       "hover": {
         "$extensions": {
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3735:863"
         },
         "$type": "string",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "underline",
           "default": "underline"
@@ -9648,15 +7521,11 @@
       },
       "idle": {
         "$extensions": {
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3735:862"
         },
         "$type": "string",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "none",
           "default": "none"
@@ -9666,15 +7535,11 @@
     "textStyle": {
       "active": {
         "$extensions": {
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3735:871"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.link.strong}",
           "default": "{typography.link.strong}"
@@ -9682,15 +7547,11 @@
       },
       "disabled": {
         "$extensions": {
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3735:872"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.link.strong}",
           "default": "{typography.link.strong}"
@@ -9698,15 +7559,11 @@
       },
       "hover": {
         "$extensions": {
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3735:870"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.link.strong-underline}",
           "default": "{typography.link.strong-underline}"
@@ -9714,15 +7571,11 @@
       },
       "idle": {
         "$extensions": {
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3735:861"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.link.strong}",
           "default": "{typography.link.strong}"
@@ -9736,16 +7589,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2597:1743"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.full}",
             "default": "{units.radius.full}"
@@ -9754,16 +7602,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2597:1744"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -9772,16 +7615,11 @@
         "marginY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2597:1745"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -9790,16 +7628,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2597:1742"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -9810,16 +7643,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2597:1737"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -9828,16 +7656,11 @@
         "widthMax": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2597:1739"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.632}",
             "default": "{units.size.632}"
@@ -9846,16 +7669,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2597:1738"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -9866,16 +7684,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2597:1740"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -9884,16 +7697,11 @@
         "widthMax": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2597:1741"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.632}",
             "default": "{units.size.632}"
@@ -9904,15 +7712,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2597:1747"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -9925,9 +7729,7 @@
             "com.figma.variableId": "VariableID:2597:1749"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -9938,15 +7740,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2597:1746"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -9959,9 +7757,7 @@
             "com.figma.variableId": "VariableID:2597:1748"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -9975,15 +7771,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1764"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -9992,15 +7784,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1765"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -10009,15 +7797,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1763"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -10026,15 +7810,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1762"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -10045,15 +7825,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2597:1760"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
               "default": "{colors.background.brand.secondary-active}"
@@ -10062,15 +7838,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2597:1761"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -10079,15 +7851,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2597:1759"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
               "default": "{colors.background.brand.secondary-hover}"
@@ -10096,15 +7864,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2597:1758"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary}",
               "default": "{colors.background.brand.secondary}"
@@ -10117,16 +7881,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1768"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -10135,16 +7894,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1769"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -10153,16 +7907,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1767"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -10171,16 +7920,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1766"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -10195,15 +7939,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1756"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -10212,15 +7952,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1757"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.divider}",
               "default": "{colors.border.onSurface.divider}"
@@ -10229,15 +7965,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1755"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -10246,15 +7978,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1754"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -10265,15 +7993,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2597:1752"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.active}"
@@ -10282,15 +8006,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2597:1753"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -10299,15 +8019,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2597:1751"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
               "default": "{colors.background.surface.hover}"
@@ -10316,15 +8032,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2597:1750"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}"
@@ -10339,15 +8051,11 @@
       "borderRadius": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "CORNER_RADIUS"
-          ],
+          "com.figma.scopes": ["CORNER_RADIUS"],
           "com.figma.variableId": "VariableID:3459:3716"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.radius.4}",
           "default": "{units.radius.4}"
@@ -10356,15 +8064,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "FRAME_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL"],
           "com.figma.variableId": "VariableID:3459:3717"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.background.brand.secondary}",
           "default": "{colors.background.brand.secondary}"
@@ -10373,15 +8077,11 @@
       "height": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:3459:3715"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.32}",
           "default": "{units.size.32}"
@@ -10390,15 +8090,11 @@
       "width": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:3459:3713"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.7}",
           "default": "{units.size.7}"
@@ -10410,15 +8106,11 @@
         "active": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:3459:3712"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
             "default": "{colors.border.onSurface.border-active}"
@@ -10427,15 +8119,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:3459:3710"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
             "default": "{colors.border.onSurface.border-active}"
@@ -10445,15 +8133,11 @@
       "style": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3459:3709"
         },
         "$type": "string",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "solid",
           "default": "solid"
@@ -10462,15 +8146,11 @@
       "width": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_FLOAT"
-          ],
+          "com.figma.scopes": ["STROKE_FLOAT"],
           "com.figma.variableId": "VariableID:3459:3708"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.stroke.1}",
           "default": "{units.stroke.1}"
@@ -10480,15 +8160,11 @@
     "cursor": {
       "$extensions": {
         "com.figma.hiddenFromPublishing": true,
-        "com.figma.scopes": [
-          "ALL_SCOPES"
-        ],
+        "com.figma.scopes": ["ALL_SCOPES"],
         "com.figma.variableId": "VariableID:3459:3719"
       },
       "$type": "string",
-      "platforms": [
-        "PD"
-      ],
+      "platforms": ["PD"],
       "values": {
         "deep_sky_itkontoret": "ew-resize",
         "default": "ew-resize"
@@ -10500,15 +8176,11 @@
       "active": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:2962:669"
         },
         "$type": "string",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{gradients.ai.active}",
           "default": "{gradients.ai.active}"
@@ -10517,15 +8189,11 @@
       "hover": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:2962:668"
         },
         "$type": "string",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{gradients.ai.hover}",
           "default": "{gradients.ai.hover}"
@@ -10534,15 +8202,11 @@
       "idle": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:2962:667"
         },
         "$type": "string",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{gradients.ai.idle}",
           "default": "{gradients.ai.idle}"
@@ -10553,15 +8217,11 @@
       "borderRadius": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "CORNER_RADIUS"
-          ],
+          "com.figma.scopes": ["CORNER_RADIUS"],
           "com.figma.variableId": "VariableID:2959:657"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.radius.24}",
           "default": "{units.radius.24}"
@@ -10570,15 +8230,11 @@
       "borderStyle": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:2959:656"
         },
         "$type": "string",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "solid",
           "default": "solid"
@@ -10587,15 +8243,11 @@
       "borderWidth": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_FLOAT"
-          ],
+          "com.figma.scopes": ["STROKE_FLOAT"],
           "com.figma.variableId": "VariableID:2959:655"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.stroke.2}",
           "default": "{units.stroke.2}"
@@ -10604,15 +8256,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "FRAME_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL"],
           "com.figma.variableId": "VariableID:2962:662"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.background.surface.primary}",
           "default": "{colors.background.surface.primary}"
@@ -10621,15 +8269,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP"
-          ],
+          "com.figma.scopes": ["GAP"],
           "com.figma.variableId": "VariableID:2962:663"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
           "default": "{units.gap.8}"
@@ -10638,15 +8282,11 @@
       "height": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:2959:648"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.48}",
           "default": "{units.size.48}"
@@ -10655,15 +8295,11 @@
       "paddingX": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP"
-          ],
+          "com.figma.scopes": ["GAP"],
           "com.figma.variableId": "VariableID:2959:649"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.16}",
           "default": "{units.gap.16}"
@@ -10672,15 +8308,11 @@
       "width": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:2959:647"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.512}",
           "default": "{units.size.512}"
@@ -10689,15 +8321,11 @@
       "widthMax": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:2984:3908"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.512}",
           "default": "{units.size.512}"
@@ -10706,15 +8334,11 @@
       "widthMin": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:2984:3909"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.256}",
           "default": "{units.size.256}"
@@ -10725,16 +8349,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2959:658"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.glyph.onStatus.ai}",
           "default": "{colors.glyph.onStatus.ai}"
@@ -10743,15 +8362,11 @@
       "size": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:2959:659"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.16}",
           "default": "{units.size.16}"
@@ -10762,15 +8377,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:2962:660"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onStatus.ai}",
           "default": "{colors.text.onStatus.ai}"
@@ -10779,15 +8390,11 @@
       "textStyle": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:2962:661"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
           "default": "{typography.body.default}"
@@ -10798,15 +8405,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:2962:664"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
           "default": "{colors.text.onSurface.secondary}"
@@ -10815,15 +8418,11 @@
       "textStyle": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:2962:665"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
           "default": "{typography.body.default}"
@@ -10838,16 +8437,11 @@
           "gap": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2463:56486"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
               "default": "{units.gap.8}"
@@ -10856,16 +8450,11 @@
           "height": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "WIDTH_HEIGHT",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2463:56483"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.40}",
               "default": "{units.size.40}"
@@ -10874,16 +8463,11 @@
           "paddingX": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2463:56484"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.16}",
               "default": "{units.gap.16}"
@@ -10892,16 +8476,11 @@
           "paddingY": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2463:56485"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
               "default": "{units.gap.8}"
@@ -10912,16 +8491,11 @@
           "marginT": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2463:56488"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.4}",
               "default": "{units.gap.4}"
@@ -10930,16 +8504,11 @@
           "size": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "WIDTH_HEIGHT",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2463:56487"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.16}",
               "default": "{units.size.16}"
@@ -10954,9 +8523,7 @@
               "com.figma.variableId": "VariableID:2463:56489"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.body.strong}",
               "default": "{typography.body.strong}"
@@ -10970,15 +8537,11 @@
             "active": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2463:56501"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.brand.primary-active}",
                 "default": "{colors.background.brand.primary-active}"
@@ -10987,15 +8550,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2463:56500"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.brand.primary-active}",
                 "default": "{colors.background.brand.primary-active}"
@@ -11004,15 +8563,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2463:56499"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.brand.primary-active}",
                 "default": "{colors.background.brand.primary-active}"
@@ -11025,16 +8580,11 @@
             "active": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "SHAPE_FILL",
-                  "STROKE_COLOR"
-                ],
+                "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
                 "com.figma.variableId": "VariableID:2463:56504"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
                 "default": "{colors.glyph.onBrand.primary}"
@@ -11043,16 +8593,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "SHAPE_FILL",
-                  "STROKE_COLOR"
-                ],
+                "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
                 "com.figma.variableId": "VariableID:2463:56503"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
                 "default": "{colors.glyph.onBrand.primary}"
@@ -11061,16 +8606,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "SHAPE_FILL",
-                  "STROKE_COLOR"
-                ],
+                "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
                 "com.figma.variableId": "VariableID:2463:56502"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onBrand.secondary}",
                 "default": "{colors.glyph.onBrand.primary}"
@@ -11083,15 +8623,11 @@
             "active": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "TEXT_FILL"
-                ],
+                "com.figma.scopes": ["TEXT_FILL"],
                 "com.figma.variableId": "VariableID:2463:56507"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
                 "default": "{colors.text.onBrand.primary}"
@@ -11100,15 +8636,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "TEXT_FILL"
-                ],
+                "com.figma.scopes": ["TEXT_FILL"],
                 "com.figma.variableId": "VariableID:2463:56506"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
                 "default": "{colors.text.onBrand.primary}"
@@ -11117,15 +8649,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "TEXT_FILL"
-                ],
+                "com.figma.scopes": ["TEXT_FILL"],
                 "com.figma.variableId": "VariableID:2463:56505"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
                 "default": "{colors.text.onBrand.primary}"
@@ -11140,15 +8668,11 @@
             "active": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2463:56492"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.brand.primary-hover}",
                 "default": "{colors.background.brand.primary-hover}"
@@ -11157,15 +8681,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2463:56491"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.brand.primary-hover}",
                 "default": "{colors.background.brand.primary-hover}"
@@ -11174,15 +8694,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2463:56490"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.brand.primary}",
                 "default": "{colors.background.brand.primary}"
@@ -11195,16 +8711,11 @@
             "active": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "SHAPE_FILL",
-                  "STROKE_COLOR"
-                ],
+                "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
                 "com.figma.variableId": "VariableID:2463:56495"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
                 "default": "{colors.glyph.onBrand.primary}"
@@ -11213,16 +8724,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "SHAPE_FILL",
-                  "STROKE_COLOR"
-                ],
+                "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
                 "com.figma.variableId": "VariableID:2463:56494"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
                 "default": "{colors.glyph.onBrand.primary}"
@@ -11231,16 +8737,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "SHAPE_FILL",
-                  "STROKE_COLOR"
-                ],
+                "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
                 "com.figma.variableId": "VariableID:2463:56493"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onBrand.secondary}",
                 "default": "{colors.glyph.onBrand.secondary}"
@@ -11253,15 +8754,11 @@
             "active": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "TEXT_FILL"
-                ],
+                "com.figma.scopes": ["TEXT_FILL"],
                 "com.figma.variableId": "VariableID:2463:56498"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
                 "default": "{colors.text.onBrand.primary}"
@@ -11270,15 +8767,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "TEXT_FILL"
-                ],
+                "com.figma.scopes": ["TEXT_FILL"],
                 "com.figma.variableId": "VariableID:2463:56497"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
                 "default": "{colors.text.onBrand.primary}"
@@ -11287,15 +8780,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "TEXT_FILL"
-                ],
+                "com.figma.scopes": ["TEXT_FILL"],
                 "com.figma.variableId": "VariableID:2463:56496"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onBrand.secondary}",
                 "default": "{colors.text.onBrand.secondary}"
@@ -11311,16 +8800,11 @@
           "gap": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2463:56508"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
               "default": "{units.gap.8}"
@@ -11331,16 +8815,11 @@
           "color": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2463:56510"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.secondary}",
               "default": "{colors.glyph.onBrand.secondary}"
@@ -11349,16 +8828,11 @@
           "size": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "WIDTH_HEIGHT",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2463:56509"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.16}",
               "default": "{units.size.16}"
@@ -11369,15 +8843,11 @@
           "color": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2463:56511"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.secondary}",
               "default": "{colors.text.onBrand.secondary}"
@@ -11390,9 +8860,7 @@
               "com.figma.variableId": "VariableID:2463:56512"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.body.default}",
               "default": "{typography.body.default}"
@@ -11406,16 +8874,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56482"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -11426,15 +8889,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2463:56481"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onBrand.border}",
             "default": "{colors.border.onBrand.border}"
@@ -11443,16 +8902,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56480"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -11461,16 +8915,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56479"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -11483,15 +8932,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2463:56467"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.brand.primary}",
             "default": "{colors.background.brand.primary}"
@@ -11502,15 +8947,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2468:67776"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onBrand.border}",
             "default": "{colors.border.onBrand.border}"
@@ -11519,21 +8960,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS",
-              "WIDTH_HEIGHT",
-              "GAP",
-              "STROKE_FLOAT",
-              "EFFECT_FLOAT",
-              "OPACITY",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS", "WIDTH_HEIGHT", "GAP", "STROKE_FLOAT", "EFFECT_FLOAT", "OPACITY", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:67775"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -11544,16 +8975,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56469"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -11564,16 +8990,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2463:56470"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
             "default": "{colors.glyph.onBrand.primary}"
@@ -11584,16 +9005,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56468"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -11606,16 +9022,11 @@
         "width": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56475"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.48}",
             "default": "{units.size.48}"
@@ -11626,16 +9037,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56476"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -11644,16 +9050,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56477"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
             "default": "{units.gap.16}"
@@ -11664,16 +9065,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56478"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -11686,16 +9082,11 @@
         "width": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56471"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.256}",
             "default": "{units.size.256}"
@@ -11706,16 +9097,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56472"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
             "default": "{units.gap.16}"
@@ -11724,16 +9110,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56473"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -11744,16 +9125,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56474"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.48}",
             "default": "{units.size.48}"
@@ -11769,15 +9145,11 @@
           "gap": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP"
-              ],
+              "com.figma.scopes": ["GAP"],
               "com.figma.variableId": "VariableID:2468:145008"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
               "default": "{units.gap.8}"
@@ -11786,15 +9158,11 @@
           "heightMin": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "WIDTH_HEIGHT"
-              ],
+              "com.figma.scopes": ["WIDTH_HEIGHT"],
               "com.figma.variableId": "VariableID:2468:145005"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.40}",
               "default": "{units.size.40}"
@@ -11803,15 +9171,11 @@
           "paddingX": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP"
-              ],
+              "com.figma.scopes": ["GAP"],
               "com.figma.variableId": "VariableID:2468:145006"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.16}",
               "default": "{units.gap.16}"
@@ -11820,15 +9184,11 @@
           "paddingY": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP"
-              ],
+              "com.figma.scopes": ["GAP"],
               "com.figma.variableId": "VariableID:2468:145007"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
               "default": "{units.gap.8}"
@@ -11840,16 +9200,11 @@
             "color": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "SHAPE_FILL",
-                  "STROKE_COLOR"
-                ],
+                "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
                 "com.figma.variableId": "VariableID:2468:145012"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
                 "default": "{colors.glyph.onSurface.primary}"
@@ -11859,15 +9214,11 @@
           "marginT": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP"
-              ],
+              "com.figma.scopes": ["GAP"],
               "com.figma.variableId": "VariableID:2468:145011"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.4}",
               "default": "{units.gap.4}"
@@ -11876,15 +9227,11 @@
           "size": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "WIDTH_HEIGHT"
-              ],
+              "com.figma.scopes": ["WIDTH_HEIGHT"],
               "com.figma.variableId": "VariableID:2468:145010"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.16}",
               "default": "{units.size.16}"
@@ -11896,15 +9243,11 @@
             "color": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "TEXT_FILL"
-                ],
+                "com.figma.scopes": ["TEXT_FILL"],
                 "com.figma.variableId": "VariableID:2468:145015"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
                 "default": "{colors.text.onSurface.primary}"
@@ -11918,9 +9261,7 @@
               "com.figma.variableId": "VariableID:2468:145018"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.body.default}",
               "default": "{typography.body.default}"
@@ -11934,15 +9275,11 @@
             "active": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2468:145024"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.active}",
                 "default": "{colors.background.surface.active}"
@@ -11951,15 +9288,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2468:145023"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.active}",
                 "default": "{colors.background.surface.active}"
@@ -11968,15 +9301,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2468:145022"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.active}",
                 "default": "{colors.background.surface.active}"
@@ -11991,15 +9320,11 @@
             "active": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2468:145021"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.hover}",
                 "default": "{colors.background.surface.hover}"
@@ -12008,15 +9333,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2468:145020"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.hover}",
                 "default": "{colors.background.surface.hover}"
@@ -12025,15 +9346,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2468:145019"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.primary}",
                 "default": "{colors.background.surface.secondary}"
@@ -12049,15 +9366,11 @@
           "gap": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP"
-              ],
+              "com.figma.scopes": ["GAP"],
               "com.figma.variableId": "VariableID:2468:145025"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
               "default": "{units.gap.8}"
@@ -12068,16 +9381,11 @@
           "color": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2468:145027"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -12086,15 +9394,11 @@
           "size": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "WIDTH_HEIGHT"
-              ],
+              "com.figma.scopes": ["WIDTH_HEIGHT"],
               "com.figma.variableId": "VariableID:2468:145026"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.16}",
               "default": "{units.size.16}"
@@ -12105,15 +9409,11 @@
           "color": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2468:145028"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -12126,9 +9426,7 @@
               "com.figma.variableId": "VariableID:2468:145029"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.body.default}",
               "default": "{typography.body.default}"
@@ -12142,15 +9440,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:145004"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -12161,15 +9455,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:144997"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.0}"
@@ -12180,15 +9470,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2914:13386"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -12197,15 +9483,11 @@
         "minWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2934:5009"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": 36,
             "default": 36
@@ -12214,15 +9496,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:145000"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
             "default": "{units.gap.16}"
@@ -12231,15 +9509,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:145001"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.2}"
@@ -12250,24 +9524,15 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2914:13387"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
-              "components": [
-                0,
-                0,
-                100
-              ]
+              "components": [0, 0, 100]
             },
             "default": "{colors.glyph.onSurface.primary}"
           }
@@ -12277,15 +9542,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2468:145002"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -12298,9 +9559,7 @@
             "com.figma.variableId": "VariableID:2468:145003"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
             "default": "{typography.body.strong}"
@@ -12313,15 +9572,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2468:144976"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
             "default": "{colors.border.onSurface.border}"
@@ -12330,16 +9585,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:144977"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -12348,15 +9598,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2468:144975"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
             "default": "{colors.background.surface.secondary}"
@@ -12367,15 +9613,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2468:144978"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
             "default": "{colors.border.onSurface.border}"
@@ -12384,16 +9626,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:144979"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -12404,15 +9641,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2931:3817"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
             "default": "{units.gap.16}"
@@ -12421,15 +9654,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2931:3818"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -12440,15 +9669,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2468:144981"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -12461,9 +9686,7 @@
             "com.figma.variableId": "VariableID:2468:144982"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.headings.title}",
             "default": "{typography.headings.title}"
@@ -12474,16 +9697,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:144980"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -12496,15 +9714,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2468:144991"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -12517,9 +9731,7 @@
             "com.figma.variableId": "VariableID:2468:144992"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
             "default": "{typography.body.strong}"
@@ -12530,15 +9742,11 @@
         "width": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2468:144986"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.48}",
             "default": "{units.size.48}"
@@ -12549,15 +9757,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:144990"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -12566,15 +9770,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:144989"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
             "default": "{units.gap.16}"
@@ -12585,15 +9785,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:144987"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -12602,15 +9798,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:144988"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
             "default": "{units.gap.16}"
@@ -12621,16 +9813,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2468:144993"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.neutral}",
             "default": "{colors.glyph.onSurface.neutral}"
@@ -12639,15 +9826,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2468:144994"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -12658,15 +9841,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2468:144995"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -12679,9 +9858,7 @@
             "com.figma.variableId": "VariableID:2468:144996"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
             "default": "{typography.body.strong}"
@@ -12694,15 +9871,11 @@
         "width": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2468:144983"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.256}",
             "default": "{units.size.256}"
@@ -12713,15 +9886,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:144984"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
             "default": "{units.gap.16}"
@@ -12730,15 +9899,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:144985"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -12754,15 +9919,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2511:141823"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.transparent}",
               "default": "{colors.border.transparent}"
@@ -12771,15 +9932,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2511:141824"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -12788,15 +9945,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2511:141822"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.transparent}",
               "default": "{colors.border.transparent}"
@@ -12805,15 +9958,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2511:141821"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.transparent}",
               "default": "{colors.border.transparent}"
@@ -12823,15 +9972,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS"],
             "com.figma.variableId": "VariableID:2511:141816"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.full}",
             "default": "{units.radius.full}"
@@ -12844,9 +9989,7 @@
             "com.figma.variableId": "VariableID:2511:141820"
           },
           "$type": "string",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
             "default": "solid"
@@ -12855,15 +9998,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT"],
             "com.figma.variableId": "VariableID:2511:141819"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -12872,15 +10011,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2511:141815"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -12889,15 +10024,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2511:141817"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.2}",
             "default": "{units.gap.2}"
@@ -12906,15 +10037,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2511:141818"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.2}",
             "default": "{units.gap.2}"
@@ -12923,15 +10050,11 @@
         "width": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2511:141814"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -12942,15 +10065,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2511:141813"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -12961,15 +10080,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2511:141831"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -12982,9 +10097,7 @@
             "com.figma.variableId": "VariableID:2511:141832"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -12995,15 +10108,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS"],
             "com.figma.variableId": "VariableID:2511:141826"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.full}",
             "default": "{units.radius.full}"
@@ -13013,15 +10122,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2511:141829"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.base}",
               "default": "{palette.base}"
@@ -13030,15 +10135,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2511:141830"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onStatus.disabled}",
               "default": "{colors.glyph.onStatus.disabled}"
@@ -13047,15 +10148,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2511:141828"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.base}",
               "default": "{palette.base}"
@@ -13064,15 +10161,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2511:141827"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.base}",
               "default": "{palette.base}"
@@ -13082,15 +10175,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2511:141825"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.12}",
             "default": "{units.size.12}"
@@ -13104,15 +10193,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2347:137058"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.off}",
               "default": "{colors.background.status.off}"
@@ -13121,15 +10206,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2347:137059"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -13138,15 +10219,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2347:137057"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.off}",
               "default": "{colors.background.status.off}"
@@ -13155,15 +10232,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2347:137056"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.off}",
               "default": "{colors.background.status.off}"
@@ -13178,15 +10251,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2347:137082"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.on}",
               "default": "{colors.background.status.on}"
@@ -13195,15 +10264,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2347:137083"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -13212,15 +10277,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2347:137081"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.on}",
               "default": "{colors.background.status.on}"
@@ -13229,15 +10290,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2347:137080"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.on}",
               "default": "{colors.background.status.on}"
@@ -13252,15 +10309,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP"
-          ],
+          "com.figma.scopes": ["GAP"],
           "com.figma.variableId": "VariableID:3427:170"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
           "default": "{units.gap.8}"
@@ -13271,15 +10324,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3427:173"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -13288,15 +10337,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3427:167"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -13306,15 +10351,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3427:168"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -13328,15 +10369,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3427:162"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.active}"
@@ -13345,15 +10382,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3427:161"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
               "default": "{colors.background.surface.hover}"
@@ -13362,15 +10395,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3427:160"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -13380,15 +10409,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3389:2337"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -13398,15 +10423,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3427:166"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
           "default": "{units.gap.8}"
@@ -13416,15 +10437,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3427:159"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -13433,15 +10450,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3427:165"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
             "default": "{typography.body.strong}"
@@ -13453,16 +10466,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3427:183"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -13471,16 +10479,11 @@
           "inactive": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3427:182"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.neutral}",
               "default": "{colors.glyph.onSurface.neutral}"
@@ -13490,15 +10493,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3447:3616"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -13511,15 +10510,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:3389:2338"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
             "default": "{colors.border.onSurface.border}"
@@ -13528,15 +10523,11 @@
         "borderStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3389:2341"
           },
           "$type": "string",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
             "default": "solid"
@@ -13545,15 +10536,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT"],
             "com.figma.variableId": "VariableID:3389:2339"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -13562,15 +10549,11 @@
         "minHeight": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3389:2336"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.40}",
             "default": "{units.size.40}"
@@ -13579,15 +10562,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3502:158"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -13596,15 +10575,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3427:212"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.8}",
             "default": "{units.size.8}"
@@ -13615,15 +10590,11 @@
         "color": {
           "active": {
             "$extensions": {
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3699:293"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.active}"
@@ -13631,15 +10602,11 @@
           },
           "hover": {
             "$extensions": {
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3699:292"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
               "default": "{colors.background.surface.hover}"
@@ -13647,15 +10614,11 @@
           },
           "idle": {
             "$extensions": {
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3699:291"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -13671,15 +10634,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS"],
             "com.figma.variableId": "VariableID:2265:179"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.full}",
             "default": "{units.radius.full}"
@@ -13688,15 +10647,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT"],
             "com.figma.variableId": "VariableID:2265:180"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -13705,15 +10660,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2265:186"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -13722,15 +10673,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2265:185"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -13739,21 +10686,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS",
-              "WIDTH_HEIGHT",
-              "GAP",
-              "STROKE_FLOAT",
-              "EFFECT_FLOAT",
-              "OPACITY",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS", "WIDTH_HEIGHT", "GAP", "STROKE_FLOAT", "EFFECT_FLOAT", "OPACITY", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2313:42563"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -13762,15 +10699,11 @@
         "widthMax": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2265:181"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.256}",
             "default": "{units.size.256}"
@@ -13779,15 +10712,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2265:182"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -13802,9 +10731,7 @@
             "com.figma.variableId": "VariableID:2265:265"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.strong}",
             "default": "{typography.caption.strong}"
@@ -13816,15 +10743,11 @@
           "height": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "WIDTH_HEIGHT"
-              ],
+              "com.figma.scopes": ["WIDTH_HEIGHT"],
               "com.figma.variableId": "VariableID:2265:183"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.24}",
               "default": "{units.size.24}"
@@ -13835,15 +10758,11 @@
           "borderWidth": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_FLOAT"
-              ],
+              "com.figma.scopes": ["STROKE_FLOAT"],
               "com.figma.variableId": "VariableID:2515:164762"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.stroke.1-6}",
               "default": "{units.stroke.1-6}"
@@ -13852,21 +10771,11 @@
           "size": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "CORNER_RADIUS",
-                "WIDTH_HEIGHT",
-                "GAP",
-                "STROKE_FLOAT",
-                "EFFECT_FLOAT",
-                "OPACITY",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["CORNER_RADIUS", "WIDTH_HEIGHT", "GAP", "STROKE_FLOAT", "EFFECT_FLOAT", "OPACITY", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2265:264"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.16}",
               "default": "{units.size.16}"
@@ -13879,15 +10788,11 @@
           "height": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "WIDTH_HEIGHT"
-              ],
+              "com.figma.scopes": ["WIDTH_HEIGHT"],
               "com.figma.variableId": "VariableID:2265:184"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.20}",
               "default": "{units.size.20}"
@@ -13905,9 +10810,7 @@
             "com.figma.variableId": "VariableID:2313:42571"
           },
           "$type": "string",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{gradients.ai.idle}",
             "default": "{gradients.ai.idle}"
@@ -13916,15 +10819,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2265:205"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.ai}",
             "default": "{colors.background.status.ai}"
@@ -13935,16 +10834,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:260"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.ai}",
             "default": "{colors.glyph.onStatus.ai}"
@@ -13955,15 +10849,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2265:206"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.ai}",
             "default": "{colors.text.onStatus.ai}"
@@ -13976,15 +10866,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:197"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onStatus.critical}",
             "default": "{colors.border.onStatus.critical}"
@@ -13993,15 +10879,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2265:196"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.critical}",
             "default": "{colors.background.status.critical}"
@@ -14012,16 +10894,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:254"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.critical}",
             "default": "{colors.glyph.onStatus.critical}"
@@ -14032,15 +10909,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2265:198"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.critical}",
             "default": "{colors.text.onStatus.critical}"
@@ -14053,15 +10926,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:200"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onStatus.danger}",
             "default": "{colors.border.onStatus.danger}"
@@ -14070,15 +10939,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2265:199"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.danger}",
             "default": "{colors.background.status.danger}"
@@ -14089,16 +10954,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:256"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.danger}",
             "default": "{colors.glyph.onStatus.danger}"
@@ -14109,15 +10969,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2265:201"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.danger}",
             "default": "{colors.text.onStatus.danger}"
@@ -14130,15 +10986,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:188"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onStatus.info}",
             "default": "{colors.border.onStatus.info}"
@@ -14147,15 +10999,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2265:187"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.info}",
             "default": "{colors.background.status.info}"
@@ -14166,16 +11014,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:249"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.info}",
             "default": "{colors.glyph.onStatus.info}"
@@ -14186,15 +11029,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2265:189"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.info}",
             "default": "{colors.text.onStatus.info}"
@@ -14207,15 +11046,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:203"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onStatus.neutral}",
             "default": "{colors.border.onStatus.neutral}"
@@ -14224,15 +11059,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2265:202"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.neutral}",
             "default": "{colors.background.status.neutral}"
@@ -14243,16 +11074,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:258"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.neutral}",
             "default": "{colors.glyph.onStatus.neutral}"
@@ -14263,15 +11089,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2265:204"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.neutral}",
             "default": "{colors.text.onStatus.neutral}"
@@ -14284,15 +11106,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:191"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onStatus.success}",
             "default": "{colors.border.onStatus.success}"
@@ -14301,15 +11119,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2265:190"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.success}",
             "default": "{colors.background.status.success}"
@@ -14320,16 +11134,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:250"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.success}",
             "default": "{colors.glyph.onStatus.success}"
@@ -14340,15 +11149,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2265:192"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.success}",
             "default": "{colors.text.onStatus.success}"
@@ -14361,15 +11166,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:194"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onStatus.warning}",
             "default": "{colors.border.onStatus.warning}"
@@ -14378,15 +11179,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2265:193"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.warning}",
             "default": "{colors.background.status.warning}"
@@ -14397,16 +11194,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:252"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.warning}",
             "default": "{colors.glyph.onStatus.warning}"
@@ -14417,15 +11209,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2265:195"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.warning}",
             "default": "{colors.text.onStatus.warning}"
@@ -14439,15 +11227,11 @@
       "borderRadius": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "CORNER_RADIUS"
-          ],
+          "com.figma.scopes": ["CORNER_RADIUS"],
           "com.figma.variableId": "VariableID:2235:1610"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.radius.4}",
           "default": "{units.radius.4}"
@@ -14456,15 +11240,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "FRAME_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL"],
           "com.figma.variableId": "VariableID:2235:1607"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.background.inverse.primary}",
           "default": "{colors.background.inverse.primary}"
@@ -14473,15 +11253,11 @@
       "paddingX": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP"
-          ],
+          "com.figma.scopes": ["GAP"],
           "com.figma.variableId": "VariableID:2235:1613"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.12}",
           "default": "{units.gap.12}"
@@ -14490,15 +11266,11 @@
       "paddingY": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP"
-          ],
+          "com.figma.scopes": ["GAP"],
           "com.figma.variableId": "VariableID:2235:1614"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
           "default": "{units.gap.8}"
@@ -14507,15 +11279,11 @@
       "widthMax": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:2235:1612"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.256}",
           "default": "{units.size.256}"
@@ -14524,15 +11292,11 @@
       "widthMin": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:2235:1611"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.48}",
           "default": "{units.size.48}"
@@ -14543,15 +11307,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:2235:1608"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onInverse.primary}",
           "default": "{colors.text.onInverse.primary}"
@@ -14564,9 +11324,7 @@
           "com.figma.variableId": "VariableID:2235:1609"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.caption.strong}",
           "default": "{typography.caption.strong}"

--- a/packages/design-tokens/tiers/primitives.json
+++ b/packages/design-tokens/tiers/primitives.json
@@ -1704,6 +1704,114 @@
         }
       }
     },
+    "red_home_pl": {
+      "ButtonPrimary": {
+        "active": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:5242:10313"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "dark": { "colorSpace": "hsl", "components": [215.24, 79.89, 35.1] },
+            "light": { "colorSpace": "hsl", "components": [220, 5.88, 20] }
+          }
+        },
+        "disabled": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:5242:10314"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "dark": { "colorSpace": "hsl", "components": [220, 5.88, 20] },
+            "light": { "colorSpace": "hsl", "components": [210, 5.26, 85.1] }
+          }
+        },
+        "hover": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:5242:10312"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "dark": { "colorSpace": "hsl", "components": [215.22, 80, 45.1] },
+            "light": { "colorSpace": "hsl", "components": [220, 4.69, 25.1] }
+          }
+        },
+        "idle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:5242:10311"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "dark": {
+              "colorSpace": "hsl",
+              "components": [212.36, 90.16, 64.12]
+            },
+            "light": { "colorSpace": "hsl", "components": [214.29, 4.58, 30] }
+          }
+        }
+      },
+      "SidebarPrimary": {
+        "active": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:4031:9608"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "dark": {
+              "colorSpace": "hsl",
+              "components": [212.36, 90.16, 64.12]
+            },
+            "light": { "colorSpace": "hsl", "components": [0, 100, 88.04] }
+          }
+        },
+        "disabled": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:5242:10306"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "dark": { "colorSpace": "hsl", "components": [213.33, 5.03, 35.1] },
+            "light": { "colorSpace": "hsl", "components": [0, 100, 96.08] }
+          }
+        },
+        "hover": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:5242:10305"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "dark": { "colorSpace": "hsl", "components": [220, 4.69, 25.1] },
+            "light": { "colorSpace": "hsl", "components": [0, 100, 53.92] }
+          }
+        },
+        "idle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:4031:9609"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "dark": { "colorSpace": "hsl", "components": [240, 7.69, 5.1] },
+            "light": { "colorSpace": "hsl", "components": [0, 100, 44.12] }
+          }
+        }
+      }
+    },
     "sand": {
       "ButtonPrimary": {
         "active": {
@@ -2874,7 +2982,7 @@
         },
         "platforms": ["PD"],
         "values": {
-          "dark": { "colorSpace": "hsl", "components": [38.82, 100, 50] },
+          "dark": { "colorSpace": "hsl", "components": [212.2, 80.39, 70] },
           "light": { "colorSpace": "hsl", "components": [214.81, 85.62, 30] }
         }
       },
@@ -4935,6 +5043,14 @@
         "$value": { "unit": "px", "value": 72 },
         "platforms": ["PD"]
       },
+      "76": {
+        "$extensions": {
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
+          "com.figma.variableId": "VariableID:6327:19743"
+        },
+        "$value": { "unit": "px", "value": 76 },
+        "platforms": ["PD"]
+      },
       "96": {
         "$extensions": {
           "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
@@ -4965,6 +5081,14 @@
           "com.figma.variableId": "VariableID:1330:10895"
         },
         "$value": { "unit": "px", "value": 256 },
+        "platforms": ["PD"]
+      },
+      "320": {
+        "$extensions": {
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
+          "com.figma.variableId": "VariableID:6364:18086"
+        },
+        "$value": { "unit": "px", "value": 320 },
         "platforms": ["PD"]
       },
       "512": {

--- a/packages/design-tokens/tiers/semantics.json
+++ b/packages/design-tokens/tiers/semantics.json
@@ -17,885 +17,710 @@
         "element": {
           "primary": {
             "$extensions": {
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:202:38"
             },
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.transparent.white.inverse-95}",
-              "default": "{palette.transparent.white.inverse-95}"
+              "default": "{palette.transparent.white.inverse-95}",
+              "virtuozzo": "{palette.transparent.white.inverse-95}"
             }
           },
           "secondary": {
             "$extensions": {
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:4370:2956"
             },
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.transparent.blue.inverse-95}",
-              "default": "{palette.transparent.blue.inverse-95}"
+              "default": "{palette.transparent.blue.inverse-95}",
+              "virtuozzo": "{palette.transparent.blue.inverse-95}"
             }
           }
         },
         "screen": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1433"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.dark.fixed-90}",
-            "default": "{palette.transparent.dark.fixed-90}"
+            "default": "{palette.transparent.dark.fixed-90}",
+            "virtuozzo": "{palette.transparent.dark.fixed-90}"
           }
         }
       },
       "brand": {
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1428"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.SidebarPrimary.idle}",
-            "default": "{palette.blue.13}"
+            "default": "{palette.blue.13}",
+            "virtuozzo": "{branding.virtuozzo.SidebarPrimary.idle}"
           }
         },
         "primary-active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:143:3"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.SidebarPrimary.active}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{branding.virtuozzo.SidebarPrimary.active}"
           }
         },
         "primary-disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:383:39"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.SidebarPrimary.disabled}",
-            "default": "{palette.blue.5}"
+            "default": "{palette.blue.5}",
+            "virtuozzo": "{branding.virtuozzo.SidebarPrimary.disabled}"
           }
         },
         "primary-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:143:2"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.SidebarPrimary.hover}",
-            "default": "{palette.blue.12}"
+            "default": "{palette.blue.12}",
+            "virtuozzo": "{branding.virtuozzo.SidebarPrimary.hover}"
           }
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1429"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.ButtonPrimary.idle}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{branding.virtuozzo.ButtonPrimary.idle}"
           }
         },
         "secondary-active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:265:59"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.ButtonPrimary.active}",
-            "default": "{palette.blue.9}"
+            "default": "{palette.blue.9}",
+            "virtuozzo": "{branding.virtuozzo.ButtonPrimary.active}"
           }
         },
         "secondary-disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:227:24"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.ButtonPrimary.disabled}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{branding.virtuozzo.ButtonPrimary.disabled}"
           }
         },
         "secondary-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:265:58"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.ButtonPrimary.hover}",
-            "default": "{palette.blue.8}"
+            "default": "{palette.blue.8}",
+            "virtuozzo": "{branding.virtuozzo.ButtonPrimary.hover}"
           }
         }
       },
       "inverse": {
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:3665:6953"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.dark.inverse-100}",
-            "default": "{palette.transparent.dark.inverse-100}"
+            "default": "{palette.transparent.dark.inverse-100}",
+            "virtuozzo": "{palette.transparent.dark.inverse-100}"
           }
         }
       },
       "status": {
         "ai": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2277:406"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.1}",
-            "default": "{palette.violet.1}"
+            "default": "{palette.violet.1}",
+            "virtuozzo": "{palette.violet.1}"
           }
         },
         "ai-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2277:407"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.2}",
-            "default": "{palette.violet.2}"
+            "default": "{palette.violet.2}",
+            "virtuozzo": "{palette.violet.2}"
           }
         },
         "ai-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2277:408"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.3}",
-            "default": "{palette.violet.3}"
+            "default": "{palette.violet.3}",
+            "virtuozzo": "{palette.violet.3}"
           }
         },
         "critical": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:14"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.1}",
-            "default": "{palette.orange.1}"
+            "default": "{palette.orange.1}",
+            "virtuozzo": "{palette.orange.1}"
           }
         },
         "critical-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:15"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.2}",
-            "default": "{palette.orange.2}"
+            "default": "{palette.orange.2}",
+            "virtuozzo": "{palette.orange.2}"
           }
         },
         "critical-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:16"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.3}",
-            "default": "{palette.orange.3}"
+            "default": "{palette.orange.3}",
+            "virtuozzo": "{palette.orange.3}"
           }
         },
         "danger": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:16"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.1}",
-            "default": "{palette.red.1}"
+            "default": "{palette.red.1}",
+            "virtuozzo": "{palette.red.1}"
           }
         },
         "danger-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:17"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.2}",
-            "default": "{palette.red.2}"
+            "default": "{palette.red.2}",
+            "virtuozzo": "{palette.red.2}"
           }
         },
         "danger-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:18"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.3}",
-            "default": "{palette.red.3}"
+            "default": "{palette.red.3}",
+            "virtuozzo": "{palette.red.3}"
           }
         },
         "info": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:8"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.1}",
-            "default": "{palette.electricblue.1}"
+            "default": "{palette.electricblue.1}",
+            "virtuozzo": "{palette.electricblue.1}"
           }
         },
         "info-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:9"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.2}",
-            "default": "{palette.electricblue.2}"
+            "default": "{palette.electricblue.2}",
+            "virtuozzo": "{palette.electricblue.2}"
           }
         },
         "info-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:10"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.3}",
-            "default": "{palette.electricblue.3}"
+            "default": "{palette.electricblue.3}",
+            "virtuozzo": "{palette.electricblue.3}"
           }
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263457"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.base}",
-            "default": "{palette.base}"
+            "default": "{palette.base}",
+            "virtuozzo": "{palette.base}"
           }
         },
         "neutral-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263458"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.1}",
-            "default": "{palette.grayscale.1}"
+            "default": "{palette.grayscale.1}",
+            "virtuozzo": "{palette.grayscale.1}"
           }
         },
         "neutral-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263459"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.2}",
-            "default": "{palette.grayscale.2}"
+            "default": "{palette.grayscale.2}",
+            "virtuozzo": "{palette.grayscale.2}"
           }
         },
         "off": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:1205:160"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.3}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.grayscale.3}"
           }
         },
         "on": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:1205:161"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.6}",
-            "default": "{palette.green.6}"
+            "default": "{palette.green.6}",
+            "virtuozzo": "{palette.green.6}"
           }
         },
         "success": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:10"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.1}",
-            "default": "{palette.green.1}"
+            "default": "{palette.green.1}",
+            "virtuozzo": "{palette.green.1}"
           }
         },
         "success-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:11"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.2}",
-            "default": "{palette.green.2}"
+            "default": "{palette.green.2}",
+            "virtuozzo": "{palette.green.2}"
           }
         },
         "success-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:12"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.3}",
-            "default": "{palette.green.3}"
+            "default": "{palette.green.3}",
+            "virtuozzo": "{palette.green.3}"
           }
         },
         "warning": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:12"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.1}",
-            "default": "{palette.yellow.1}"
+            "default": "{palette.yellow.1}",
+            "virtuozzo": "{palette.yellow.1}"
           }
         },
         "warning-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:13"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.2}",
-            "default": "{palette.yellow.2}"
+            "default": "{palette.yellow.2}",
+            "virtuozzo": "{palette.yellow.2}"
           }
         },
         "warning-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:14"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.3}",
-            "default": "{palette.yellow.3}"
+            "default": "{palette.yellow.3}",
+            "virtuozzo": "{palette.yellow.3}"
           }
         }
       },
       "statusStrong": {
         "critical": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263451"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.7}",
-            "default": "{palette.orange.7}"
+            "default": "{palette.orange.7}",
+            "virtuozzo": "{palette.orange.7}"
           }
         },
         "critical-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263452"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.8}",
-            "default": "{palette.orange.8}"
+            "default": "{palette.orange.8}",
+            "virtuozzo": "{palette.orange.8}"
           }
         },
         "critical-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263453"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.9}",
-            "default": "{palette.orange.9}"
+            "default": "{palette.orange.9}",
+            "virtuozzo": "{palette.orange.9}"
           }
         },
         "danger": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263454"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.7}",
-            "default": "{palette.red.7}"
+            "default": "{palette.red.7}",
+            "virtuozzo": "{palette.red.7}"
           }
         },
         "danger-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263455"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.9}",
-            "default": "{palette.red.9}"
+            "default": "{palette.red.9}",
+            "virtuozzo": "{palette.red.9}"
           }
         },
         "danger-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263456"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.10}",
-            "default": "{palette.red.10}"
+            "default": "{palette.red.10}",
+            "virtuozzo": "{palette.red.10}"
           }
         },
         "info": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263442"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.7}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{palette.blue.7}"
           }
         },
         "info-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263443"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.8}",
-            "default": "{palette.blue.8}"
+            "default": "{palette.blue.8}",
+            "virtuozzo": "{palette.blue.8}"
           }
         },
         "info-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263444"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.9}",
-            "default": "{palette.blue.9}"
+            "default": "{palette.blue.9}",
+            "virtuozzo": "{palette.blue.9}"
           }
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263460"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.7}",
-            "default": "{palette.grayscale.7}"
+            "default": "{palette.grayscale.7}",
+            "virtuozzo": "{palette.grayscale.7}"
           }
         },
         "neutral-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263461"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.8}",
-            "default": "{palette.grayscale.8}"
+            "default": "{palette.grayscale.8}",
+            "virtuozzo": "{palette.grayscale.8}"
           }
         },
         "neutral-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263462"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.9}",
-            "default": "{palette.grayscale.9}"
+            "default": "{palette.grayscale.9}",
+            "virtuozzo": "{palette.grayscale.9}"
           }
         },
         "success": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263445"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.7}",
-            "default": "{palette.green.7}"
+            "default": "{palette.green.7}",
+            "virtuozzo": "{palette.green.7}"
           }
         },
         "success-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263446"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.8}",
-            "default": "{palette.green.8}"
+            "default": "{palette.green.8}",
+            "virtuozzo": "{palette.green.8}"
           }
         },
         "success-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263447"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.9}",
-            "default": "{palette.green.9}"
+            "default": "{palette.green.9}",
+            "virtuozzo": "{palette.green.9}"
           }
         },
         "warning": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263448"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.7}",
-            "default": "{palette.yellow.7}"
+            "default": "{palette.yellow.7}",
+            "virtuozzo": "{palette.yellow.7}"
           }
         },
         "warning-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263449"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.8}",
-            "default": "{palette.yellow.8}"
+            "default": "{palette.yellow.8}",
+            "virtuozzo": "{palette.yellow.8}"
           }
         },
         "warning-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263450"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.9}",
-            "default": "{palette.yellow.9}"
+            "default": "{palette.yellow.9}",
+            "virtuozzo": "{palette.yellow.9}"
           }
         }
       },
       "surface": {
         "active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:141:276"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.2}",
-            "default": "{palette.blue.2}"
+            "default": "{palette.blue.2}",
+            "virtuozzo": "{palette.grayscale.2}"
           }
         },
         "hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:141:275"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.1}",
-            "default": "{palette.blue.1}"
+            "default": "{palette.blue.1}",
+            "virtuozzo": "{palette.grayscale.1}"
           }
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1426"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.base}",
-            "default": "{palette.base}"
+            "default": "{palette.base}",
+            "virtuozzo": "{palette.base}"
           }
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1427"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.0}",
-            "default": "{palette.blue.0}"
+            "default": "{palette.blue.0}",
+            "virtuozzo": "{palette.grayscale.0}"
           }
         }
       },
       "transparent": {
         "$extensions": {
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.variableId": "VariableID:2500:145417"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.transparent.clear}",
-          "default": "{palette.transparent.clear}"
+          "default": "{palette.transparent.clear}",
+          "virtuozzo": "{palette.transparent.clear}"
         }
       }
     },
@@ -903,64 +728,52 @@
       "onBrand": {
         "border": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:52:1377"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-10}",
-            "default": "{palette.transparent.white.fixed-10}"
+            "default": "{palette.transparent.white.fixed-10}",
+            "virtuozzo": "{palette.transparent.white.fixed-10}"
           }
         },
         "border-active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:139:5"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.0}",
-            "default": "{palette.grayscale.0}"
+            "default": "{palette.grayscale.0}",
+            "virtuozzo": "{palette.grayscale.0}"
           }
         },
         "divider": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:52:1378"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-10}",
-            "default": "{palette.transparent.white.fixed-10}"
+            "default": "{palette.transparent.white.fixed-10}",
+            "virtuozzo": "{palette.transparent.white.fixed-10}"
           }
         }
       },
       "onStatus": {
         "ai": {
           "$extensions": {
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:4313:50249"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.4}",
-            "default": "{palette.violet.4}"
+            "default": "{palette.violet.4}",
+            "virtuozzo": "{palette.violet.4}"
           }
         },
         "aiStrong": {
@@ -969,332 +782,268 @@
             "com.figma.variableId": "VariableID:2277:437"
           },
           "$type": "gradient",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{gradients.ai.idle}",
-            "default": "{gradients.ai.idle}"
+            "default": "{gradients.ai.idle}",
+            "virtuozzo": "{gradients.ai.idle}"
           }
         },
         "critical": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:41"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.4}",
-            "default": "{palette.orange.4}"
+            "default": "{palette.orange.4}",
+            "virtuozzo": "{palette.orange.4}"
           }
         },
         "criticalStrong": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2005"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.8}",
-            "default": "{palette.orange.8}"
+            "default": "{palette.orange.8}",
+            "virtuozzo": "{palette.orange.8}"
           }
         },
         "danger": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:42"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.4}",
-            "default": "{palette.red.4}"
+            "default": "{palette.red.4}",
+            "virtuozzo": "{palette.red.4}"
           }
         },
         "dangerStrong": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2004"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.8}",
-            "default": "{palette.red.8}"
+            "default": "{palette.red.8}",
+            "virtuozzo": "{palette.red.8}"
           }
         },
         "info": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:38"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
-            "default": "{palette.electricblue.4}"
+            "default": "{palette.electricblue.4}",
+            "virtuozzo": "{palette.electricblue.4}"
           }
         },
         "infoStrong": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2008"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.8}",
-            "default": "{palette.electricblue.8}"
+            "default": "{palette.electricblue.8}",
+            "virtuozzo": "{palette.electricblue.8}"
           }
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:911:263463"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.4}",
-            "default": "{palette.grayscale.4}"
+            "default": "{palette.grayscale.4}",
+            "virtuozzo": "{palette.grayscale.4}"
           }
         },
         "neutralStrong": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:912:268723"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.8}",
-            "default": "{palette.grayscale.8}"
+            "default": "{palette.grayscale.8}",
+            "virtuozzo": "{palette.grayscale.8}"
           }
         },
         "success": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:39"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.4}",
-            "default": "{palette.green.4}"
+            "default": "{palette.green.4}",
+            "virtuozzo": "{palette.green.4}"
           }
         },
         "successStrong": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2007"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.8}",
-            "default": "{palette.green.8}"
+            "default": "{palette.green.8}",
+            "virtuozzo": "{palette.green.8}"
           }
         },
         "warning": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:40"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.4}",
-            "default": "{palette.yellow.4}"
+            "default": "{palette.yellow.4}",
+            "virtuozzo": "{palette.yellow.4}"
           }
         },
         "warningStrong": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2006"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.8}",
-            "default": "{palette.yellow.8}"
+            "default": "{palette.yellow.8}",
+            "virtuozzo": "{palette.yellow.8}"
           }
         }
       },
       "onSurface": {
         "border": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:50:1437"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.3}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.grayscale.3}"
           }
         },
         "border-active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:138:187"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.7}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{palette.grayscale.7}"
           }
         },
         "border-error": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:1234:100"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.7}",
-            "default": "{palette.red.7}"
+            "default": "{palette.red.7}",
+            "virtuozzo": "{palette.red.7}"
           }
         },
         "divider": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:50:1438"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.3}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.grayscale.3}"
           }
         }
       },
       "transparent": {
         "$extensions": {
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2500:145418"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.transparent.clear}",
-          "default": "{palette.transparent.clear}"
+          "default": "{palette.transparent.clear}",
+          "virtuozzo": "{palette.transparent.clear}"
         }
       }
     },
     "focus": {
       "brand": {
         "$extensions": {
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:1838:1394"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.blue.4}",
-          "default": "{palette.blue.4}"
+          "default": "{palette.blue.4}",
+          "virtuozzo": "{palette.blue.4}"
         }
       },
       "error": {
         "$extensions": {
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:1828:1379"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.red.4}",
-          "default": "{palette.red.4}"
+          "default": "{palette.red.4}",
+          "virtuozzo": "{palette.red.4}"
         }
       },
       "primary": {
         "$extensions": {
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:1828:1378"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.blue.4}",
-          "default": "{palette.blue.4}"
+          "default": "{palette.blue.4}",
+          "virtuozzo": "{palette.blue.4}"
         }
       },
       "secondary": {
         "$extensions": {
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:1838:1393"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.blue.4}",
-          "default": "{palette.blue.4}"
+          "default": "{palette.blue.4}",
+          "virtuozzo": "{palette.blue.4}"
         }
       }
     },
@@ -1302,1087 +1051,878 @@
       "onBackdrop": {
         "elementPrimary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:3931:8751"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.7}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{palette.grayscale.7}"
           }
         },
         "screenPrimary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:143:179"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         }
       },
       "onBrand": {
         "disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:179:195"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-10}",
-            "default": "{palette.transparent.white.fixed-10}"
+            "default": "{palette.transparent.white.fixed-10}",
+            "virtuozzo": "{palette.transparent.white.fixed-10}"
           }
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:52:2202"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:179:196"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
-            "default": "{palette.transparent.white.fixed-60}"
+            "default": "{palette.transparent.white.fixed-60}",
+            "virtuozzo": "{palette.transparent.white.fixed-60}"
           }
         }
       },
       "onInverse": {
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:305:125"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         }
       },
       "onStatus": {
         "ai": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:1936:2682"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.11}",
-            "default": "{palette.violet.11}"
+            "default": "{palette.violet.11}",
+            "virtuozzo": "{palette.violet.11}"
           }
         },
         "critical": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1732"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.11}",
-            "default": "{palette.orange.11}"
+            "default": "{palette.orange.11}",
+            "virtuozzo": "{palette.orange.11}"
           }
         },
         "danger": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1731"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.11}",
-            "default": "{palette.red.11}"
+            "default": "{palette.red.11}",
+            "virtuozzo": "{palette.red.11}"
           }
         },
         "disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:151:43"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.3}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.grayscale.3}"
           }
         },
         "info": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1735"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.11}",
-            "default": "{palette.electricblue.11}"
+            "default": "{palette.electricblue.11}",
+            "virtuozzo": "{palette.electricblue.11}"
           }
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:911:263464"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.11}",
-            "default": "{palette.grayscale.11}"
+            "default": "{palette.grayscale.11}",
+            "virtuozzo": "{palette.grayscale.11}"
           }
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:149:7"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.11}",
-            "default": "{palette.electricblue.11}"
+            "default": "{palette.electricblue.11}",
+            "virtuozzo": "{palette.electricblue.11}"
           }
         },
         "success": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1734"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.11}",
-            "default": "{palette.green.11}"
+            "default": "{palette.green.11}",
+            "virtuozzo": "{palette.green.11}"
           }
         },
         "warning": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1733"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.11}",
-            "default": "{palette.yellow.11}"
+            "default": "{palette.yellow.11}",
+            "virtuozzo": "{palette.yellow.11}"
+          }
+        }
+      },
+      "onStatusStrong": {
+        "primary": {
+          "$extensions": {
+            "com.figma.scopes": ["SHAPE_FILL"],
+            "com.figma.variableId": "VariableID:4169:6903"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         }
       },
       "onSurface": {
         "brand": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:2463:54749"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.13}",
-            "default": "{palette.blue.13}"
+            "default": "{palette.blue.13}",
+            "virtuozzo": "{palette.blue.13}"
           }
         },
         "destructive": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:143:8"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.7}",
-            "default": "{palette.red.7}"
+            "default": "{palette.red.7}",
+            "virtuozzo": "{palette.red.7}"
           }
         },
         "disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:56:1581"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.5}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.grayscale.5}"
           }
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:1024:122"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.4}",
-            "default": "{palette.grayscale.4}"
+            "default": "{palette.grayscale.4}",
+            "virtuozzo": "{palette.grayscale.4}"
+          }
+        },
+        "neutral-dark": {
+          "$extensions": {
+            "com.figma.scopes": ["SHAPE_FILL"],
+            "com.figma.variableId": "VariableID:6540:20828"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.10}",
+            "default": "{palette.grayscale.10}",
+            "virtuozzo": "{palette.grayscale.10}"
           }
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:50:1436"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.10}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{palette.grayscale.10}"
           }
         }
       }
     },
     "text": {
       "onBackdrop": {
-        "elementPrimary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:3931:7751"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.transparent.dark.inverse-100}",
-            "default": "{palette.transparent.dark.inverse-100}"
-          }
-        },
-        "screenPrimary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:3931:7747"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
-          }
-        },
-        "screenSecondary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:3931:7754"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
-            "default": "{palette.transparent.white.fixed-60}"
-          }
-        },
         "elementLink-active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3939:3396"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
-            "default": "{palette.electricblue.4}"
+            "default": "{palette.electricblue.4}",
+            "virtuozzo": "{palette.electricblue.4}"
           }
         },
         "elementLink-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3939:3395"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
-            "default": "{palette.electricblue.4}"
+            "default": "{palette.electricblue.4}",
+            "virtuozzo": "{palette.electricblue.4}"
           }
         },
         "elementLink-idle": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3939:3394"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.7}",
-            "default": "{palette.electricblue.7}"
+            "default": "{palette.electricblue.7}",
+            "virtuozzo": "{palette.electricblue.7}"
+          }
+        },
+        "elementPrimary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:3931:7751"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.transparent.dark.inverse-100}",
+            "default": "{palette.transparent.dark.inverse-100}",
+            "virtuozzo": "{palette.transparent.dark.inverse-100}"
           }
         },
         "screenLink-active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:8760"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
-            "default": "{palette.electricblue.4}"
+            "default": "{palette.electricblue.4}",
+            "virtuozzo": "{palette.electricblue.4}"
           }
         },
         "screenLink-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:8759"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
-            "default": "{palette.electricblue.4}"
+            "default": "{palette.electricblue.4}",
+            "virtuozzo": "{palette.electricblue.4}"
           }
         },
         "screenLink-idle": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:8758"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
-            "default": "{palette.electricblue.4}"
+            "default": "{palette.electricblue.4}",
+            "virtuozzo": "{palette.electricblue.4}"
+          }
+        },
+        "screenPrimary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:3931:7747"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
+          }
+        },
+        "screenSecondary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:3931:7754"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
+            "default": "{palette.transparent.white.fixed-60}",
+            "virtuozzo": "{palette.transparent.white.fixed-60}"
           }
         }
       },
       "onBrand": {
         "disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:52:1358"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-30}",
-            "default": "{palette.transparent.white.fixed-30}"
-          }
-        },
-        "link": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:139:169"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.blue.7}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.transparent.white.fixed-30}",
+            "virtuozzo": "{palette.transparent.white.fixed-30}"
           }
         },
         "link-disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:172"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-30}",
-            "default": "{palette.transparent.white.fixed-30}"
+            "default": "{palette.transparent.white.fixed-30}",
+            "virtuozzo": "{palette.transparent.white.fixed-30}"
           }
         },
         "link-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:170"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.5}",
-            "default": "{palette.blue.5}"
+            "default": "{palette.blue.5}",
+            "virtuozzo": "{palette.blue.5}"
+          }
+        },
+        "link-idle": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:169"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.blue.7}",
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{palette.blue.7}"
           }
         },
         "link-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:171"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.3}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.blue.3}"
           }
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:52:1353"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:52:1354"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
-            "default": "{palette.transparent.white.fixed-60}"
-          }
-        }
-      },
-      "onStatus": {
-        "ai": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:912:266569"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.violet.11}",
-            "default": "{palette.violet.11}"
-          }
-        },
-        "critical": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:201:20"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.orange.11}",
-            "default": "{palette.orange.11}"
-          }
-        },
-        "danger": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:201:19"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.red.11}",
-            "default": "{palette.red.11}"
-          }
-        },
-        "info": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:201:17"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.electricblue.11}",
-            "default": "{palette.electricblue.11}"
-          }
-        },
-        "link": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:149:4"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.electricblue.11}",
-            "default": "{palette.electricblue.11}"
-          }
-        },
-        "link-disabled": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:149:8"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.electricblue.5}",
-            "default": "{palette.electricblue.5}"
-          }
-        },
-        "link-hover": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:149:5"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.electricblue.13}",
-            "default": "{palette.electricblue.13}"
-          }
-        },
-        "link-pressed": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:149:6"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.electricblue.14}",
-            "default": "{palette.electricblue.14}"
-          }
-        },
-        "neutral": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:911:263465"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.grayscale.11}",
-            "default": "{palette.grayscale.11}"
-          }
-        },
-        "primary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:149:2"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.grayscale.14}",
-            "default": "{palette.grayscale.14}"
-          }
-        },
-        "secondary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:149:3"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.grayscale.11}",
-            "default": "{palette.grayscale.11}"
-          }
-        },
-        "success": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:201:21"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.green.11}",
-            "default": "{palette.green.11}"
-          }
-        },
-        "warning": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:201:18"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.yellow.11}",
-            "default": "{palette.yellow.11}"
-          }
-        }
-      },
-      "onSurface": {
-        "destructive": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:139:150"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.red.7}",
-            "default": "{palette.red.7}"
-          }
-        },
-        "disabled": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:52:1357"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": {
-              "colorSpace": "hsl",
-              "components": [
-                205.71,
-                14.58,
-                18.82
-              ]
-            },
-            "default": "{palette.grayscale.5}"
-          }
-        },
-        "link": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:139:155"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": {
-              "colorSpace": "hsl",
-              "components": [
-                208.8,
-                15.53,
-                31.57
-              ]
-            },
-            "default": "{palette.blue.7}"
-          }
-        },
-        "link-disabled": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:139:160"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.grayscale.3}",
-            "default": "{palette.blue.3}"
-          }
-        },
-        "link-hover": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:139:156"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.grayscale.11}",
-            "default": "{palette.blue.8}"
-          }
-        },
-        "link-pressed": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:139:159"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.grayscale.12}",
-            "default": "{palette.blue.11}"
-          }
-        },
-        "primary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:50:1425"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": {
-              "colorSpace": "hsl",
-              "components": [
-                208.8,
-                15.53,
-                31.57
-              ]
-            },
-            "default": "{palette.grayscale.14}"
-          }
-        },
-        "secondary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:50:1434"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": {
-              "colorSpace": "hsl",
-              "components": [
-                207,
-                15.63,
-                25.1
-              ]
-            },
-            "default": "{palette.grayscale.7}"
+            "default": "{palette.transparent.white.fixed-60}",
+            "virtuozzo": "{palette.transparent.white.fixed-60}"
           }
         }
       },
       "onInverse": {
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:305:127"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "deep_sky_itkontoret": "{palette.transparent.white.inverse-100}",
+            "default": "{palette.transparent.white.inverse-100}",
+            "virtuozzo": "{palette.transparent.white.inverse-100}"
           }
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:4363:6331"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
-            "default": "{palette.transparent.white.fixed-60}"
+            "default": "{palette.transparent.white.fixed-60}",
+            "virtuozzo": "{palette.transparent.white.fixed-60}"
+          }
+        }
+      },
+      "onStatus": {
+        "ai": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:912:266569"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.violet.11}",
+            "default": "{palette.violet.11}",
+            "virtuozzo": "{palette.violet.11}"
+          }
+        },
+        "critical": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:201:20"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.orange.11}",
+            "default": "{palette.orange.11}",
+            "virtuozzo": "{palette.orange.11}"
+          }
+        },
+        "danger": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:201:19"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.red.11}",
+            "default": "{palette.red.11}",
+            "virtuozzo": "{palette.red.11}"
+          }
+        },
+        "info": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:201:17"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.electricblue.11}",
+            "default": "{palette.electricblue.11}",
+            "virtuozzo": "{palette.electricblue.11}"
+          }
+        },
+        "link-disabled": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:149:8"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.electricblue.5}",
+            "default": "{palette.electricblue.5}",
+            "virtuozzo": "{palette.electricblue.5}"
+          }
+        },
+        "link-hover": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:149:5"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.electricblue.13}",
+            "default": "{palette.electricblue.13}",
+            "virtuozzo": "{palette.electricblue.13}"
+          }
+        },
+        "link-idle": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:149:4"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.electricblue.11}",
+            "default": "{palette.electricblue.11}",
+            "virtuozzo": "{palette.electricblue.11}"
+          }
+        },
+        "link-pressed": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:149:6"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.electricblue.14}",
+            "default": "{palette.electricblue.14}",
+            "virtuozzo": "{palette.electricblue.14}"
+          }
+        },
+        "neutral": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:911:263465"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.11}",
+            "default": "{palette.grayscale.11}",
+            "virtuozzo": "{palette.grayscale.11}"
+          }
+        },
+        "primary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:149:2"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.14}",
+            "default": "{palette.grayscale.14}",
+            "virtuozzo": "{palette.grayscale.14}"
+          }
+        },
+        "secondary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:149:3"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.11}",
+            "default": "{palette.grayscale.11}",
+            "virtuozzo": "{palette.grayscale.11}"
+          }
+        },
+        "success": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:201:21"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.green.11}",
+            "default": "{palette.green.11}",
+            "virtuozzo": "{palette.green.11}"
+          }
+        },
+        "warning": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:201:18"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.yellow.11}",
+            "default": "{palette.yellow.11}",
+            "virtuozzo": "{palette.yellow.11}"
           }
         }
       },
       "onStatusStrong": {
         "ai": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12115"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "critical": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12112"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "danger": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12113"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "info": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12109"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "link": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12116"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.11}",
-            "default": "{palette.electricblue.11}"
+            "default": "{palette.electricblue.11}",
+            "virtuozzo": "{palette.electricblue.11}"
           }
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12114"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12107"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.0}",
-            "default": "{palette.grayscale.0}"
+            "default": "{palette.grayscale.0}",
+            "virtuozzo": "{palette.grayscale.0}"
           }
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12108"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.2}",
-            "default": "{palette.grayscale.2}"
+            "default": "{palette.grayscale.2}",
+            "virtuozzo": "{palette.grayscale.2}"
           }
         },
         "success": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12110"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "warning": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12111"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
+          }
+        }
+      },
+      "onSurface": {
+        "destructive": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:150"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.red.7}",
+            "default": "{palette.red.7}",
+            "virtuozzo": "{palette.red.7}"
+          }
+        },
+        "disabled": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:52:1357"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.5}",
+            "default": "{palette.grayscale.5}",
+            "virtuozzo": "{palette.grayscale.5}"
+          }
+        },
+        "link-disabled": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:160"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.3}",
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.grayscale.3}"
+          }
+        },
+        "link-hover": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:156"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.11}",
+            "default": "{palette.blue.8}",
+            "virtuozzo": "{palette.grayscale.11}"
+          }
+        },
+        "link-idle": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:155"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.10}",
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{palette.grayscale.10}"
+          }
+        },
+        "link-pressed": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:159"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.12}",
+            "default": "{palette.blue.11}",
+            "virtuozzo": "{palette.grayscale.12}"
+          }
+        },
+        "primary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:50:1425"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.14}",
+            "default": "{palette.grayscale.14}",
+            "virtuozzo": "{palette.grayscale.14}"
+          }
+        },
+        "secondary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:50:1434"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.7}",
+            "default": "{palette.grayscale.7}",
+            "virtuozzo": "{palette.grayscale.7}"
           }
         }
       }
@@ -2397,30 +1937,20 @@
           "com.figma.scopes": [],
           "com.figma.variableId": "VariableID:2277:28"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": [
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  234.11,
-                  56.57,
-                  38.82
-                ]
+                "components": [234.11, 56.57, 38.82]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.09,
-                  69.78,
-                  27.25
-                ]
+                "components": [303.09, 69.78, 27.25]
               },
               "position": 1
             }
@@ -2429,22 +1959,30 @@
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  234.11,
-                  56.57,
-                  38.82
-                ]
+                "components": [234.11, 56.57, 38.82]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.09,
-                  69.78,
-                  27.25
-                ]
+                "components": [303.09, 69.78, 27.25]
+              },
+              "position": 1
+            }
+          ],
+          "virtuozzo": [
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [234.11, 56.57, 38.82]
+              },
+              "position": 0.2
+            },
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [303.09, 69.78, 27.25]
               },
               "position": 1
             }
@@ -2457,30 +1995,20 @@
           "com.figma.scopes": [],
           "com.figma.variableId": "VariableID:2277:29"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": [
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  234.38,
-                  100,
-                  93.73
-                ]
+                "components": [234.38, 100, 93.73]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.24,
-                  100,
-                  92.75
-                ]
+                "components": [303.24, 100, 92.75]
               },
               "position": 1
             }
@@ -2489,22 +2017,30 @@
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  234.38,
-                  100,
-                  93.73
-                ]
+                "components": [234.38, 100, 93.73]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.24,
-                  100,
-                  92.75
-                ]
+                "components": [303.24, 100, 92.75]
+              },
+              "position": 1
+            }
+          ],
+          "virtuozzo": [
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [234.38, 100, 93.73]
+              },
+              "position": 0.2
+            },
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [303.24, 100, 92.75]
               },
               "position": 1
             }
@@ -2517,30 +2053,20 @@
           "com.figma.scopes": [],
           "com.figma.variableId": "VariableID:2277:27"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": [
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  233.75,
-                  58.54,
-                  48.24
-                ]
+                "components": [233.75, 58.54, 48.24]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.22,
-                  69.3,
-                  42.16
-                ]
+                "components": [303.22, 69.3, 42.16]
               },
               "position": 1
             }
@@ -2549,22 +2075,30 @@
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  233.75,
-                  58.54,
-                  48.24
-                ]
+                "components": [233.75, 58.54, 48.24]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.22,
-                  69.3,
-                  42.16
-                ]
+                "components": [303.22, 69.3, 42.16]
+              },
+              "position": 1
+            }
+          ],
+          "virtuozzo": [
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [233.75, 58.54, 48.24]
+              },
+              "position": 0.2
+            },
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [303.22, 69.3, 42.16]
               },
               "position": 1
             }
@@ -2577,30 +2111,20 @@
           "com.figma.scopes": [],
           "com.figma.variableId": "VariableID:2277:21"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": [
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  233.93,
-                  73.04,
-                  54.9
-                ]
+                "components": [233.93, 73.04, 54.9]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.19,
-                  97.18,
-                  58.24
-                ]
+                "components": [303.19, 97.18, 58.24]
               },
               "position": 1
             }
@@ -2609,22 +2133,30 @@
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  233.93,
-                  73.04,
-                  54.9
-                ]
+                "components": [233.93, 73.04, 54.9]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.19,
-                  97.18,
-                  58.24
-                ]
+                "components": [303.19, 97.18, 58.24]
+              },
+              "position": 1
+            }
+          ],
+          "virtuozzo": [
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [233.93, 73.04, 54.9]
+              },
+              "position": 0.2
+            },
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [303.19, 97.18, 58.24]
               },
               "position": 1
             }
@@ -2647,9 +2179,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "default": {
         "$extensions": {
@@ -2662,9 +2192,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "form-label": {
         "$extensions": {
@@ -2677,9 +2205,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "heading": {
         "$extensions": {
@@ -2693,9 +2219,7 @@
           "letterSpacing": "{font.letter-spacing.0-3}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "strong": {
         "$extensions": {
@@ -2708,9 +2232,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       }
     },
     "caption": {
@@ -2725,9 +2247,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "default": {
         "$extensions": {
@@ -2740,9 +2260,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "strong": {
         "$extensions": {
@@ -2755,9 +2273,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       }
     },
     "fineprint": {
@@ -2772,9 +2288,7 @@
           "letterSpacing": "{font.letter-spacing.1}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       }
     },
     "headings": {
@@ -2789,9 +2303,20 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.40}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
+      },
+      "display-numeric": {
+        "$extensions": {
+          "com.figma.styleId": "S:3a1abe681039f062b989ad383b761ae7c964035b,"
+        },
+        "$value": {
+          "fontFamily": "{font.font-family.default}",
+          "fontSize": "{font.font-size.32}",
+          "fontWeight": "{font.font-weight.regular}",
+          "letterSpacing": "{font.letter-spacing.0}",
+          "lineHeight": "{font.line-height.40}"
+        },
+        "platforms": ["PD"]
       },
       "lead": {
         "$extensions": {
@@ -2804,9 +2329,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "title": {
         "$extensions": {
@@ -2819,9 +2342,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.32}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "title-accent": {
         "$extensions": {
@@ -2834,9 +2355,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.32}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       }
     },
     "link": {
@@ -2851,9 +2370,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "default-underline": {
         "$extensions": {
@@ -2867,9 +2384,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "strong": {
         "$extensions": {
@@ -2882,9 +2397,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "strong-underline": {
         "$extensions": {
@@ -2898,9 +2411,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       }
     },
     "note": {
@@ -2915,9 +2426,7 @@
           "letterSpacing": "{font.letter-spacing.1}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "heading": {
         "$extensions": {
@@ -2931,9 +2440,7 @@
           "letterSpacing": "{font.letter-spacing.1}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       }
     }
   }


### PR DESCRIPTION
## Summary

Syncs design tokens with Figma snapshot 2026-07-21. All changes are validated — schema valid, tokens-pd build clean.

### Primitives
- **New:** 8 branding palette tokens for `red_home_pl` product (`ButtonPrimary` and `SidebarPrimary` ramps, light + dark)
- **New:** size units `76px` and `320px`
- **Fix:** `palette.blue.10` dark mode had wrong hue (orange → correct blue)

### Semantics
- **New mode:** 159 virtuozzo mode values filled in across all semantic color, glyph, border, focus, and gradient tokens
- **New tokens:** `colors.glyph.onStatusStrong.primary`, `colors.glyph.onSurface.neutral-dark`, `typography.headings.display-numeric`
- **Rename:** `colors.text.onBrand/onStatus/onSurface.link` → `*.link-idle` (removes the ambiguous bare `link` alias)

### Components
- Updated Button, ButtonMenu, CardFilter, Chip, and Link component tokens to reference `*.link-idle` following the semantic rename above

## Pipeline fixes (in `acronis-tokens-updater`)
- `PaletteMapper` fallback no longer lowercases unknown Figma group names — preserves TitleCase branding names (`ButtonPrimary`, `SidebarPrimary`)
- Removed sanitize rule that was converting `units.radius.full` 999px → 50%; value now matches Figma exactly