### PR TITLE
chore(release): version packages

### DIFF
--- a/packages/ui-react/CHANGELOG.md
+++ b/packages/ui-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @acronis-platform/ui-react
 
+## 0.57.1
+
+### Patch Changes
+
+- Republish — `0.57.0` was published to npm without its `dist/` build output. No functional changes.
+
 ## 0.57.0
 
 ### Minor Changes

--- a/packages/ui-react/package.json
+++ b/packages/ui-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acronis-platform/ui-react",
-  "version": "0.57.0",
+  "version": "0.57.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/acronis/uikit.git",


### PR DESCRIPTION
### Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

### Description

`@acronis-platform/ui-react@0.57.0` was published to npm without its `dist/` build output (3 files, 8.2 kB — just `package.json`/`README.md`/`LICENSE`, no compiled JS/CSS/types). 

Since npm versions are immutable (unpublish-and-republish-same-version would break integrity hashes for anyone who already resolved `0.57.0`), the fix is a clean republish under a new patch version — `0.57.1`, no functional changes.

This is a hand-applied version bump (no changeset), consistent with how `0.56.0`→`0.56.1` was fixed previously. Scope confirmed via npm registry inspection: `design-tokens@2.2.0` and `tokens-pd@2.2.0` (published by the same broken run) are unaffected — their artifacts are either committed to git or a no-op build, so `ui-react` is the only package this hit.

### Checklist

- [x] I have performed a **self-review** of my code;
- [x] My code follows the style **guidelines** of this project;
- [x] My changes generate no new **warnings**.