### PR TITLE
ci(release): stop auto-publishing to npm on push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,15 +71,13 @@ jobs:
       - name: Validate design packages
         run: pnpm --filter "./packages/design-*" test
 
-      - name: Create release PR or publish to npm
+      - name: Create release PR
         id: changesets
         uses: changesets/action@v1
         with:
           version: pnpm run version
-          publish: pnpm run release
           commit: 'chore(release): version packages'
           title: 'chore(release): version packages'
-          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.ACV_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
### Description

Publishing now succeeds, so every push to main after a "Version Packages" PR merge was auto-publishing to npm — racing with and undermining manual runs of "xxxxxx". This drops the `publish` step from `release.yml`: it now only opens/updates the version PR, and npm publishing becomes exclusively a manual `workflow_dispatch` action via "xxxxxxxx".

### Type of change

- [ ] Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality like performance)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Refactoring (old API is revised and supported)
- [x] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related issue

N/A

### 📸 Screenshots (if appropriate)

N/A — CI/workflow change only.

### Checklist

- [ ] I have linked an **issue** or **discussion**;
- [ ] I have updated the **documentation** accordingly;
- [ ] I have added or updated **tests** to cover my changes;
- [x] I have performed a **self-review** of my code;
- [x] My code follows the style **guidelines** of this project;
- [x] My changes generate no new **warnings**.