### PR TITLE
feat(design-tokens): sync with Figma

### DIFF
--- a/.changeset/design-tokens-figma-sync.md
+++ b/.changeset/design-tokens-figma-sync.md
@@ -1,0 +1,8 @@
+---
+'@acronis-platform/design-tokens': minor
+'@acronis-platform/tokens-pd': minor
+---
+
+Sync design tokens with Figma.
+
+Adds 10 primitive tokens and 211 new component tokens; removes deprecated Link, Table, Resizable and clearIcon component tokens plus the `colors.text.on*.link` semantic tokens. Populates the `virtuozzo` brand mode across component tokens and updates `default`/`deep_sky_itkontoret` mode values, alongside refreshed semantic color mode values.

--- a/packages/design-tokens/tiers/components.json
+++ b/packages/design-tokens/tiers/components.json
@@ -740,8 +740,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onBrand.disabled}",
-              "default": "{colors.text.onBrand.disabled}",
+              "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
+              "default": "{colors.text.onBrand.primary}",
               "virtuozzo": "{colors.text.onBrand.primary}"
             }
           },
@@ -876,7 +876,7 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.glyph.onInverse.primary}",
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}",
               "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
@@ -890,8 +890,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.glyph.onInverse.primary}",
-              "default": "{colors.glyph.onBrand.disabled}",
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+              "default": "{colors.glyph.onBrand.primary}",
               "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           },
@@ -904,7 +904,7 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.glyph.onInverse.primary}",
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}",
               "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
@@ -918,7 +918,7 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.glyph.onInverse.primary}",
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}",
               "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
@@ -936,7 +936,7 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onInverse.primary}",
+              "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
               "default": "{colors.text.onBrand.primary}",
               "virtuozzo": "{colors.text.onBrand.primary}"
             }
@@ -950,8 +950,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onBrand.disabled}",
-              "default": "{colors.text.onBrand.disabled}",
+              "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
+              "default": "{colors.text.onBrand.primary}",
               "virtuozzo": "{colors.text.onBrand.primary}"
             }
           },
@@ -964,7 +964,7 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onInverse.primary}",
+              "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
               "default": "{colors.text.onBrand.primary}",
               "virtuozzo": "{colors.text.onBrand.primary}"
             }
@@ -978,7 +978,7 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onInverse.primary}",
+              "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
               "default": "{colors.text.onBrand.primary}",
               "virtuozzo": "{colors.text.onBrand.primary}"
             }
@@ -1116,8 +1116,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-              "default": "{colors.text.onSurface.link}",
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+              "default": "{colors.text.onSurface.link-idle}",
               "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           }
@@ -1354,8 +1354,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.glyph.onBrand.disabled}",
-              "default": "{colors.glyph.onBrand.disabled}",
+              "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
+              "default": "{colors.glyph.onBrand.primary}",
               "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           },
@@ -1414,8 +1414,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onBrand.disabled}",
-              "default": "{colors.text.onBrand.disabled}",
+              "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
+              "default": "{colors.text.onBrand.primary}",
               "virtuozzo": "{colors.text.onBrand.primary}"
             }
           },
@@ -1462,8 +1462,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "transparent",
-              "default": "transparent",
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}",
               "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
@@ -1476,8 +1476,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}",
+              "deep_sky_itkontoret": "{palette.grayscale.3}",
+              "default": "{palette.electricblue.3}",
               "virtuozzo": "{palette.grayscale.3}"
             }
           },
@@ -1490,8 +1490,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "transparent",
-              "default": "transparent",
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}",
               "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
@@ -1504,8 +1504,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}",
+              "deep_sky_itkontoret": "{palette.grayscale.3}",
+              "default": "{palette.electricblue.3}",
               "virtuozzo": "{palette.grayscale.3}"
             }
           }
@@ -1696,8 +1696,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
-              "default": "{colors.text.onSurface.link}",
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+              "default": "{colors.text.onSurface.link-idle}",
               "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           },
@@ -1724,8 +1724,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
-              "default": "{colors.text.onSurface.link}",
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+              "default": "{colors.text.onSurface.link-idle}",
               "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           },
@@ -1738,8 +1738,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-              "default": "{colors.text.onSurface.link}",
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+              "default": "{colors.text.onSurface.link-idle}",
               "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           }
@@ -2143,8 +2143,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{units.size.24}",
-            "default": "{units.size.24}",
+            "deep_sky_itkontoret": "{units.size.16}",
+            "default": "{units.size.16}",
             "virtuozzo": "{units.size.16}"
           }
         }
@@ -2162,8 +2162,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.border.transparent}",
-              "default": "{colors.border.transparent}",
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}",
               "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
@@ -2176,8 +2176,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}",
+              "deep_sky_itkontoret": "{palette.grayscale.3}",
+              "default": "{palette.electricblue.3}",
               "virtuozzo": "{palette.grayscale.3}"
             }
           },
@@ -2190,8 +2190,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.border.transparent}",
-              "default": "{colors.border.transparent}",
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}",
               "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
@@ -2204,8 +2204,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}",
+              "deep_sky_itkontoret": "{palette.grayscale.3}",
+              "default": "{palette.electricblue.3}",
               "virtuozzo": "{palette.grayscale.3}"
             }
           }
@@ -2587,7 +2587,7 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+            "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
             "default": "{colors.border.onSurface.border-active}",
             "virtuozzo": "{colors.border.onSurface.border-active}"
           }
@@ -2756,7 +2756,7 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+              "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.active}",
               "virtuozzo": "{colors.background.surface.active}"
             }
@@ -2770,7 +2770,7 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.background.surface.active}",
+              "deep_sky_itkontoret": "{colors.background.surface.hover}",
               "default": "{colors.background.surface.hover}",
               "virtuozzo": "{colors.background.surface.hover}"
             }
@@ -2784,7 +2784,7 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.background.surface.active}",
+              "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}",
               "virtuozzo": "{colors.background.surface.primary}"
             }
@@ -2873,8 +2873,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-            "default": "{colors.text.onSurface.link}",
+            "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+            "default": "{colors.text.onSurface.link-idle}",
             "virtuozzo": "{colors.text.onSurface.link-idle}"
           }
         },
@@ -2887,7 +2887,7 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "String value",
+            "deep_sky_itkontoret": "{typography.body.strong}",
             "default": "{typography.body.strong}",
             "virtuozzo": "{typography.body.strong}"
           }
@@ -2947,8 +2947,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}",
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}",
             "virtuozzo": "{units.gap.8}"
           }
         }
@@ -3196,8 +3196,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "transparent",
-              "default": "transparent",
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}",
               "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
@@ -3210,8 +3210,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}",
+              "deep_sky_itkontoret": "{palette.grayscale.3}",
+              "default": "{palette.electricblue.3}",
               "virtuozzo": "{palette.grayscale.3}"
             }
           },
@@ -3224,8 +3224,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "transparent",
-              "default": "transparent",
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}",
               "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
@@ -3238,8 +3238,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}",
+              "deep_sky_itkontoret": "{palette.grayscale.3}",
+              "default": "{palette.electricblue.3}",
               "virtuozzo": "{palette.grayscale.3}"
             }
           }
@@ -3402,8 +3402,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-              "default": "{colors.text.onSurface.link}",
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+              "default": "{colors.text.onSurface.link-idle}",
               "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           },
@@ -3430,8 +3430,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-              "default": "{colors.text.onSurface.link}",
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+              "default": "{colors.text.onSurface.link-idle}",
               "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           },
@@ -3444,8 +3444,8 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-              "default": "{colors.text.onSurface.link}",
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+              "default": "{colors.text.onSurface.link-idle}",
               "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           }
@@ -3466,7 +3466,7 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-            "default": "{colors.border.onSurface.border}",
+            "default": "{colors.border.onSurface.border-active}",
             "virtuozzo": "{colors.border.onSurface.border-active}"
           }
         },
@@ -3494,7 +3494,7 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-            "default": "{colors.border.onSurface.border}",
+            "default": "{colors.border.onSurface.border-active}",
             "virtuozzo": "{colors.border.onSurface.border-active}"
           }
         },
@@ -3566,7 +3566,7 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.background.surface.primary}",
+              "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.active}",
               "virtuozzo": "{colors.background.surface.active}"
             }
@@ -3580,7 +3580,7 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.background.surface.primary}",
+              "deep_sky_itkontoret": "{colors.background.surface.hover}",
               "default": "{colors.background.surface.hover}",
               "virtuozzo": "{colors.background.surface.hover}"
             }
@@ -3717,8 +3717,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-            "default": "{colors.text.onSurface.link}",
+            "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+            "default": "{colors.text.onSurface.link-idle}",
             "virtuozzo": "{colors.text.onSurface.link-idle}"
           }
         }
@@ -5029,7 +5029,7 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": ["WIDTH_HEIGHT"],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3767:4110"
           },
           "$type": "dimension",
@@ -5053,8 +5053,8 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-            "default": "{colors.text.onSurface.link}",
+            "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+            "default": "{colors.text.onSurface.link-idle}",
             "virtuozzo": "{colors.text.onSurface.link-idle}"
           }
         },
@@ -5067,7 +5067,7 @@
           "$type": "typography",
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{typography.link.strong}",
+            "deep_sky_itkontoret": "{typography.link.default}",
             "default": "{typography.link.strong}",
             "virtuozzo": "{typography.link.default}"
           }
@@ -5093,7 +5093,8 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": ["ALL_SCOPES"]
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:3767:4107"
           },
           "$type": "typography",
           "platforms": ["PD"],
@@ -5124,7 +5125,8 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": ["ALL_SCOPES"]
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:4090:12306"
           },
           "$type": "typography",
           "platforms": ["PD"],
@@ -6495,7 +6497,7 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.headings.display-numeric}",
-          "default": "{typography.headigns.display-numeric}",
+          "default": "{typography.headings.display-numeric}",
           "virtuozzo": "{typography.headings.display-numeric}"
         }
       }
@@ -6539,7 +6541,7 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.headings.display-numeric}",
-          "default": "{typography.headigns.display-numeric}",
+          "default": "{typography.headings.display-numeric}",
           "virtuozzo": "{typography.headings.display-numeric}"
         }
       }
@@ -7659,7 +7661,7 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+            "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
             "default": "{colors.border.onSurface.border-active}",
             "virtuozzo": "{colors.border.onSurface.border-active}"
           }
@@ -8063,8 +8065,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}",
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}",
             "virtuozzo": "{units.gap.8}"
           }
         }
@@ -8229,7 +8231,7 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{units.gap.12}",
+            "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}",
             "virtuozzo": "{units.gap.8}"
           }
@@ -8610,7 +8612,7 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.destructive}",
               "default": "{colors.glyph.onSurface.destructive}",
               "virtuozzo": "{colors.glyph.onSurface.destructive}"
             }
@@ -8624,7 +8626,7 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.destructive}",
               "default": "{colors.glyph.onSurface.destructive}",
               "virtuozzo": "{colors.glyph.onSurface.destructive}"
             }
@@ -8656,7 +8658,7 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.destructive}",
               "default": "{colors.glyph.onSurface.destructive}",
               "virtuozzo": "{colors.glyph.onSurface.destructive}"
             }
@@ -8670,7 +8672,7 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.destructive}",
               "default": "{colors.glyph.onSurface.destructive}",
               "virtuozzo": "{colors.glyph.onSurface.destructive}"
             }
@@ -8810,7 +8812,7 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}",
               "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
@@ -8824,7 +8826,7 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}",
               "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
@@ -9128,7 +9130,7 @@
             "$type": "color",
             "platforms": ["PD"],
             "values": {
-              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}",
               "virtuozzo": "{colors.text.onSurface.disabled}"
             }
@@ -11889,7 +11891,7 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "deep_sky_itkontoret": "{colors.glyph.onBrand.secondary}",
+                "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
                 "default": "{colors.glyph.onBrand.primary}",
                 "virtuozzo": "{colors.glyph.onBrand.primary}"
               }
@@ -12651,7 +12653,7 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "deep_sky_itkontoret": "{colors.background.surface.hover}",
+                "deep_sky_itkontoret": "{colors.background.surface.active}",
                 "default": "{colors.background.surface.hover}",
                 "virtuozzo": "{colors.background.surface.active}"
               }
@@ -12679,7 +12681,7 @@
               "$type": "color",
               "platforms": ["PD"],
               "values": {
-                "deep_sky_itkontoret": "{colors.background.surface.primary}",
+                "deep_sky_itkontoret": "{colors.background.surface.secondary}",
                 "default": "{colors.background.surface.secondary}",
                 "virtuozzo": "{colors.background.surface.secondary}"
               }
@@ -12795,7 +12797,7 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{units.gap.8}",
+            "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}",
             "virtuozzo": "{units.gap.0}"
           }
@@ -12825,8 +12827,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": 36,
-            "default": 36,
+            "deep_sky_itkontoret": "{units.size.40}",
+            "default": "{units.size.40}",
             "virtuozzo": "{units.size.40}"
           }
         },
@@ -12853,7 +12855,7 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{units.gap.8}",
+            "deep_sky_itkontoret": "{units.gap.2}",
             "default": "{units.gap.2}",
             "virtuozzo": "{units.gap.2}"
           }
@@ -12869,10 +12871,7 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": {
-              "colorSpace": "hsl",
-              "components": [0, 0, 100]
-            },
+            "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
             "default": "{colors.glyph.onSurface.primary}",
             "virtuozzo": "{colors.glyph.onSurface.primary}"
           }
@@ -12948,7 +12947,7 @@
           "$type": "color",
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{colors.background.surface.primary}",
+            "deep_sky_itkontoret": "{colors.background.surface.secondary}",
             "default": "{colors.background.surface.secondary}",
             "virtuozzo": "{colors.background.surface.secondary}"
           }
@@ -13008,8 +13007,8 @@
           "$type": "dimension",
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{units.gap.12}",
-            "default": "{units.gap.12}",
+            "deep_sky_itkontoret": "{units.gap.16}",
+            "default": "{units.gap.16}",
             "virtuozzo": "{units.gap.16}"
           }
         }
@@ -14859,8 +14858,8 @@
         "$type": "typography",
         "platforms": ["PD"],
         "values": {
-          "deep_sky_itkontoret": "{typography.caption.strong}",
-          "default": "{typography.caption.strong}",
+          "deep_sky_itkontoret": "{typography.caption.default}",
+          "default": "{typography.caption.default}",
           "virtuozzo": "{typography.caption.default}"
         }
       }

--- a/packages/design-tokens/tiers/components.json
+++ b/packages/design-tokens/tiers/components.json
@@ -1633,6 +1633,202 @@
       }
     }
   },
+  "ButtonGroup": {
+    "_global": {
+      "box": {
+        "color": {
+          "active": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["FRAME_FILL"],
+              "com.figma.variableId": "VariableID:5558:17489"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.surface.active}",
+              "default": "{colors.background.surface.active}",
+              "virtuozzo": "{colors.background.surface.active}"
+            }
+          },
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["FRAME_FILL"],
+              "com.figma.variableId": "VariableID:5558:17488"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+              "default": "{colors.background.surface.hover}",
+              "virtuozzo": "{colors.background.surface.hover}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["FRAME_FILL"],
+              "com.figma.variableId": "VariableID:5558:17487"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "transparent",
+              "default": "transparent",
+              "virtuozzo": "transparent"
+            }
+          }
+        },
+        "height": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
+            "com.figma.variableId": "VariableID:5558:17538"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.32}",
+            "default": "{units.size.32}",
+            "virtuozzo": "{units.size.32}"
+          }
+        },
+        "paddingX": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP"],
+            "com.figma.variableId": "VariableID:5558:17485"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}",
+            "virtuozzo": "{units.gap.12}"
+          }
+        },
+        "paddingY": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP"],
+            "com.figma.variableId": "VariableID:5558:17486"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
+          }
+        }
+      },
+      "container": {
+        "borderColor": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["STROKE_COLOR"],
+            "com.figma.variableId": "VariableID:5558:17484"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+            "default": "{colors.border.onSurface.border}",
+            "virtuozzo": "{colors.border.onSurface.border}"
+          }
+        },
+        "borderRadius": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["CORNER_RADIUS"],
+            "com.figma.variableId": "VariableID:5558:17429"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.radius.4}",
+            "default": "{units.radius.4}",
+            "virtuozzo": "{units.radius.4}"
+          }
+        },
+        "borderWidth": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["STROKE_FLOAT"],
+            "com.figma.variableId": "VariableID:5558:17482"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
+          }
+        }
+      },
+      "separator": {
+        "borderWidth": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["STROKE_FLOAT"],
+            "com.figma.variableId": "VariableID:5558:17491"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
+          }
+        },
+        "color": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["STROKE_COLOR"],
+            "com.figma.variableId": "VariableID:5558:17490"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.border.onSurface.divider}",
+            "default": "{colors.border.onSurface.divider}",
+            "virtuozzo": "{colors.border.onSurface.divider}"
+          }
+        }
+      },
+      "value": {
+        "color": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:5558:17539"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
+          }
+        },
+        "textStyle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:5558:17431"
+          },
+          "$type": "typography",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{typography.body.strong}",
+            "default": "{typography.body.strong}",
+            "virtuozzo": "{typography.body.strong}"
+          }
+        }
+      }
+    }
+  },
   "ButtonIcon": {
     "_global": {
       "container": {
@@ -1727,6 +1923,34 @@
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
+          }
+        },
+        "paddingY": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
+            "com.figma.variableId": "VariableID:5288:5844"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
+          }
+        },
+        "width": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
+            "com.figma.variableId": "VariableID:4566:5555"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.32}",
+            "default": "{units.size.32}",
+            "virtuozzo": "{units.size.32}"
           }
         }
       },
@@ -1885,6 +2109,340 @@
       }
     }
   },
+  "ButtonIconInput": {
+    "_global": {
+      "container": {
+        "borderRadius": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
+            "com.figma.variableId": "VariableID:5304:5425"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.radius.4}",
+            "default": "{units.radius.4}",
+            "virtuozzo": "{units.radius.4}"
+          }
+        },
+        "height": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
+            "com.figma.variableId": "VariableID:5304:5426"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.20}",
+            "default": "{units.size.20}",
+            "virtuozzo": "{units.size.20}"
+          }
+        },
+        "paddingX": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
+            "com.figma.variableId": "VariableID:5304:5428"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.2}",
+            "default": "{units.gap.2}",
+            "virtuozzo": "{units.gap.2}"
+          }
+        },
+        "paddingY": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
+            "com.figma.variableId": "VariableID:5304:5429"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.2}",
+            "default": "{units.gap.2}",
+            "virtuozzo": "{units.gap.2}"
+          }
+        },
+        "width": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
+            "com.figma.variableId": "VariableID:5304:5427"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.20}",
+            "default": "{units.size.20}",
+            "virtuozzo": "{units.size.20}"
+          }
+        }
+      }
+    },
+    "error": {
+      "container": {
+        "color": {
+          "active": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["FRAME_FILL"],
+              "com.figma.variableId": "VariableID:5304:5447"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.status.danger-pressed}",
+              "default": "{colors.background.status.danger-pressed}",
+              "virtuozzo": "{colors.background.status.danger-pressed}"
+            }
+          },
+          "disabled": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["FRAME_FILL"],
+              "com.figma.variableId": "VariableID:5304:5448"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.transparent}",
+              "default": "{colors.background.transparent}",
+              "virtuozzo": "{colors.background.transparent}"
+            }
+          },
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["FRAME_FILL"],
+              "com.figma.variableId": "VariableID:5304:5446"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.status.danger}",
+              "default": "{colors.background.status.danger}",
+              "virtuozzo": "{colors.background.status.danger}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["FRAME_FILL"],
+              "com.figma.variableId": "VariableID:5304:5445"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.transparent}",
+              "default": "{colors.background.transparent}",
+              "virtuozzo": "{colors.background.transparent}"
+            }
+          }
+        }
+      },
+      "icon": {
+        "color": {
+          "active": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:5304:5452"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.destructive}",
+              "default": "{colors.glyph.onSurface.destructive}",
+              "virtuozzo": "{colors.glyph.onSurface.destructive}"
+            }
+          },
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:5304:5451"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.destructive}",
+              "default": "{colors.glyph.onSurface.destructive}",
+              "virtuozzo": "{colors.glyph.onSurface.destructive}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:5304:5450"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.destructive}",
+              "default": "{colors.glyph.onSurface.destructive}",
+              "virtuozzo": "{colors.glyph.onSurface.destructive}"
+            }
+          }
+        },
+        "size": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
+            "com.figma.variableId": "VariableID:5304:5449"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.16}",
+            "default": "{units.size.16}",
+            "virtuozzo": "{units.size.16}"
+          }
+        }
+      }
+    },
+    "normal": {
+      "container": {
+        "color": {
+          "active": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["FRAME_FILL"],
+              "com.figma.variableId": "VariableID:5304:5432"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.surface.active}",
+              "default": "{colors.background.surface.active}",
+              "virtuozzo": "{colors.background.surface.active}"
+            }
+          },
+          "disabled": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["FRAME_FILL"],
+              "com.figma.variableId": "VariableID:5304:5433"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.transparent}",
+              "default": "{colors.background.transparent}",
+              "virtuozzo": "{colors.background.transparent}"
+            }
+          },
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["FRAME_FILL"],
+              "com.figma.variableId": "VariableID:5304:5431"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.surface.hover}",
+              "default": "{colors.background.surface.hover}",
+              "virtuozzo": "{colors.background.surface.hover}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["FRAME_FILL"],
+              "com.figma.variableId": "VariableID:5304:5430"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.transparent}",
+              "default": "{colors.background.transparent}",
+              "virtuozzo": "{colors.background.transparent}"
+            }
+          }
+        }
+      },
+      "icon": {
+        "color": {
+          "active": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:5304:5437"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
+            }
+          },
+          "disabled": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:5304:5438"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
+              "default": "{colors.glyph.onSurface.disabled}",
+              "virtuozzo": "{colors.glyph.onSurface.disabled}"
+            }
+          },
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:5304:5436"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:5304:5435"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
+            }
+          }
+        },
+        "size": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
+            "com.figma.variableId": "VariableID:5304:5434"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.16}",
+            "default": "{units.size.16}",
+            "virtuozzo": "{units.size.16}"
+          }
+        }
+      }
+    }
+  },
   "ButtonMenu": {
     "Dropdown": {
       "container": {
@@ -1977,6 +2535,20 @@
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
+          }
+        },
+        "widthMin": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
+            "com.figma.variableId": "VariableID:5350:919"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.128}",
+            "default": "{units.size.128}",
+            "virtuozzo": "{units.size.128}"
           }
         }
       }
@@ -2978,6 +3550,376 @@
       }
     }
   },
+  "Carousel": {
+    "dialog": {
+      "listIndicator": {
+        "gap": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP"],
+            "com.figma.variableId": "VariableID:6353:4717"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.6}",
+            "default": "{units.gap.6}",
+            "virtuozzo": "{units.gap.6}"
+          }
+        }
+      }
+    }
+  },
+  "Chat": {
+    "_global": {
+      "borderColor": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["STROKE_COLOR"],
+          "com.figma.variableId": "VariableID:6504:33150"
+        },
+        "$type": "color",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{colors.border.onSurface.divider}",
+          "default": "{colors.border.onSurface.divider}",
+          "virtuozzo": "{colors.border.onSurface.divider}"
+        }
+      },
+      "borderStyle": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["ALL_SCOPES"],
+          "com.figma.variableId": "VariableID:6504:33520"
+        },
+        "$type": "string",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "solid",
+          "default": "solid",
+          "virtuozzo": "solid"
+        }
+      },
+      "borderWidth": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["STROKE_FLOAT"],
+          "com.figma.variableId": "VariableID:6504:33151"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.stroke.1}",
+          "default": "{units.stroke.1}",
+          "virtuozzo": "{units.stroke.1}"
+        }
+      }
+    },
+    "container": {
+      "collapsed": {
+        "width": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
+            "com.figma.variableId": "VariableID:6504:33522"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.48}",
+            "default": "{units.size.48}",
+            "virtuozzo": "{units.size.48}"
+          }
+        }
+      },
+      "color": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["FRAME_FILL"],
+          "com.figma.variableId": "VariableID:6504:33149"
+        },
+        "$type": "color",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{colors.background.surface.primary}",
+          "default": "{colors.background.surface.primary}",
+          "virtuozzo": "{colors.background.surface.primary}"
+        }
+      },
+      "expanded": {
+        "maxWidth": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
+            "com.figma.variableId": "VariableID:6504:33523"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.512}",
+            "default": "{units.size.512}",
+            "virtuozzo": "{units.size.512}"
+          }
+        },
+        "minWidth": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
+            "com.figma.variableId": "VariableID:6504:33521"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.320}",
+            "default": "{units.size.320}",
+            "virtuozzo": "{units.size.320}"
+          }
+        }
+      }
+    },
+    "header": {
+      "height": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:6504:33525"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.size.64}",
+          "default": "{units.size.64}",
+          "virtuozzo": "{units.size.64}"
+        }
+      },
+      "paddingX": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:6504:33526"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.gap.16}",
+          "default": "{units.gap.16}",
+          "virtuozzo": "{units.gap.16}"
+        }
+      }
+    },
+    "menuItem": {
+      "collapsed": {
+        "maxWidth": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
+            "com.figma.variableId": "VariableID:6504:34720"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.48}",
+            "default": "{units.size.48}",
+            "virtuozzo": "{units.size.48}"
+          }
+        }
+      },
+      "color": {
+        "active": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:6504:34727"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.background.surface.active}",
+            "default": "{colors.background.surface.active}",
+            "virtuozzo": "{colors.background.surface.active}"
+          }
+        },
+        "hover": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:6504:34726"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.background.surface.hover}",
+            "default": "{colors.background.surface.hover}",
+            "virtuozzo": "{colors.background.surface.hover}"
+          }
+        },
+        "idle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:6504:34725"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "transparent",
+            "default": "transparent",
+            "virtuozzo": "transparent"
+          }
+        }
+      },
+      "expanded": {
+        "gap": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP"],
+            "com.figma.variableId": "VariableID:6504:34715"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
+          }
+        },
+        "minWidth": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
+            "com.figma.variableId": "VariableID:6547:5847"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.224}",
+            "default": "{units.size.224}",
+            "virtuozzo": "{units.size.224}"
+          }
+        }
+      },
+      "height": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:6504:33524"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.size.40}",
+          "default": "{units.size.40}",
+          "virtuozzo": "{units.size.40}"
+        }
+      },
+      "hint": {
+        "color": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:6504:34728"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+            "default": "{colors.text.onSurface.secondary}",
+            "virtuozzo": "{colors.text.onSurface.secondary}"
+          }
+        },
+        "textStyle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:6504:34730"
+          },
+          "$type": "typography",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
+          }
+        }
+      },
+      "icon": {
+        "color": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.variableId": "VariableID:6504:34717"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+            "default": "{colors.glyph.onSurface.primary}",
+            "virtuozzo": "{colors.glyph.onSurface.primary}"
+          }
+        }
+      },
+      "label": {
+        "color": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:6504:34716"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
+          }
+        },
+        "textStyle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:6504:34729"
+          },
+          "$type": "typography",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
+          }
+        }
+      },
+      "paddingX": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:6516:2311"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.gap.16}",
+          "default": "{units.gap.16}",
+          "virtuozzo": "{units.gap.16}"
+        }
+      }
+    },
+    "sidebar": {
+      "width": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["ALL_SCOPES"],
+          "com.figma.variableId": "VariableID:6571:21715"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.size.256}",
+          "default": "{units.size.256}",
+          "virtuozzo": "{units.size.256}"
+        }
+      }
+    }
+  },
   "Checkbox": {
     "_global": {
       "box": {
@@ -3919,6 +4861,390 @@
       }
     }
   },
+  "Dialog": {
+    "body": {
+      "gap": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:4220:3601"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.gap.12}",
+          "default": "{units.gap.12}",
+          "virtuozzo": "{units.gap.12}"
+        }
+      },
+      "heightMin": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:4220:3634"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.size.72}",
+          "default": "{units.size.72}",
+          "virtuozzo": "{units.size.72}"
+        }
+      },
+      "paddingY": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:4220:3600"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.gap.16}",
+          "default": "{units.gap.16}",
+          "virtuozzo": "{units.gap.16}"
+        }
+      }
+    },
+    "container": {
+      "borderRadius": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["CORNER_RADIUS"],
+          "com.figma.variableId": "VariableID:4220:3279"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.radius.8}",
+          "default": "{units.radius.8}",
+          "virtuozzo": "{units.radius.8}"
+        }
+      },
+      "color": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["FRAME_FILL"],
+          "com.figma.variableId": "VariableID:4220:3276"
+        },
+        "$type": "color",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+          "default": "{colors.background.surface.secondary}",
+          "virtuozzo": "{colors.background.surface.secondary}"
+        }
+      },
+      "heightMin": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:4220:3275"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.size.224}",
+          "default": "{units.size.224}",
+          "virtuozzo": "{units.size.224}"
+        }
+      },
+      "size": {
+        "md": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:4220:3617"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.632}",
+            "default": "{units.size.632}",
+            "virtuozzo": "{units.size.632}"
+          }
+        },
+        "sm": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:4220:3272"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.512}",
+            "default": "{units.size.512}",
+            "virtuozzo": "{units.size.512}"
+          }
+        }
+      },
+      "widthMin": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:4220:3278"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.size.256}",
+          "default": "{units.size.256}",
+          "virtuozzo": "{units.size.256}"
+        }
+      }
+    },
+    "header": {
+      "borderColor": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["STROKE_COLOR"],
+          "com.figma.variableId": "VariableID:4220:3291"
+        },
+        "$type": "color",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{colors.border.onSurface.divider}",
+          "default": "{colors.border.onSurface.divider}",
+          "virtuozzo": "{colors.border.onSurface.divider}"
+        }
+      },
+      "borderStyle": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["ALL_SCOPES"],
+          "com.figma.variableId": "VariableID:4220:3292"
+        },
+        "$type": "string",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "solid",
+          "default": "solid",
+          "virtuozzo": "solid"
+        }
+      },
+      "borderWidth": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["STROKE_FLOAT"],
+          "com.figma.variableId": "VariableID:4220:3289"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.stroke.1}",
+          "default": "{units.stroke.1}",
+          "virtuozzo": "{units.stroke.1}"
+        }
+      },
+      "color": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["FRAME_FILL"],
+          "com.figma.variableId": "VariableID:4220:3290"
+        },
+        "$type": "color",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{colors.background.surface.primary}",
+          "default": "{colors.background.surface.primary}",
+          "virtuozzo": "{colors.background.surface.primary}"
+        }
+      },
+      "gap": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:4220:3294"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.gap.16}",
+          "default": "{units.gap.16}",
+          "virtuozzo": "{units.gap.16}"
+        }
+      },
+      "height": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:4220:3288"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.size.64}",
+          "default": "{units.size.64}",
+          "virtuozzo": "{units.size.64}"
+        }
+      },
+      "paddingX": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:4220:3293"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.gap.16}",
+          "default": "{units.gap.16}",
+          "virtuozzo": "{units.gap.16}"
+        }
+      },
+      "title": {
+        "color": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:4220:3295"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
+          }
+        },
+        "textStyle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:4220:3296"
+          },
+          "$type": "typography",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{typography.headings.title}",
+            "default": "{typography.headings.title}",
+            "virtuozzo": "{typography.headings.title}"
+          }
+        }
+      }
+    }
+  },
+  "Footer": {
+    "_global": {
+      "gap": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:6364:18157"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.gap.16}",
+          "default": "{units.gap.16}",
+          "virtuozzo": "{units.gap.16}"
+        }
+      },
+      "height": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:6364:18152"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.size.64}",
+          "default": "{units.size.64}",
+          "virtuozzo": "{units.size.64}"
+        }
+      },
+      "paddingX": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:6364:18153"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.gap.16}",
+          "default": "{units.gap.16}",
+          "virtuozzo": "{units.gap.16}"
+        }
+      }
+    },
+    "carousel": {
+      "color": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["ALL_SCOPES"],
+          "com.figma.variableId": "VariableID:6364:18160"
+        },
+        "$type": "color",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "transparent",
+          "default": "transparent",
+          "virtuozzo": "transparent"
+        }
+      }
+    },
+    "default": {
+      "borderColor": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["STROKE_COLOR"],
+          "com.figma.variableId": "VariableID:6364:18155"
+        },
+        "$type": "color",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{colors.border.onSurface.divider}",
+          "default": "{colors.border.onSurface.divider}",
+          "virtuozzo": "{colors.border.onSurface.divider}"
+        }
+      },
+      "borderStyle": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["ALL_SCOPES"],
+          "com.figma.variableId": "VariableID:6364:18159"
+        },
+        "$type": "string",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "solid",
+          "default": "solid",
+          "virtuozzo": "solid"
+        }
+      },
+      "borderWidth": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["STROKE_FLOAT"],
+          "com.figma.variableId": "VariableID:6364:18156"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.stroke.1}",
+          "default": "{units.stroke.1}",
+          "virtuozzo": "{units.stroke.1}"
+        }
+      },
+      "color": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["ALL_SCOPES"],
+          "com.figma.variableId": "VariableID:6364:18151"
+        },
+        "$type": "color",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{colors.background.surface.primary}",
+          "default": "{colors.background.surface.primary}",
+          "virtuozzo": "{colors.background.surface.primary}"
+        }
+      }
+    }
+  },
   "InputDatePicker": {
     "_global": {
       "box": {
@@ -4095,6 +5421,22 @@
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
+          }
+        }
+      },
+      "iconBox": {
+        "size": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
+            "com.figma.variableId": "VariableID:6327:29567"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.20}",
+            "default": "{units.size.20}",
+            "virtuozzo": "{units.size.20}"
           }
         }
       },
@@ -4607,6 +5949,820 @@
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
             }
+          }
+        }
+      }
+    }
+  },
+  "InputOTP": {
+    "box": {
+      "border": {
+        "color": {
+          "active": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:6327:19736"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
+            }
+          },
+          "error": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:6327:20642"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
+              "default": "{colors.border.onSurface.border-error}",
+              "virtuozzo": "{colors.border.onSurface.border-error}"
+            }
+          },
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:6327:19738"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:6327:19735"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{colors.border.onSurface.border}"
+            }
+          }
+        },
+        "radius": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["CORNER_RADIUS"],
+            "com.figma.variableId": "VariableID:6327:19740"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.radius.4}",
+            "default": "{units.radius.4}",
+            "virtuozzo": "{units.radius.4}"
+          }
+        },
+        "width": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["STROKE_FLOAT"],
+            "com.figma.variableId": "VariableID:6327:19739"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
+          }
+        }
+      },
+      "color": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["FRAME_FILL"],
+          "com.figma.variableId": "VariableID:6327:19734"
+        },
+        "$type": "color",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{colors.background.surface.primary}",
+          "default": "{colors.background.surface.primary}",
+          "virtuozzo": "{colors.background.surface.primary}"
+        }
+      },
+      "height": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:6327:19742"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.size.76}",
+          "default": "{units.size.76}",
+          "virtuozzo": "{units.size.76}"
+        }
+      },
+      "paddingX": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:6327:20636"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.gap.12}",
+          "default": "{units.gap.12}",
+          "virtuozzo": "{units.gap.12}"
+        }
+      },
+      "paddingY": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:6327:20637"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.gap.12}",
+          "default": "{units.gap.12}",
+          "virtuozzo": "{units.gap.12}"
+        }
+      },
+      "width": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:6327:19741"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.size.48}",
+          "default": "{units.size.48}",
+          "virtuozzo": "{units.size.48}"
+        }
+      }
+    },
+    "container": {
+      "justify-content": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["ALL_SCOPES"],
+          "com.figma.variableId": "VariableID:6327:20656"
+        },
+        "$type": "string",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "space-between",
+          "default": "space-between",
+          "virtuozzo": "space-between"
+        }
+      }
+    },
+    "placeholder": {
+      "color": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["TEXT_FILL"],
+          "com.figma.variableId": "VariableID:6327:27416"
+        },
+        "$type": "color",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+          "default": "{colors.text.onSurface.disabled}",
+          "virtuozzo": "{colors.text.onSurface.disabled}"
+        }
+      },
+      "font-variant-numeric": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["ALL_SCOPES"],
+          "com.figma.variableId": "VariableID:6327:27418"
+        },
+        "$type": "string",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "tabular-nums",
+          "default": "tabular-nums",
+          "virtuozzo": "tabular-nums"
+        }
+      },
+      "textStyle": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["ALL_SCOPES"],
+          "com.figma.variableId": "VariableID:6327:27417"
+        },
+        "$type": "typography",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{typography.headings.display-numeric}",
+          "default": "{typography.headigns.display-numeric}",
+          "virtuozzo": "{typography.headings.display-numeric}"
+        }
+      }
+    },
+    "value": {
+      "color": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["TEXT_FILL"],
+          "com.figma.variableId": "VariableID:6327:20638"
+        },
+        "$type": "color",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+          "default": "{colors.text.onSurface.primary}",
+          "virtuozzo": "{colors.text.onSurface.primary}"
+        }
+      },
+      "font-variant-numeric": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["ALL_SCOPES"],
+          "com.figma.variableId": "VariableID:6327:27357"
+        },
+        "$type": "string",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "tabular-nums",
+          "default": "tabular-nums",
+          "virtuozzo": "tabular-nums"
+        }
+      },
+      "textStyle": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["ALL_SCOPES"],
+          "com.figma.variableId": "VariableID:6327:20640"
+        },
+        "$type": "typography",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{typography.headings.display-numeric}",
+          "default": "{typography.headigns.display-numeric}",
+          "virtuozzo": "{typography.headings.display-numeric}"
+        }
+      }
+    }
+  },
+  "InputPassword": {
+    "_global": {
+      "box": {
+        "borderRadius": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
+            "com.figma.variableId": "VariableID:6325:11547"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.radius.4}",
+            "default": "{units.radius.4}",
+            "virtuozzo": "{units.radius.4}"
+          }
+        },
+        "borderWidth": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
+            "com.figma.variableId": "VariableID:6325:11548"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
+          }
+        },
+        "color": {
+          "disabled": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["FRAME_FILL"],
+              "com.figma.variableId": "VariableID:6325:11551"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.surface.secondary}",
+              "default": "{colors.background.surface.secondary}",
+              "virtuozzo": "{colors.background.surface.secondary}"
+            }
+          },
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["FRAME_FILL"],
+              "com.figma.variableId": "VariableID:6325:11550"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.surface.primary}",
+              "default": "{colors.background.surface.primary}",
+              "virtuozzo": "{colors.background.surface.primary}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["FRAME_FILL"],
+              "com.figma.variableId": "VariableID:6325:11549"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.surface.primary}",
+              "default": "{colors.background.surface.primary}",
+              "virtuozzo": "{colors.background.surface.primary}"
+            }
+          }
+        },
+        "gap": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
+            "com.figma.variableId": "VariableID:6325:11546"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}",
+            "virtuozzo": "{units.gap.12}"
+          }
+        },
+        "height": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
+            "com.figma.variableId": "VariableID:6325:11543"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.32}",
+            "default": "{units.size.32}",
+            "virtuozzo": "{units.size.32}"
+          }
+        },
+        "paddingX": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
+            "com.figma.variableId": "VariableID:6325:11544"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.12}",
+            "default": "{units.gap.12}",
+            "virtuozzo": "{units.gap.12}"
+          }
+        },
+        "paddingY": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
+            "com.figma.variableId": "VariableID:6325:11545"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
+          }
+        }
+      },
+      "container": {
+        "gap": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
+            "com.figma.variableId": "VariableID:6325:11535"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
+          }
+        },
+        "widthMin": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
+            "com.figma.variableId": "VariableID:6325:11534"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.128}",
+            "default": "{units.size.128}",
+            "virtuozzo": "{units.size.128}"
+          }
+        }
+      },
+      "containerLabel": {
+        "gap": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
+            "com.figma.variableId": "VariableID:6325:11536"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
+          }
+        }
+      },
+      "label": {
+        "color": {
+          "disabled": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:6325:11540"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+              "default": "{colors.text.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
+            }
+          },
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:6325:11539"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:6325:11538"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
+            }
+          }
+        },
+        "textStyle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:6325:11537"
+          },
+          "$type": "typography",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{typography.body.form-label}",
+            "default": "{typography.body.form-label}",
+            "virtuozzo": "{typography.body.form-label}"
+          }
+        }
+      },
+      "placeholder": {
+        "color": {
+          "disabled": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:6325:11558"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+              "default": "{colors.text.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
+            }
+          },
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:6325:11557"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:6325:11556"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
+            }
+          }
+        }
+      },
+      "required": {
+        "color": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:6325:11541"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
+            "default": "{colors.text.onSurface.destructive}",
+            "virtuozzo": "{colors.text.onSurface.destructive}"
+          }
+        },
+        "textStyle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:6325:11542"
+          },
+          "$type": "typography",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
+          }
+        }
+      },
+      "value": {
+        "color": {
+          "disabled": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:6325:11555"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+              "default": "{colors.text.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
+            }
+          },
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:6325:11554"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:6325:11553"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
+            }
+          }
+        },
+        "textStyle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:6325:11552"
+          },
+          "$type": "typography",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
+          }
+        }
+      }
+    },
+    "errorMsg": {
+      "box": {
+        "borderColor": {
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:6325:11568"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
+              "default": "{colors.border.onSurface.border-error}",
+              "virtuozzo": "{colors.border.onSurface.border-error}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:6325:11567"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
+              "default": "{colors.border.onSurface.border-error}",
+              "virtuozzo": "{colors.border.onSurface.border-error}"
+            }
+          }
+        }
+      },
+      "error": {
+        "color": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:6325:11569"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
+            "default": "{colors.text.onSurface.destructive}",
+            "virtuozzo": "{colors.text.onSurface.destructive}"
+          }
+        },
+        "textStyle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:6325:11570"
+          },
+          "$type": "typography",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{typography.caption.default}",
+            "default": "{typography.caption.default}",
+            "virtuozzo": "{typography.caption.default}"
+          }
+        }
+      }
+    },
+    "normal": {
+      "box": {
+        "borderColor": {
+          "disabled": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:6325:11561"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{colors.border.onSurface.border}"
+            }
+          },
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:6325:11560"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:6325:11559"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{colors.border.onSurface.border}"
+            }
+          }
+        }
+      },
+      "description": {
+        "color": {
+          "disabled": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:6325:11566"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
+              "default": "{colors.text.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
+            }
+          },
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:6325:11565"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:6325:11564"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
+            }
+          }
+        },
+        "textStyle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:6325:11562"
+          },
+          "$type": "typography",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{typography.caption.default}",
+            "default": "{typography.caption.default}",
+            "virtuozzo": "{typography.caption.default}"
           }
         }
       }
@@ -5757,6 +7913,22 @@
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
+          }
+        }
+      },
+      "iconBox": {
+        "size": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
+            "com.figma.variableId": "VariableID:6327:29557"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.20}",
+            "default": "{units.size.20}",
+            "virtuozzo": "{units.size.20}"
           }
         }
       },
@@ -7305,6 +9477,854 @@
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
           "default": "{typography.body.default}"
+        }
+      }
+    }
+  },
+  "Link": {
+    "_global": {
+      "container": {
+        "gap": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP"],
+            "com.figma.variableId": "VariableID:3735:874"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.4}",
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
+          }
+        },
+        "height": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
+            "com.figma.variableId": "VariableID:3735:873"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.32}",
+            "default": "{units.size.32}",
+            "virtuozzo": "{units.size.32}"
+          }
+        }
+      },
+      "textDecoration": {
+        "active": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:3735:864"
+          },
+          "$type": "string",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "none",
+            "default": "none",
+            "virtuozzo": "none"
+          }
+        },
+        "disabled": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:3735:865"
+          },
+          "$type": "string",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "none",
+            "default": "none",
+            "virtuozzo": "none"
+          }
+        },
+        "hover": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:3735:863"
+          },
+          "$type": "string",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "underline",
+            "default": "underline",
+            "virtuozzo": "underline"
+          }
+        },
+        "idle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:3735:862"
+          },
+          "$type": "string",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "none",
+            "default": "none",
+            "virtuozzo": "none"
+          }
+        }
+      },
+      "textStyle": {
+        "active": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:3735:871"
+          },
+          "$type": "typography",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{typography.link.strong}",
+            "default": "{typography.link.strong}",
+            "virtuozzo": "{typography.link.strong}"
+          }
+        },
+        "disabled": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:3735:872"
+          },
+          "$type": "typography",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{typography.link.strong}",
+            "default": "{typography.link.strong}",
+            "virtuozzo": "{typography.link.strong}"
+          }
+        },
+        "hover": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:3735:870"
+          },
+          "$type": "typography",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{typography.link.strong-underline}",
+            "default": "{typography.link.strong-underline}",
+            "virtuozzo": "{typography.link.strong-underline}"
+          }
+        },
+        "idle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:3735:861"
+          },
+          "$type": "typography",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{typography.link.strong}",
+            "default": "{typography.link.strong}",
+            "virtuozzo": "{typography.link.strong}"
+          }
+        }
+      }
+    },
+    "inverse": {
+      "externalIcon": {
+        "color": {
+          "active": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:3951:4484"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.glyph.onBackdrop.screenPrimary}",
+              "default": "{colors.glyph.onBackdrop.screenPrimary}",
+              "virtuozzo": "{colors.glyph.onBackdrop.screenPrimary}"
+            }
+          },
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:3951:4483"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.glyph.onBackdrop.screenPrimary}",
+              "default": "{colors.glyph.onBackdrop.screenPrimary}",
+              "virtuozzo": "{colors.glyph.onBackdrop.screenPrimary}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:3951:4482"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.glyph.onBackdrop.screenPrimary}",
+              "default": "{colors.glyph.onBackdrop.screenPrimary}",
+              "virtuozzo": "{colors.glyph.onBackdrop.screenPrimary}"
+            }
+          }
+        }
+      },
+      "text": {
+        "color": {
+          "active": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:3951:4389"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onBackdrop.screenLink-active}",
+              "default": "{colors.text.onBackdrop.screenLink-active}",
+              "virtuozzo": "{colors.text.onBackdrop.screenLink-active}"
+            }
+          },
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:3951:4388"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onBackdrop.screenLink-hover}",
+              "default": "{colors.text.onBackdrop.screenLink-hover}",
+              "virtuozzo": "{colors.text.onBackdrop.screenLink-hover}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:3951:4387"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onBackdrop.screenLink-idle}",
+              "default": "{colors.text.onBackdrop.screenLink-idle}",
+              "virtuozzo": "{colors.text.onBackdrop.screenLink-idle}"
+            }
+          }
+        }
+      }
+    },
+    "normal": {
+      "externalIcon": {
+        "color": {
+          "active": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:3741:877"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
+              "default": "{colors.text.onSurface.link-pressed}",
+              "virtuozzo": "{colors.text.onSurface.link-pressed}"
+            }
+          },
+          "disabled": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:3741:878"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
+              "default": "{colors.text.onSurface.link-disabled}",
+              "virtuozzo": "{colors.text.onSurface.link-disabled}"
+            }
+          },
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:3741:876"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
+              "default": "{colors.text.onSurface.link-hover}",
+              "virtuozzo": "{colors.text.onSurface.link-hover}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+              "com.figma.variableId": "VariableID:3740:875"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+              "default": "{colors.text.onSurface.link-idle}",
+              "virtuozzo": "{colors.text.onSurface.link-idle}"
+            }
+          }
+        }
+      },
+      "text": {
+        "color": {
+          "active": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:3735:859"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
+              "default": "{colors.text.onSurface.link-pressed}",
+              "virtuozzo": "{colors.text.onSurface.link-pressed}"
+            }
+          },
+          "disabled": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:3735:860"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
+              "default": "{colors.text.onSurface.link-disabled}",
+              "virtuozzo": "{colors.text.onSurface.link-disabled}"
+            }
+          },
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:3735:858"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
+              "default": "{colors.text.onSurface.link-hover}",
+              "virtuozzo": "{colors.text.onSurface.link-hover}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["TEXT_FILL"],
+              "com.figma.variableId": "VariableID:3735:857"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.text.onSurface.link-idle}",
+              "default": "{colors.text.onSurface.link-idle}",
+              "virtuozzo": "{colors.text.onSurface.link-idle}"
+            }
+          }
+        }
+      }
+    }
+  },
+  "Loading": {
+    "element": {
+      "container": {
+        "color": {
+          "primary": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["FRAME_FILL"],
+              "com.figma.variableId": "VariableID:4370:2889"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.backdrop.element.primary}",
+              "default": "{colors.background.backdrop.element.primary}",
+              "virtuozzo": "{colors.background.backdrop.element.primary}"
+            }
+          },
+          "secondary": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["FRAME_FILL"],
+              "com.figma.variableId": "VariableID:4370:2955"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.backdrop.element.secondary}",
+              "default": "{colors.background.backdrop.element.secondary}",
+              "virtuozzo": "{colors.background.backdrop.element.secondary}"
+            }
+          }
+        },
+        "gap": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP"],
+            "com.figma.variableId": "VariableID:4370:2883"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
+          }
+        },
+        "paddingX": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP"],
+            "com.figma.variableId": "VariableID:4370:2882"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.16}",
+            "default": "{units.gap.16}",
+            "virtuozzo": "{units.gap.16}"
+          }
+        },
+        "paddingY": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP"],
+            "com.figma.variableId": "VariableID:4370:2888"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.16}",
+            "default": "{units.gap.16}",
+            "virtuozzo": "{units.gap.16}"
+          }
+        }
+      },
+      "icon": {
+        "color": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.variableId": "VariableID:4370:2884"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.glyph.onBackdrop.elementPrimary}",
+            "default": "{colors.glyph.onBackdrop.elementPrimary}",
+            "virtuozzo": "{colors.glyph.onBackdrop.elementPrimary}"
+          }
+        },
+        "size": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
+            "com.figma.variableId": "VariableID:4370:2885"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.32}",
+            "default": "{units.size.32}",
+            "virtuozzo": "{units.size.32}"
+          }
+        }
+      },
+      "label": {
+        "color": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:4370:2886"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.text.onBackdrop.elementPrimary}",
+            "default": "{colors.text.onBackdrop.elementPrimary}",
+            "virtuozzo": "{colors.text.onBackdrop.elementPrimary}"
+          }
+        },
+        "textStyle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:4370:2887"
+          },
+          "$type": "typography",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
+          }
+        }
+      }
+    },
+    "inline": {
+      "container": {
+        "gap": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP"],
+            "com.figma.variableId": "VariableID:4370:2876"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
+          }
+        },
+        "height": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
+            "com.figma.variableId": "VariableID:4370:2877"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.24}",
+            "default": "{units.size.24}",
+            "virtuozzo": "{units.size.24}"
+          }
+        }
+      },
+      "icon": {
+        "color": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.variableId": "VariableID:4370:2869"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
+            "default": "{colors.glyph.onSurface.primary}",
+            "virtuozzo": "{colors.glyph.onSurface.primary}"
+          }
+        },
+        "size": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
+            "com.figma.variableId": "VariableID:4370:2872"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.16}",
+            "default": "{units.size.16}",
+            "virtuozzo": "{units.size.16}"
+          }
+        }
+      },
+      "label": {
+        "color": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:4370:2874"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
+          }
+        },
+        "textStyle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:4370:2875"
+          },
+          "$type": "typography",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
+          }
+        }
+      }
+    },
+    "screen": {
+      "container": {
+        "color": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["FRAME_FILL"],
+            "com.figma.variableId": "VariableID:4370:2903"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.background.backdrop.screen}",
+            "default": "{colors.background.backdrop.screen}",
+            "virtuozzo": "{colors.background.backdrop.screen}"
+          }
+        },
+        "gap": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP"],
+            "com.figma.variableId": "VariableID:4370:2902"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.8}",
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
+          }
+        },
+        "paddingX": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP"],
+            "com.figma.variableId": "VariableID:4370:2900"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.16}",
+            "default": "{units.gap.16}",
+            "virtuozzo": "{units.gap.16}"
+          }
+        },
+        "paddingY": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["GAP"],
+            "com.figma.variableId": "VariableID:4370:2901"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.gap.16}",
+            "default": "{units.gap.16}",
+            "virtuozzo": "{units.gap.16}"
+          }
+        }
+      },
+      "icon": {
+        "color": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
+            "com.figma.variableId": "VariableID:4370:2904"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.glyph.onBackdrop.screenPrimary}",
+            "default": "{colors.glyph.onBackdrop.screenPrimary}",
+            "virtuozzo": "{colors.glyph.onBackdrop.screenPrimary}"
+          }
+        },
+        "size": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
+            "com.figma.variableId": "VariableID:4370:2905"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.size.48}",
+            "default": "{units.size.48}",
+            "virtuozzo": "{units.size.48}"
+          }
+        }
+      },
+      "label": {
+        "color": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:4370:2906"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.text.onBackdrop.screenPrimary}",
+            "default": "{colors.text.onBackdrop.screenPrimary}",
+            "virtuozzo": "{colors.text.onBackdrop.screenPrimary}"
+          }
+        },
+        "textStyle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:4370:2907"
+          },
+          "$type": "typography",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{typography.body.default}",
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
+          }
+        }
+      }
+    }
+  },
+  "Popover": {
+    "body": {
+      "gap": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:6364:17910"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.gap.12}",
+          "default": "{units.gap.12}",
+          "virtuozzo": "{units.gap.12}"
+        }
+      },
+      "paddingY": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["GAP"],
+          "com.figma.variableId": "VariableID:6364:17909"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.gap.16}",
+          "default": "{units.gap.16}",
+          "virtuozzo": "{units.gap.16}"
+        }
+      }
+    },
+    "container": {
+      "borderColor": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["STROKE_COLOR"],
+          "com.figma.variableId": "VariableID:6364:17889"
+        },
+        "$type": "color",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
+          "default": "{colors.border.onSurface.border-active}",
+          "virtuozzo": "{colors.border.onSurface.border-active}"
+        }
+      },
+      "borderRadius": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["CORNER_RADIUS"],
+          "com.figma.variableId": "VariableID:6364:17890"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.radius.4}",
+          "default": "{units.radius.4}",
+          "virtuozzo": "{units.radius.4}"
+        }
+      },
+      "borderStyle": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["ALL_SCOPES"],
+          "com.figma.variableId": "VariableID:6364:17892"
+        },
+        "$type": "string",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "solid",
+          "default": "solid",
+          "virtuozzo": "solid"
+        }
+      },
+      "borderWidth": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["STROKE_FLOAT"],
+          "com.figma.variableId": "VariableID:6364:17891"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.stroke.1}",
+          "default": "{units.stroke.1}",
+          "virtuozzo": "{units.stroke.1}"
+        }
+      },
+      "color": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["FRAME_FILL"],
+          "com.figma.variableId": "VariableID:6364:17888"
+        },
+        "$type": "color",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{colors.background.surface.primary}",
+          "default": "{colors.background.surface.primary}",
+          "virtuozzo": "{colors.background.surface.primary}"
+        }
+      },
+      "maxWidth": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:6364:17893"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.size.512}",
+          "default": "{units.size.512}",
+          "virtuozzo": "{units.size.512}"
+        }
+      },
+      "minWidth": {
+        "$extensions": {
+          "com.figma.hiddenFromPublishing": true,
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
+          "com.figma.variableId": "VariableID:6364:17887"
+        },
+        "$type": "dimension",
+        "platforms": ["PD"],
+        "values": {
+          "deep_sky_itkontoret": "{units.size.320}",
+          "default": "{units.size.320}",
+          "virtuozzo": "{units.size.320}"
         }
       }
     }
@@ -9978,6 +12998,52 @@
   },
   "Table": {
     "Data": {
+      "cell": {
+        "color": {
+          "active": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["ALL_SCOPES"],
+              "com.figma.variableId": "VariableID:5881:16235"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.surface.active}",
+              "default": "{colors.background.surface.active}",
+              "virtuozzo": "{colors.background.surface.active}"
+            }
+          },
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["ALL_SCOPES"],
+              "com.figma.variableId": "VariableID:5881:16234"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.surface.hover}",
+              "default": "{colors.background.surface.hover}",
+              "virtuozzo": "{colors.background.surface.hover}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["ALL_SCOPES"],
+              "com.figma.variableId": "VariableID:5881:16233"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "transparent",
+              "default": "transparent",
+              "virtuozzo": "transparent"
+            }
+          }
+        }
+      },
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
@@ -9989,6 +13055,52 @@
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
           "default": "{units.gap.8}"
+        }
+      },
+      "row": {
+        "color": {
+          "active": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["ALL_SCOPES"],
+              "com.figma.variableId": "VariableID:4536:664"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.surface.hover}",
+              "default": "{colors.background.surface.hover}",
+              "virtuozzo": "{colors.background.surface.hover}"
+            }
+          },
+          "hover": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["ALL_SCOPES"],
+              "com.figma.variableId": "VariableID:4536:663"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{colors.background.surface.hover}",
+              "default": "{colors.background.surface.hover}",
+              "virtuozzo": "{colors.background.surface.hover}"
+            }
+          },
+          "idle": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["ALL_SCOPES"],
+              "com.figma.variableId": "VariableID:4536:662"
+            },
+            "$type": "color",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "transparent",
+              "default": "transparent",
+              "virtuozzo": "transparent"
+            }
+          }
         }
       },
       "value": {
@@ -10166,6 +13278,22 @@
     },
     "_global": {
       "cell": {
+        "icon": {
+          "marginY": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["GAP"],
+              "com.figma.variableId": "VariableID:4560:3624"
+            },
+            "$type": "dimension",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{units.gap.4}",
+              "default": "{units.gap.4}",
+              "virtuozzo": "{units.gap.4}"
+            }
+          }
+        },
         "minHeight": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
@@ -10203,6 +13331,66 @@
           "values": {
             "deep_sky_itkontoret": "{units.size.8}",
             "default": "{units.size.8}"
+          }
+        },
+        "tag": {
+          "marginY": {
+            "$extensions": {
+              "com.figma.hiddenFromPublishing": true,
+              "com.figma.scopes": ["GAP"],
+              "com.figma.variableId": "VariableID:4567:6596"
+            },
+            "$type": "dimension",
+            "platforms": ["PD"],
+            "values": {
+              "deep_sky_itkontoret": "{units.gap.2}",
+              "default": "{units.gap.2}",
+              "virtuozzo": "{units.gap.2}"
+            }
+          }
+        }
+      },
+      "row": {
+        "borderColor": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["STROKE_COLOR"],
+            "com.figma.variableId": "VariableID:3389:2338"
+          },
+          "$type": "color",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{colors.border.onSurface.border}",
+            "default": "{colors.border.onSurface.border}",
+            "virtuozzo": "{colors.border.onSurface.border}"
+          }
+        },
+        "borderStyle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["ALL_SCOPES"],
+            "com.figma.variableId": "VariableID:3389:2341"
+          },
+          "$type": "string",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "solid",
+            "default": "solid",
+            "virtuozzo": "solid"
+          }
+        },
+        "borderWidth": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": ["STROKE_FLOAT"],
+            "com.figma.variableId": "VariableID:3389:2339"
+          },
+          "$type": "dimension",
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{units.stroke.1}",
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         }
       }

--- a/packages/design-tokens/tiers/components.json
+++ b/packages/design-tokens/tiers/components.json
@@ -4775,21 +4775,6 @@
         }
       }
     },
-    "clearIcon": {
-      "color": {
-        "$extensions": {
-          "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
-          "com.figma.variableId": "VariableID:2605:115"
-        },
-        "$type": "color",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-          "default": "{colors.glyph.onSurface.primary}"
-        }
-      }
-    },
     "color": {
       "disabled": {
         "$extensions": {
@@ -6403,21 +6388,6 @@
           }
         }
       },
-      "clearIcon": {
-        "color": {
-          "$extensions": {
-            "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
-            "com.figma.variableId": "VariableID:2624:92"
-          },
-          "$type": "color",
-          "platforms": ["PD"],
-          "values": {
-            "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-            "default": "{colors.glyph.onSurface.primary}"
-          }
-        }
-      },
       "container": {
         "gap": {
           "$extensions": {
@@ -7339,240 +7309,6 @@
       }
     }
   },
-  "Link": {
-    "color": {
-      "active": {
-        "$extensions": {
-          "com.figma.scopes": ["TEXT_FILL"],
-          "com.figma.variableId": "VariableID:3735:859"
-        },
-        "$type": "color",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
-          "default": "{colors.text.onSurface.link-pressed}"
-        }
-      },
-      "disabled": {
-        "$extensions": {
-          "com.figma.scopes": ["TEXT_FILL"],
-          "com.figma.variableId": "VariableID:3735:860"
-        },
-        "$type": "color",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
-          "default": "{colors.text.onSurface.link-disabled}"
-        }
-      },
-      "hover": {
-        "$extensions": {
-          "com.figma.scopes": ["TEXT_FILL"],
-          "com.figma.variableId": "VariableID:3735:858"
-        },
-        "$type": "color",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
-          "default": "{colors.text.onSurface.link-hover}"
-        }
-      },
-      "idle": {
-        "$extensions": {
-          "com.figma.scopes": ["TEXT_FILL"],
-          "com.figma.variableId": "VariableID:3735:857"
-        },
-        "$type": "color",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-          "default": "{colors.text.onSurface.link}"
-        }
-      }
-    },
-    "container": {
-      "gap": {
-        "$extensions": {
-          "com.figma.scopes": ["GAP"],
-          "com.figma.variableId": "VariableID:3735:874"
-        },
-        "$type": "dimension",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "{units.gap.4}",
-          "default": "{units.gap.4}"
-        }
-      },
-      "height": {
-        "$extensions": {
-          "com.figma.scopes": ["WIDTH_HEIGHT"],
-          "com.figma.variableId": "VariableID:3735:873"
-        },
-        "$type": "dimension",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "{units.size.32}",
-          "default": "{units.size.32}"
-        }
-      }
-    },
-    "externalIcon": {
-      "color": {
-        "active": {
-          "$extensions": {
-            "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": ["SHAPE_FILL"],
-            "com.figma.variableId": "VariableID:3735:874"
-          },
-          "$type": "color",
-          "platforms": ["PD"],
-          "values": {
-            "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
-            "default": "{colors.text.onSurface.link-pressed}"
-          }
-        },
-        "disabled": {
-          "$extensions": {
-            "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": ["SHAPE_FILL"],
-            "com.figma.variableId": "VariableID:3735:865"
-          },
-          "$type": "color",
-          "platforms": ["PD"],
-          "values": {
-            "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
-            "default": "{colors.text.onSurface.link-disabled}"
-          }
-        },
-        "hover": {
-          "$extensions": {
-            "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": ["SHAPE_FILL"],
-            "com.figma.variableId": "VariableID:3735:863"
-          },
-          "$type": "color",
-          "platforms": ["PD"],
-          "values": {
-            "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
-            "default": "{colors.text.onSurface.link-hover}"
-          }
-        },
-        "idle": {
-          "$extensions": {
-            "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": ["SHAPE_FILL"],
-            "com.figma.variableId": "VariableID:3735:862"
-          },
-          "$type": "color",
-          "platforms": ["PD"],
-          "values": {
-            "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-            "default": "{colors.text.onSurface.link}"
-          }
-        }
-      }
-    },
-    "textDecoration": {
-      "active": {
-        "$extensions": {
-          "com.figma.scopes": ["ALL_SCOPES"],
-          "com.figma.variableId": "VariableID:3735:864"
-        },
-        "$type": "string",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "none",
-          "default": "none"
-        }
-      },
-      "disabled": {
-        "$extensions": {
-          "com.figma.scopes": ["ALL_SCOPES"],
-          "com.figma.variableId": "VariableID:3735:865"
-        },
-        "$type": "string",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "none",
-          "default": "none"
-        }
-      },
-      "hover": {
-        "$extensions": {
-          "com.figma.scopes": ["ALL_SCOPES"],
-          "com.figma.variableId": "VariableID:3735:863"
-        },
-        "$type": "string",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "underline",
-          "default": "underline"
-        }
-      },
-      "idle": {
-        "$extensions": {
-          "com.figma.scopes": ["ALL_SCOPES"],
-          "com.figma.variableId": "VariableID:3735:862"
-        },
-        "$type": "string",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "none",
-          "default": "none"
-        }
-      }
-    },
-    "textStyle": {
-      "active": {
-        "$extensions": {
-          "com.figma.scopes": ["ALL_SCOPES"],
-          "com.figma.variableId": "VariableID:3735:871"
-        },
-        "$type": "typography",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "{typography.link.strong}",
-          "default": "{typography.link.strong}"
-        }
-      },
-      "disabled": {
-        "$extensions": {
-          "com.figma.scopes": ["ALL_SCOPES"],
-          "com.figma.variableId": "VariableID:3735:872"
-        },
-        "$type": "typography",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "{typography.link.strong}",
-          "default": "{typography.link.strong}"
-        }
-      },
-      "hover": {
-        "$extensions": {
-          "com.figma.scopes": ["ALL_SCOPES"],
-          "com.figma.variableId": "VariableID:3735:870"
-        },
-        "$type": "typography",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "{typography.link.strong-underline}",
-          "default": "{typography.link.strong-underline}"
-        }
-      },
-      "idle": {
-        "$extensions": {
-          "com.figma.scopes": ["ALL_SCOPES"],
-          "com.figma.variableId": "VariableID:3735:861"
-        },
-        "$type": "typography",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "{typography.link.strong}",
-          "default": "{typography.link.strong}"
-        }
-      }
-    }
-  },
   "Radio": {
     "_global": {
       "box": {
@@ -8037,60 +7773,6 @@
     }
   },
   "Resizable": {
-    "bar": {
-      "borderRadius": {
-        "$extensions": {
-          "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": ["CORNER_RADIUS"],
-          "com.figma.variableId": "VariableID:3459:3716"
-        },
-        "$type": "dimension",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "{units.radius.4}",
-          "default": "{units.radius.4}"
-        }
-      },
-      "color": {
-        "$extensions": {
-          "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": ["FRAME_FILL"],
-          "com.figma.variableId": "VariableID:3459:3717"
-        },
-        "$type": "color",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "{colors.background.brand.secondary}",
-          "default": "{colors.background.brand.secondary}"
-        }
-      },
-      "height": {
-        "$extensions": {
-          "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": ["WIDTH_HEIGHT"],
-          "com.figma.variableId": "VariableID:3459:3715"
-        },
-        "$type": "dimension",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "{units.size.32}",
-          "default": "{units.size.32}"
-        }
-      },
-      "width": {
-        "$extensions": {
-          "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": ["WIDTH_HEIGHT"],
-          "com.figma.variableId": "VariableID:3459:3713"
-        },
-        "$type": "dimension",
-        "platforms": ["PD"],
-        "values": {
-          "deep_sky_itkontoret": "{units.size.7}",
-          "default": "{units.size.7}"
-        }
-      }
-    },
     "border": {
       "color": {
         "active": {
@@ -10395,19 +10077,6 @@
               "default": "transparent"
             }
           }
-        },
-        "paddingX": {
-          "$extensions": {
-            "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": ["GAP"],
-            "com.figma.variableId": "VariableID:3389:2337"
-          },
-          "$type": "dimension",
-          "platforms": ["PD"],
-          "values": {
-            "deep_sky_itkontoret": "{units.size.16}",
-            "default": "{units.size.16}"
-          }
         }
       },
       "gap": {
@@ -10497,45 +10166,6 @@
     },
     "_global": {
       "cell": {
-        "borderColor": {
-          "$extensions": {
-            "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": ["STROKE_COLOR"],
-            "com.figma.variableId": "VariableID:3389:2338"
-          },
-          "$type": "color",
-          "platforms": ["PD"],
-          "values": {
-            "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-            "default": "{colors.border.onSurface.border}"
-          }
-        },
-        "borderStyle": {
-          "$extensions": {
-            "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": ["ALL_SCOPES"],
-            "com.figma.variableId": "VariableID:3389:2341"
-          },
-          "$type": "string",
-          "platforms": ["PD"],
-          "values": {
-            "deep_sky_itkontoret": "solid",
-            "default": "solid"
-          }
-        },
-        "borderWidth": {
-          "$extensions": {
-            "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": ["STROKE_FLOAT"],
-            "com.figma.variableId": "VariableID:3389:2339"
-          },
-          "$type": "dimension",
-          "platforms": ["PD"],
-          "values": {
-            "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
-          }
-        },
         "minHeight": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
@@ -10573,46 +10203,6 @@
           "values": {
             "deep_sky_itkontoret": "{units.size.8}",
             "default": "{units.size.8}"
-          }
-        }
-      },
-      "row": {
-        "color": {
-          "active": {
-            "$extensions": {
-              "com.figma.scopes": ["ALL_SCOPES"],
-              "com.figma.variableId": "VariableID:3699:293"
-            },
-            "$type": "color",
-            "platforms": ["PD"],
-            "values": {
-              "deep_sky_itkontoret": "{colors.background.surface.active}",
-              "default": "{colors.background.surface.active}"
-            }
-          },
-          "hover": {
-            "$extensions": {
-              "com.figma.scopes": ["ALL_SCOPES"],
-              "com.figma.variableId": "VariableID:3699:292"
-            },
-            "$type": "color",
-            "platforms": ["PD"],
-            "values": {
-              "deep_sky_itkontoret": "{colors.background.surface.hover}",
-              "default": "{colors.background.surface.hover}"
-            }
-          },
-          "idle": {
-            "$extensions": {
-              "com.figma.scopes": ["ALL_SCOPES"],
-              "com.figma.variableId": "VariableID:3699:291"
-            },
-            "$type": "color",
-            "platforms": ["PD"],
-            "values": {
-              "deep_sky_itkontoret": "transparent",
-              "default": "transparent"
-            }
           }
         }
       }

--- a/packages/design-tokens/tiers/components.json
+++ b/packages/design-tokens/tiers/components.json
@@ -47,15 +47,11 @@
           "borderStyle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3332:5669"
             },
             "$type": "string",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "solid",
               "default": "solid"
@@ -64,15 +60,11 @@
           "borderWidth": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_FLOAT"
-              ],
+              "com.figma.scopes": ["STROKE_FLOAT"],
               "com.figma.variableId": "VariableID:3332:5667"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.stroke.2}",
               "default": "{units.stroke.2}"
@@ -81,15 +73,11 @@
           "color": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3332:5666"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.base}",
               "default": "{palette.base}"
@@ -100,15 +88,11 @@
           "gap": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP"
-              ],
+              "com.figma.scopes": ["GAP"],
               "com.figma.variableId": "VariableID:3332:5664"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.neg-6}",
               "default": "{units.gap.neg-6}"
@@ -118,15 +102,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3111:187"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -137,15 +117,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3332:5663"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -156,15 +132,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3332:4997"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.strong}",
             "default": "{typography.caption.strong}"
@@ -175,15 +147,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3332:5000"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -192,15 +160,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3332:4999"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -212,15 +176,11 @@
       "orange": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "FRAME_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL"],
           "com.figma.variableId": "VariableID:3332:1733"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.orange.3}",
           "default": "{palette.orange.3}"
@@ -229,15 +189,11 @@
       "red": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "FRAME_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL"],
           "com.figma.variableId": "VariableID:3332:1732"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.red.3}",
           "default": "{palette.red.3}"
@@ -246,15 +202,11 @@
       "teal": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "FRAME_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL"],
           "com.figma.variableId": "VariableID:3332:1730"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.teal.3}",
           "default": "{palette.teal.3}"
@@ -263,15 +215,11 @@
       "violet": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "FRAME_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL"],
           "com.figma.variableId": "VariableID:3332:1731"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.violet.3}",
           "default": "{palette.violet.3}"
@@ -280,15 +228,11 @@
       "yellow": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "FRAME_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL"],
           "com.figma.variableId": "VariableID:3332:1734"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.yellow.3}",
           "default": "{palette.yellow.3}"
@@ -300,15 +244,11 @@
         "orange": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3332:1764"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.11}",
             "default": "{palette.orange.11}"
@@ -317,15 +257,11 @@
         "red": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3332:1763"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.11}",
             "default": "{palette.red.11}"
@@ -334,15 +270,11 @@
         "teal": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3111:189"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.teal.11}",
             "default": "{palette.teal.11}"
@@ -351,15 +283,11 @@
         "violet": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3332:1753"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.11}",
             "default": "{palette.violet.11}"
@@ -368,15 +296,11 @@
         "yellow": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3332:1765"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.11}",
             "default": "{palette.yellow.11}"
@@ -392,15 +316,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:44254"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -409,15 +329,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:44253"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -426,15 +342,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:44252"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -448,9 +360,7 @@
             "com.figma.variableId": "VariableID:2504:141807"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.link.default}",
             "default": "{typography.link.default}"
@@ -463,15 +373,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2238:44256"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -484,9 +390,7 @@
             "com.figma.variableId": "VariableID:2238:44260"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -499,16 +403,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2238:44257"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.neutral}",
             "default": "{colors.glyph.onSurface.neutral}"
@@ -517,16 +416,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:141812"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -538,16 +432,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2238:44258"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
           "default": "{units.gap.4}"
@@ -561,16 +450,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:91027"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
             "default": "{units.radius.4}"
@@ -579,16 +463,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:91024"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -597,16 +476,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:91026"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -615,16 +489,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:91025"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -635,16 +504,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:91028"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -659,9 +523,7 @@
             "com.figma.variableId": "VariableID:2468:91029"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
             "default": "{typography.body.strong}"
@@ -679,9 +541,7 @@
               "com.figma.variableId": "VariableID:2277:441"
             },
             "$type": "string",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{gradients.ai.active}",
               "default": "{gradients.ai.active}"
@@ -694,9 +554,7 @@
               "com.figma.variableId": "VariableID:2277:442"
             },
             "$type": "string",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{gradients.ai.disabled}",
               "default": "{gradients.ai.disabled}"
@@ -709,9 +567,7 @@
               "com.figma.variableId": "VariableID:2277:440"
             },
             "$type": "string",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{gradients.ai.hover}",
               "default": "{gradients.ai.hover}"
@@ -724,9 +580,7 @@
               "com.figma.variableId": "VariableID:2277:439"
             },
             "$type": "string",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{gradients.ai.idle}",
               "default": "{gradients.ai.idle}"
@@ -736,16 +590,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5655"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -754,16 +603,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5654"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.64}",
             "default": "{units.size.64}"
@@ -775,16 +619,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6862"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -793,16 +632,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6863"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -811,16 +645,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6861"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -829,16 +658,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6860"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -851,15 +675,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7498"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
               "default": "{colors.text.onBrand.primary}"
@@ -868,15 +688,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7499"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.disabled}",
               "default": "{colors.text.onBrand.disabled}"
@@ -885,15 +701,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7497"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
               "default": "{colors.text.onBrand.primary}"
@@ -902,15 +714,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7496"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
               "default": "{colors.text.onBrand.primary}"
@@ -925,15 +733,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5620"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.statusStrong.danger-pressed}",
               "default": "{colors.background.statusStrong.danger-pressed}"
@@ -942,15 +746,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5621"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.danger}",
               "default": "{colors.background.status.danger}"
@@ -959,15 +759,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5619"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.statusStrong.danger-hover}",
               "default": "{colors.background.statusStrong.danger-hover}"
@@ -976,15 +772,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5618"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.statusStrong.danger}",
               "default": "{colors.background.statusStrong.danger}"
@@ -994,16 +786,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5625"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -1012,16 +799,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5624"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.64}",
             "default": "{units.size.64}"
@@ -1033,16 +815,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6858"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onInverse.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -1051,16 +828,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6859"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onInverse.primary}",
               "default": "{colors.glyph.onBrand.disabled}"
@@ -1069,16 +841,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6857"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onInverse.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -1087,16 +854,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6856"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onInverse.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -1109,15 +871,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7494"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onInverse.primary}",
               "default": "{colors.text.onBrand.primary}"
@@ -1126,15 +884,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7495"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.disabled}",
               "default": "{colors.text.onBrand.disabled}"
@@ -1143,15 +897,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7493"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onInverse.primary}",
               "default": "{colors.text.onBrand.primary}"
@@ -1160,15 +910,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7492"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onInverse.primary}",
               "default": "{colors.text.onBrand.primary}"
@@ -1182,16 +928,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2238:6462"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -1203,16 +944,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6854"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -1221,16 +957,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6855"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -1239,16 +970,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6853"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -1257,16 +983,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6852"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -1279,15 +1000,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2236:5611"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
               "default": "{colors.text.onSurface.link-pressed}"
@@ -1296,15 +1013,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2236:5612"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
               "default": "{colors.text.onSurface.link-disabled}"
@@ -1313,15 +1026,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2236:5610"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
               "default": "{colors.text.onSurface.link-hover}"
@@ -1330,15 +1039,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2236:5609"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link}",
               "default": "{colors.text.onSurface.link}"
@@ -1353,9 +1058,7 @@
               "com.figma.variableId": "VariableID:2236:5615"
             },
             "$type": "string",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "none",
               "default": "none"
@@ -1368,9 +1071,7 @@
               "com.figma.variableId": "VariableID:2236:5616"
             },
             "$type": "string",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "none",
               "default": "none"
@@ -1383,9 +1084,7 @@
               "com.figma.variableId": "VariableID:2236:5614"
             },
             "$type": "string",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "underline",
               "default": "underline"
@@ -1398,9 +1097,7 @@
               "com.figma.variableId": "VariableID:2236:5613"
             },
             "$type": "string",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "none",
               "default": "none"
@@ -1415,9 +1112,7 @@
               "com.figma.variableId": "VariableID:3735:868"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.link.strong}",
               "default": "{typography.link.strong}"
@@ -1430,9 +1125,7 @@
               "com.figma.variableId": "VariableID:3735:869"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.link.strong}",
               "default": "{typography.link.strong}"
@@ -1445,9 +1138,7 @@
               "com.figma.variableId": "VariableID:3735:867"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.link.strong-underline}",
               "default": "{typography.link.strong-underline}"
@@ -1460,9 +1151,7 @@
               "com.figma.variableId": "VariableID:3735:866"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.link.strong}",
               "default": "{typography.link.strong}"
@@ -1477,15 +1166,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5578"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
               "default": "{colors.background.brand.secondary-active}"
@@ -1494,15 +1179,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5579"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-disabled}",
               "default": "{colors.background.brand.secondary-disabled}"
@@ -1511,15 +1192,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5577"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
               "default": "{colors.background.brand.secondary-hover}"
@@ -1528,15 +1205,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5576"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary}",
               "default": "{colors.background.brand.secondary}"
@@ -1546,16 +1219,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5583"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -1564,16 +1232,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5582"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.64}",
             "default": "{units.size.64}"
@@ -1585,16 +1248,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6846"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -1603,16 +1261,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6847"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.disabled}",
               "default": "{colors.glyph.onBrand.disabled}"
@@ -1621,16 +1274,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6845"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -1639,16 +1287,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6844"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -1661,15 +1304,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7486"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
               "default": "{colors.text.onBrand.primary}"
@@ -1678,15 +1317,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7487"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.disabled}",
               "default": "{colors.text.onBrand.disabled}"
@@ -1695,15 +1330,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7485"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
               "default": "{colors.text.onBrand.primary}"
@@ -1712,15 +1343,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7484"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
               "default": "{colors.text.onBrand.primary}"
@@ -1735,15 +1362,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2468:91032"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -1752,15 +1375,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2468:91033"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -1769,15 +1388,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2468:91031"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -1786,15 +1401,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2468:91030"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -1808,9 +1419,7 @@
             "com.figma.variableId": "VariableID:2236:5590"
           },
           "$type": "string",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
             "default": "solid"
@@ -1819,16 +1428,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5591"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -1838,15 +1442,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5595"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.active}"
@@ -1855,15 +1455,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5596"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -1872,15 +1468,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5594"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
               "default": "{colors.background.surface.hover}"
@@ -1889,15 +1481,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5593"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -1907,16 +1495,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5600"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -1925,16 +1508,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5599"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.64}",
             "default": "{units.size.64}"
@@ -1946,16 +1524,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6850"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -1964,16 +1537,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6851"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -1982,16 +1550,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6849"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -2000,16 +1563,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2238:6848"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -2022,15 +1580,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7490"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
               "default": "{colors.text.onSurface.link}"
@@ -2039,15 +1593,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7491"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
               "default": "{colors.text.onSurface.link-disabled}"
@@ -2056,15 +1606,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7489"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
               "default": "{colors.text.onSurface.link}"
@@ -2073,15 +1619,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2238:7488"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link}",
               "default": "{colors.text.onSurface.link}"
@@ -2097,16 +1639,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5672"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
             "default": "{units.radius.4}"
@@ -2116,15 +1653,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5664"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.active}"
@@ -2133,15 +1666,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5665"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.transparent}",
               "default": "{colors.background.transparent}"
@@ -2150,15 +1679,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5663"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
               "default": "{colors.background.surface.hover}"
@@ -2167,15 +1692,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2236:5662"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.transparent}",
               "default": "{colors.background.transparent}"
@@ -2185,16 +1706,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5673"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -2203,16 +1719,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5675"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -2224,16 +1735,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2236:5679"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -2242,16 +1748,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2236:5680"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -2260,16 +1761,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2236:5678"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -2278,16 +1774,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2236:5677"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -2297,16 +1788,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5681"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.24}",
             "default": "{units.size.24}"
@@ -2320,15 +1806,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2236:5670"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.transparent}",
               "default": "{colors.border.transparent}"
@@ -2337,15 +1819,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2236:5671"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -2354,15 +1832,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2236:5669"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.transparent}",
               "default": "{colors.border.transparent}"
@@ -2371,15 +1845,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2236:5668"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -2393,9 +1863,7 @@
             "com.figma.variableId": "VariableID:2236:5666"
           },
           "$type": "string",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
             "default": "solid"
@@ -2404,16 +1872,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2236:5667"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -2428,15 +1891,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:3202:1157"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
             "default": "{colors.border.onSurface.border-active}"
@@ -2445,15 +1904,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS"],
             "com.figma.variableId": "VariableID:3202:1154"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
             "default": "{units.radius.4}"
@@ -2462,15 +1917,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT"],
             "com.figma.variableId": "VariableID:3202:1156"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -2479,15 +1930,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:3202:1152"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
             "default": "{colors.background.surface.primary}"
@@ -2496,15 +1943,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:1155"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -2513,15 +1956,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:1151"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -2530,15 +1969,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:1153"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -2552,15 +1987,11 @@
           "color": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:3202:1246"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -2573,15 +2004,11 @@
           "color": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3202:1248"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -2590,15 +2017,11 @@
           "textStyle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3202:1247"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.body.default}",
               "default": "{typography.body.default}"
@@ -2613,15 +2036,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3202:1239"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.active}"
@@ -2630,15 +2049,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3202:1240"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.hover}"
@@ -2647,15 +2062,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3202:1241"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.primary}"
@@ -2665,15 +2076,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:1199"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -2682,15 +2089,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3202:1200"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.40}",
             "default": "{units.size.40}"
@@ -2699,15 +2102,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:1198"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -2716,15 +2115,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:1197"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -2735,15 +2130,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:3202:1187"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
             "default": "{colors.glyph.onSurface.primary}"
@@ -2754,15 +2145,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3202:1244"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.link}",
             "default": "{colors.text.onSurface.link}"
@@ -2775,9 +2162,7 @@
             "com.figma.variableId": "VariableID:3202:1242"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "String value",
             "default": "{typography.body.strong}"
@@ -2790,15 +2175,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:3202:1171"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
             "default": "{colors.border.onSurface.border}"
@@ -2807,16 +2188,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:3202:1172"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -2825,15 +2201,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:1266"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -2842,15 +2214,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:1173"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -2861,15 +2229,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:1163"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -2882,15 +2246,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS"],
             "com.figma.variableId": "VariableID:2542:191"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
             "default": "{units.radius.4}"
@@ -2899,15 +2259,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2542:190"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -2916,15 +2272,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2542:188"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -2933,15 +2285,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2542:194"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -2950,15 +2298,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2542:189"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -2967,15 +2311,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2542:195"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.64}",
             "default": "{units.size.64}"
@@ -2986,15 +2326,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2542:192"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -3009,9 +2345,7 @@
             "com.figma.variableId": "VariableID:2542:193"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
             "default": "{typography.body.strong}"
@@ -3025,15 +2359,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2542:198"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
               "default": "{colors.background.brand.secondary-active}"
@@ -3042,15 +2372,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2542:199"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-disabled}",
               "default": "{colors.background.brand.secondary-disabled}"
@@ -3059,15 +2385,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2542:197"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
               "default": "{colors.background.brand.secondary-hover}"
@@ -3076,15 +2398,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2542:196"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary}",
               "default": "{colors.background.brand.secondary}"
@@ -3096,16 +2414,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2542:200"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
             "default": "{colors.glyph.onBrand.primary}"
@@ -3116,15 +2429,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2542:204"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
             "default": "{colors.text.onBrand.primary}"
@@ -3138,15 +2447,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2542:218"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -3155,15 +2460,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2542:219"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -3172,15 +2473,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2542:217"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -3189,15 +2486,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2542:216"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -3211,9 +2504,7 @@
             "com.figma.variableId": "VariableID:2542:210"
           },
           "$type": "string",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
             "default": "solid"
@@ -3222,15 +2513,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT"],
             "com.figma.variableId": "VariableID:2542:211"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -3240,15 +2527,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2542:214"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.active}"
@@ -3257,15 +2540,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2542:215"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -3274,15 +2553,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2542:213"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
               "default": "{colors.background.surface.hover}"
@@ -3291,15 +2566,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2542:212"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -3312,16 +2583,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2542:222"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -3330,16 +2596,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2542:223"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -3348,16 +2609,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2542:221"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -3366,16 +2622,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2542:220"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -3388,15 +2639,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2542:226"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link}",
               "default": "{colors.text.onSurface.link}"
@@ -3405,15 +2652,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2542:227"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
               "default": "{colors.text.onSurface.link-disabled}"
@@ -3422,15 +2665,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2542:225"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link}",
               "default": "{colors.text.onSurface.link}"
@@ -3439,15 +2678,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2542:224"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link}",
               "default": "{colors.text.onSurface.link}"
@@ -3463,15 +2698,11 @@
         "active": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:3269:2772"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
             "default": "{colors.border.onSurface.border}"
@@ -3480,15 +2711,11 @@
         "focused": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:3269:2773"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
             "default": "{colors.border.onSurface.border}"
@@ -3497,15 +2724,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:3269:2771"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
             "default": "{colors.border.onSurface.border}"
@@ -3514,15 +2737,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:3269:2770"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
             "default": "{colors.border.onSurface.border}"
@@ -3533,15 +2752,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS"],
             "com.figma.variableId": "VariableID:3269:8302"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.8}",
             "default": "{units.radius.8}"
@@ -3550,15 +2765,11 @@
         "borderStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3269:8303"
           },
           "$type": "string",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
             "default": "solid"
@@ -3567,15 +2778,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT"],
             "com.figma.variableId": "VariableID:3269:8351"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -3585,15 +2792,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3297:6379"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.active}"
@@ -3602,15 +2805,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3297:6378"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.hover}"
@@ -3619,15 +2818,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3269:2774"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}"
@@ -3637,15 +2832,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3269:2559"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.64}",
             "default": "{units.size.64}"
@@ -3654,15 +2845,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3269:8304"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
             "default": "{units.gap.16}"
@@ -3671,15 +2858,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3269:8305"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -3690,15 +2873,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3297:6281"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -3709,15 +2888,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3269:8298"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -3726,15 +2901,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3269:8301"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
             "default": "{typography.caption.default}"
@@ -3745,15 +2916,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3297:7246"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.headings.title-accent}",
             "default": "{typography.headings.title-accent}"
@@ -3766,15 +2933,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3297:7249"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.link}",
             "default": "{colors.text.onSurface.link}"
@@ -3788,15 +2951,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3330:1825"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -3805,15 +2964,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3297:7244"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -3829,16 +2984,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:22902"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.2}",
             "default": "{units.radius.2}"
@@ -3847,16 +2997,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:22903"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -3865,16 +3010,11 @@
         "marginY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:22904"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -3883,16 +3023,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:22901"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -3903,16 +3038,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:22896"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -3921,16 +3051,11 @@
         "widthMax": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:22898"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.632}",
             "default": "{units.size.632}"
@@ -3939,16 +3064,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:22897"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -3959,16 +3079,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:22899"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -3977,16 +3092,11 @@
         "widthMax": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2504:22900"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.632}",
             "default": "{units.size.632}"
@@ -3997,15 +3107,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2504:22907"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -4018,9 +3124,7 @@
             "com.figma.variableId": "VariableID:2504:22908"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -4031,15 +3135,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2504:22905"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -4052,9 +3152,7 @@
             "com.figma.variableId": "VariableID:2504:22906"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -4068,15 +3166,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7105"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4085,15 +3179,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7106"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -4102,15 +3192,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7104"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4119,15 +3205,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7103"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4138,15 +3220,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7101"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
               "default": "{colors.background.brand.secondary-active}"
@@ -4155,15 +3233,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7102"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -4172,15 +3246,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7100"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
               "default": "{colors.background.brand.secondary-hover}"
@@ -4189,15 +3259,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7099"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary}",
               "default": "{colors.background.brand.secondary}"
@@ -4210,16 +3276,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2504:22911"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -4228,16 +3289,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2504:22912"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -4246,16 +3302,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2504:22910"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -4264,16 +3315,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2504:22909"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -4288,15 +3334,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7113"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4305,15 +3347,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7114"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -4322,15 +3360,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7112"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4339,15 +3373,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7111"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4358,15 +3388,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7109"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
               "default": "{colors.background.brand.secondary-active}"
@@ -4375,15 +3401,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7110"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -4392,15 +3414,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7108"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
               "default": "{colors.background.brand.secondary-hover}"
@@ -4409,15 +3427,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7107"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary}",
               "default": "{colors.background.brand.secondary}"
@@ -4430,16 +3444,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2504:22915"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -4448,16 +3457,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2504:22916"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -4466,16 +3470,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2504:22914"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -4484,16 +3483,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2504:22913"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -4508,15 +3502,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7097"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4525,15 +3515,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7098"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.divider}",
               "default": "{colors.border.onSurface.divider}"
@@ -4542,15 +3528,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7096"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4559,15 +3541,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2262:7095"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -4578,15 +3556,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7093"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.active}"
@@ -4595,15 +3569,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7094"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -4612,15 +3582,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7092"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
               "default": "{colors.background.surface.hover}"
@@ -4629,15 +3595,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2262:7091"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}"
@@ -4654,15 +3616,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3795:1056"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4671,15 +3629,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3795:1055"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -4688,15 +3642,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3767:4115"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.electricblue.3}",
               "default": "{palette.electricblue.3}"
@@ -4706,15 +3656,11 @@
         "radius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS"],
             "com.figma.variableId": "VariableID:3767:4111"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.12}",
             "default": "{units.radius.12}"
@@ -4723,15 +3669,11 @@
         "style": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3767:4109"
           },
           "$type": "string",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
             "default": "solid"
@@ -4740,15 +3682,11 @@
         "width": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT"],
             "com.figma.variableId": "VariableID:3767:4108"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -4760,15 +3698,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3767:4114"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.active}"
@@ -4777,15 +3711,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3767:4113"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
               "default": "{colors.background.surface.hover}"
@@ -4794,15 +3724,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3767:4112"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -4812,15 +3738,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3767:4119"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -4829,15 +3751,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3767:4104"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.24}",
             "default": "{units.size.24}"
@@ -4846,15 +3764,11 @@
         "marginY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3929:3831"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -4863,15 +3777,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3767:4105"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -4880,15 +3790,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3799:201"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.48}",
             "default": "{units.size.48}"
@@ -4899,15 +3805,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3767:4266"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
             "default": "{colors.glyph.onSurface.primary}"
@@ -4916,15 +3818,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3767:4110"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -4937,15 +3835,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:4090:4824"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.link}",
             "default": "{colors.text.onSurface.link}"
@@ -4954,15 +3848,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:4090:4825"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.link.strong}",
             "default": "{typography.link.strong}"
@@ -4975,15 +3865,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3767:4116"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -4992,14 +3878,10 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ]
+            "com.figma.scopes": ["ALL_SCOPES"]
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -5012,15 +3894,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:4090:12305"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -5029,14 +3907,10 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ]
+            "com.figma.scopes": ["ALL_SCOPES"]
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -5051,15 +3925,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS"],
             "com.figma.variableId": "VariableID:3022:650"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
             "default": "{units.radius.4}"
@@ -5068,15 +3938,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT"],
             "com.figma.variableId": "VariableID:3022:651"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -5086,15 +3952,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3022:664"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -5103,15 +3965,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3022:663"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}"
@@ -5120,15 +3978,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3022:662"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}"
@@ -5138,15 +3992,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3022:646"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -5155,15 +4005,11 @@
         "gapRange": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3105:1377"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -5172,15 +4018,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3022:649"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -5189,15 +4031,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3022:647"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -5206,15 +4044,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3022:648"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -5225,15 +4059,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3022:643"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -5242,15 +4072,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3022:644"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.128}",
             "default": "{units.size.128}"
@@ -5261,15 +4087,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3022:645"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -5281,15 +4103,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:654"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -5298,15 +4116,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:653"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -5315,15 +4129,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:652"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -5333,15 +4143,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3105:1317"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.form-label}",
             "default": "{typography.body.form-label}"
@@ -5353,15 +4159,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:658"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -5370,15 +4172,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:657"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -5387,15 +4185,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:656"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -5405,15 +4199,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3105:1320"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -5424,15 +4214,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3022:655"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
             "default": "{colors.text.onSurface.destructive}"
@@ -5441,15 +4227,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3105:1316"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
             "default": "{typography.caption.default}"
@@ -5461,15 +4243,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3105:1407"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -5478,15 +4256,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3105:1406"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -5495,15 +4269,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:665"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -5513,15 +4283,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3105:1319"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -5533,15 +4299,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:661"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -5550,15 +4312,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:660"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -5567,15 +4325,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:659"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -5585,15 +4339,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3105:1318"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -5607,15 +4357,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3105:1323"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
               "default": "{colors.border.onSurface.border-error}"
@@ -5624,15 +4370,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:676"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
               "default": "{colors.border.onSurface.border-error}"
@@ -5641,15 +4383,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:675"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
               "default": "{colors.border.onSurface.border-error}"
@@ -5661,15 +4399,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3022:679"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
             "default": "{colors.text.onSurface.destructive}"
@@ -5678,15 +4412,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3105:1322"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
             "default": "{typography.caption.default}"
@@ -5698,16 +4428,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:678"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.destructive}",
               "default": "{colors.glyph.onSurface.destructive}"
@@ -5716,16 +4441,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:677"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.destructive}",
               "default": "{colors.glyph.onSurface.destructive}"
@@ -5740,15 +4460,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3075:2661"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -5757,15 +4473,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:668"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -5774,15 +4486,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:667"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -5791,15 +4499,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:666"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -5812,15 +4516,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:674"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -5829,15 +4529,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:673"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -5846,15 +4542,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3022:672"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -5864,15 +4556,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3105:1321"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
             "default": "{typography.caption.default}"
@@ -5884,16 +4572,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:671"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -5902,16 +4585,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:670"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -5920,16 +4598,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3022:669"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -5944,15 +4617,11 @@
       "disabled": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2605:95"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border}",
           "default": "{colors.border.onSurface.border}"
@@ -5961,15 +4630,11 @@
       "hover": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2605:93"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
           "default": "{colors.border.onSurface.border-active}"
@@ -5978,15 +4643,11 @@
       "idle": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2605:92"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border}",
           "default": "{colors.border.onSurface.border}"
@@ -5997,16 +4658,11 @@
       "borderRadius": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "CORNER_RADIUS",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2605:86"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.radius.4}",
           "default": "{units.radius.4}"
@@ -6015,16 +4671,11 @@
       "borderWidth": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_FLOAT",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2605:87"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.stroke.1}",
           "default": "{units.stroke.1}"
@@ -6034,15 +4685,11 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2605:91"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.secondary}",
             "default": "{colors.background.surface.secondary}"
@@ -6051,15 +4698,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2605:89"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
             "default": "{colors.background.surface.primary}"
@@ -6068,15 +4711,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2605:88"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
             "default": "{colors.background.surface.primary}"
@@ -6086,16 +4725,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2605:85"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
           "default": "{units.gap.8}"
@@ -6104,16 +4738,11 @@
       "height": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2605:82"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.32}",
           "default": "{units.size.32}"
@@ -6122,16 +4751,11 @@
       "paddingX": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2605:83"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.12}",
           "default": "{units.gap.12}"
@@ -6140,16 +4764,11 @@
       "paddingY": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2605:84"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
           "default": "{units.gap.4}"
@@ -6160,16 +4779,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2605:115"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
           "default": "{colors.glyph.onSurface.primary}"
@@ -6180,15 +4794,11 @@
       "disabled": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:2605:78"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
           "default": "{colors.text.onSurface.disabled}"
@@ -6197,15 +4807,11 @@
       "hover": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:2605:76"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
           "default": "{colors.text.onSurface.primary}"
@@ -6214,15 +4820,11 @@
       "idle": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:2605:75"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
           "default": "{colors.text.onSurface.primary}"
@@ -6233,16 +4835,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2605:72"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
           "default": "{units.gap.4}"
@@ -6251,16 +4848,11 @@
       "widthMin": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2605:73"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.128}",
           "default": "{units.size.128}"
@@ -6271,16 +4863,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2605:74"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
           "default": "{units.gap.4}"
@@ -6292,16 +4879,11 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2649:11863"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
             "default": "{colors.glyph.onSurface.disabled}"
@@ -6310,16 +4892,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2649:11862"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
             "default": "{colors.glyph.onSurface.primary}"
@@ -6328,16 +4905,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2614:120"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
             "default": "{colors.glyph.onSurface.primary}"
@@ -6353,9 +4925,7 @@
           "com.figma.variableId": "VariableID:2605:79"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.form-label}",
           "default": "{typography.body.form-label}"
@@ -6367,15 +4937,11 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2954:3288"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
             "default": "{colors.text.onSurface.disabled}"
@@ -6384,15 +4950,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2954:3287"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -6401,15 +4963,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2610:121"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -6421,15 +4979,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:2605:80"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
           "default": "{colors.text.onSurface.destructive}"
@@ -6442,9 +4996,7 @@
           "com.figma.variableId": "VariableID:2605:81"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
           "default": "{typography.body.default}"
@@ -6456,15 +5008,11 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2649:11867"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
             "default": "{colors.text.onSurface.disabled}"
@@ -6473,15 +5021,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2649:11866"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -6490,15 +5034,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2610:122"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -6512,9 +5052,7 @@
           "com.figma.variableId": "VariableID:2605:111"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
           "default": "{typography.body.default}"
@@ -6528,15 +5066,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:816"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -6547,15 +5081,11 @@
             "placeholder": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "TEXT_FILL"
-                ],
+                "com.figma.scopes": ["TEXT_FILL"],
                 "com.figma.variableId": "VariableID:3202:828"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
                 "default": "{colors.text.onSurface.secondary}"
@@ -6564,15 +5094,11 @@
             "value": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "TEXT_FILL"
-                ],
+                "com.figma.scopes": ["TEXT_FILL"],
                 "com.figma.variableId": "VariableID:3202:829"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
                 "default": "{colors.text.onSurface.primary}"
@@ -6586,9 +5112,7 @@
               "com.figma.variableId": "VariableID:3202:827"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.body.default}",
               "default": "{typography.body.default}"
@@ -6598,15 +5122,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:814"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -6615,15 +5135,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:815"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -6634,15 +5150,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2634:18031"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
             "default": "{colors.border.onSurface.border-active}"
@@ -6651,15 +5163,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS"],
             "com.figma.variableId": "VariableID:2634:18033"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
             "default": "{units.radius.4}"
@@ -6668,15 +5176,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT"],
             "com.figma.variableId": "VariableID:2634:18032"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -6685,15 +5189,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2634:18030"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
             "default": "{colors.background.surface.primary}"
@@ -6702,15 +5202,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:708"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -6719,15 +5215,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:707"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -6736,15 +5228,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2634:18034"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -6755,15 +5243,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:824"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.8}",
             "default": "{units.gap.8}"
@@ -6772,15 +5256,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:823"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
             "default": "{units.gap.16}"
@@ -6789,15 +5269,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3202:822"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.gap.16}"
@@ -6806,15 +5282,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3202:825"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.128}",
             "default": "{units.size.128}"
@@ -6828,15 +5300,11 @@
           "gap": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP"
-              ],
+              "com.figma.scopes": ["GAP"],
               "com.figma.variableId": "VariableID:3202:916"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
               "default": "{units.gap.8}"
@@ -6845,15 +5313,11 @@
           "height": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "WIDTH_HEIGHT"
-              ],
+              "com.figma.scopes": ["WIDTH_HEIGHT"],
               "com.figma.variableId": "VariableID:2634:18043"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.40}",
               "default": "{units.size.40}"
@@ -6862,15 +5326,11 @@
           "paddingX": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP"
-              ],
+              "com.figma.scopes": ["GAP"],
               "com.figma.variableId": "VariableID:2634:18044"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.12}",
               "default": "{units.gap.12}"
@@ -6879,15 +5339,11 @@
           "paddingY": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP"
-              ],
+              "com.figma.scopes": ["GAP"],
               "com.figma.variableId": "VariableID:2634:18045"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
               "default": "{units.gap.8}"
@@ -6897,15 +5353,11 @@
         "iconChecked": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:3064:21377"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.glyph.onSurface.primary}"
@@ -6914,15 +5366,11 @@
         "iconCollapse": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:3202:923"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.glyph.onSurface.primary}"
@@ -6931,15 +5379,11 @@
         "iconTenant": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:3202:917"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.glyph.onSurface.primary}"
@@ -6949,15 +5393,11 @@
           "color": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2634:18046"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -6971,15 +5411,11 @@
             "disabled": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2634:18054"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.secondary}",
                 "default": "{colors.background.surface.secondary}"
@@ -6988,15 +5424,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2634:18053"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.active}",
                 "default": "{colors.background.surface.active}"
@@ -7005,15 +5437,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2634:18052"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.active}",
                 "default": "{colors.background.surface.active}"
@@ -7028,15 +5456,11 @@
             "disabled": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2634:18051"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.secondary}",
                 "default": "{colors.background.surface.secondary}"
@@ -7045,15 +5469,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2634:18050"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.hover}",
                 "default": "{colors.background.surface.hover}"
@@ -7062,15 +5482,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2634:18049"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.primary}",
                 "default": "{colors.background.surface.primary}"
@@ -7085,15 +5501,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2634:18037"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
             "default": "{colors.border.onSurface.border}"
@@ -7102,16 +5514,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18038"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -7120,15 +5527,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2634:18036"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -7139,15 +5542,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2634:18039"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -7156,15 +5555,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2634:18040"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -7175,15 +5570,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2634:18041"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -7196,9 +5587,7 @@
             "com.figma.variableId": "VariableID:3202:826"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
             "default": "{typography.body.strong}"
@@ -7209,15 +5598,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2634:18042"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -7230,16 +5615,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18013"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
             "default": "{units.radius.4}"
@@ -7248,16 +5628,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18014"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -7267,15 +5642,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2634:18017"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -7284,15 +5655,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2634:18016"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}"
@@ -7301,15 +5668,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2634:18015"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}"
@@ -7319,16 +5682,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18009"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.8}"
@@ -7337,16 +5695,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18012"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -7355,16 +5708,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18010"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -7373,16 +5721,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18011"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -7393,16 +5736,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18002"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -7411,16 +5749,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18003"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.128}",
             "default": "{units.size.128}"
@@ -7431,16 +5764,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2634:18004"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -7452,15 +5780,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2634:18007"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -7469,15 +5793,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2634:18006"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -7486,15 +5806,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2634:18005"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -7508,9 +5824,7 @@
             "com.figma.variableId": "VariableID:2649:11857"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.form-label}",
             "default": "{typography.body.form-label}"
@@ -7522,15 +5836,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2951:3282"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -7539,15 +5849,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2951:3281"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -7556,15 +5862,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2634:18021"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -7576,15 +5878,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2634:18008"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
             "default": "{colors.text.onSurface.destructive}"
@@ -7597,9 +5895,7 @@
             "com.figma.variableId": "VariableID:2649:11858"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -7611,15 +5907,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2649:11869"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -7628,15 +5920,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2649:11868"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -7645,15 +5933,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2634:18022"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -7667,9 +5951,7 @@
             "com.figma.variableId": "VariableID:2649:11861"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -7683,15 +5965,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2634:18028"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
               "default": "{colors.border.onSurface.border-error}"
@@ -7700,15 +5978,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2634:18027"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
               "default": "{colors.border.onSurface.border-error}"
@@ -7720,15 +5994,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2634:18029"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
             "default": "{colors.text.onSurface.destructive}"
@@ -7741,9 +6011,7 @@
             "com.figma.variableId": "VariableID:2649:11860"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
             "default": "{typography.caption.default}"
@@ -7755,15 +6023,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:3299:9036"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.glyph.onSurface.destructive}"
@@ -7772,15 +6036,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:3299:9035"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.glyph.onSurface.destructive}"
@@ -7793,15 +6053,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:2634:18020"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -7810,15 +6066,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:2634:18019"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.destructive}"
@@ -7827,15 +6079,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:2634:18018"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.destructive}"
@@ -7850,15 +6098,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2634:18025"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -7867,15 +6111,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2634:18024"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -7884,15 +6124,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2634:18023"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -7905,15 +6141,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2951:3284"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -7922,15 +6154,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2951:3283"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -7939,15 +6167,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2634:18026"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -7961,9 +6185,7 @@
             "com.figma.variableId": "VariableID:2649:11859"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
             "default": "{typography.caption.default}"
@@ -7975,15 +6197,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:3299:8951"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -7992,15 +6210,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:3299:8950"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -8009,15 +6223,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:3299:8949"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -8030,15 +6240,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:2881:9672"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -8047,15 +6253,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:2881:9671"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -8064,15 +6266,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL"],
               "com.figma.variableId": "VariableID:2881:9670"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -8088,16 +6286,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2289:2867"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
             "default": "{units.radius.4}"
@@ -8106,16 +6299,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2289:2868"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -8125,15 +6313,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2289:2873"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -8142,15 +6326,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2289:2870"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}"
@@ -8159,15 +6339,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2289:2869"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}"
@@ -8177,16 +6353,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2289:2866"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -8195,16 +6366,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2289:2863"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -8213,16 +6379,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2289:2864"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -8231,16 +6392,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2289:2865"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -8251,16 +6407,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2624:92"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
             "default": "{colors.glyph.onSurface.primary}"
@@ -8271,16 +6422,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2289:2852"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -8289,16 +6435,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2289:2853"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.128}",
             "default": "{units.size.128}"
@@ -8309,16 +6450,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2289:2854"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -8330,15 +6466,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2289:2859"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -8347,15 +6479,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2289:2856"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -8364,15 +6492,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2289:2855"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -8386,9 +6510,7 @@
             "com.figma.variableId": "VariableID:2289:2860"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.form-label}",
             "default": "{typography.body.form-label}"
@@ -8400,15 +6522,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2848:680"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.disabled}"
@@ -8417,15 +6535,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2848:679"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -8434,15 +6548,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2289:2914"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -8454,15 +6564,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2289:2861"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
             "default": "{colors.text.onSurface.destructive}"
@@ -8475,9 +6581,7 @@
             "com.figma.variableId": "VariableID:2289:2862"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -8489,15 +6593,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2649:11865"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -8506,15 +6606,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2649:11864"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -8523,15 +6619,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2289:2919"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -8545,9 +6637,7 @@
             "com.figma.variableId": "VariableID:2289:2924"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -8561,15 +6651,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2289:2906"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
               "default": "{colors.border.onSurface.border-error}"
@@ -8578,15 +6664,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2289:2905"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
               "default": "{colors.border.onSurface.border-error}"
@@ -8598,15 +6680,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2289:2910"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
             "default": "{colors.text.onSurface.destructive}"
@@ -8619,9 +6697,7 @@
             "com.figma.variableId": "VariableID:2289:2911"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
             "default": "{typography.caption.default}"
@@ -8635,15 +6711,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2289:2878"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -8652,15 +6724,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2289:2875"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -8669,15 +6737,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2289:2874"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -8690,15 +6754,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2954:3286"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -8707,15 +6767,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2954:3285"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -8724,15 +6780,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2289:2881"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -8746,9 +6798,7 @@
             "com.figma.variableId": "VariableID:2289:2882"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
             "default": "{typography.caption.default}"
@@ -8762,15 +6812,11 @@
       "disabled": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2795:688"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border}",
           "default": "{colors.border.onSurface.border}"
@@ -8779,15 +6825,11 @@
       "focus": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2951:3243"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
           "default": "{colors.border.onSurface.border-active}"
@@ -8796,15 +6838,11 @@
       "hover": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2795:686"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
           "default": "{colors.border.onSurface.border-active}"
@@ -8813,15 +6851,11 @@
       "idle": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2795:685"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border}",
           "default": "{colors.border.onSurface.border}"
@@ -8832,16 +6866,11 @@
       "borderRadius": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "CORNER_RADIUS",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2795:679"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.radius.4}",
           "default": "{units.radius.4}"
@@ -8850,16 +6879,11 @@
       "borderWidth": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_FLOAT",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2795:680"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.stroke.1}",
           "default": "{units.stroke.1}"
@@ -8869,15 +6893,11 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2795:684"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.secondary}",
             "default": "{colors.background.surface.secondary}"
@@ -8886,15 +6906,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2795:682"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
             "default": "{colors.background.surface.primary}"
@@ -8903,15 +6919,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2795:681"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
             "default": "{colors.background.surface.primary}"
@@ -8921,16 +6933,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2795:678"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.12}",
           "default": "{units.gap.12}"
@@ -8939,16 +6946,11 @@
       "heightMin": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2795:675"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.96}",
           "default": "{units.size.96}"
@@ -8957,16 +6959,11 @@
       "paddingX": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2795:676"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.12}",
           "default": "{units.gap.12}"
@@ -8975,16 +6972,11 @@
       "paddingY": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2795:677"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
           "default": "{units.gap.8}"
@@ -8995,16 +6987,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2795:665"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
           "default": "{units.gap.4}"
@@ -9013,16 +7000,11 @@
       "widthMin": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2795:666"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.256}",
           "default": "{units.size.256}"
@@ -9033,16 +7015,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP",
-            "FONT_VARIATIONS"
-          ],
+          "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
           "com.figma.variableId": "VariableID:2795:667"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
           "default": "{units.gap.4}"
@@ -9054,15 +7031,11 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2845:739"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
             "default": "{colors.text.onSurface.disabled}"
@@ -9071,15 +7044,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2845:738"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -9088,15 +7057,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2795:695"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -9110,9 +7075,7 @@
           "com.figma.variableId": "VariableID:2795:696"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.caption.default}",
           "default": "{typography.caption.default}"
@@ -9129,9 +7092,7 @@
               "com.figma.variableId": "VariableID:3689:2477"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
               "default": "{colors.border.onSurface.border-error}"
@@ -9144,9 +7105,7 @@
               "com.figma.variableId": "VariableID:3689:2476"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
               "default": "{colors.border.onSurface.border-error}"
@@ -9162,9 +7121,7 @@
             "com.figma.variableId": "VariableID:3689:2478"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
             "default": "{colors.text.onSurface.destructive}"
@@ -9177,9 +7134,7 @@
             "com.figma.variableId": "VariableID:3689:2479"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
             "default": "{typography.caption.default}"
@@ -9192,15 +7147,11 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2795:671"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
             "default": "{colors.text.onSurface.disabled}"
@@ -9209,15 +7160,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2795:669"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -9226,15 +7173,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2795:668"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -9248,9 +7191,7 @@
           "com.figma.variableId": "VariableID:2795:672"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.form-label}",
           "default": "{typography.body.form-label}"
@@ -9262,15 +7203,11 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2845:737"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
             "default": "{colors.text.onSurface.disabled}"
@@ -9279,15 +7216,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2845:736"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -9296,15 +7229,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2795:689"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -9318,9 +7247,7 @@
           "com.figma.variableId": "VariableID:2818:1200"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
           "default": "{typography.body.default}"
@@ -9331,15 +7258,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:2795:673"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
           "default": "{colors.text.onSurface.destructive}"
@@ -9352,9 +7275,7 @@
           "com.figma.variableId": "VariableID:2795:674"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
           "default": "{typography.body.default}"
@@ -9366,15 +7287,11 @@
         "disabled": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2795:693"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
             "default": "{colors.text.onSurface.disabled}"
@@ -9383,15 +7300,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2795:691"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -9400,15 +7313,11 @@
         "idle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2795:690"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -9422,9 +7331,7 @@
           "com.figma.variableId": "VariableID:2795:694"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
           "default": "{typography.body.default}"
@@ -9436,15 +7343,11 @@
     "color": {
       "active": {
         "$extensions": {
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:3735:859"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
           "default": "{colors.text.onSurface.link-pressed}"
@@ -9452,15 +7355,11 @@
       },
       "disabled": {
         "$extensions": {
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:3735:860"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
           "default": "{colors.text.onSurface.link-disabled}"
@@ -9468,15 +7367,11 @@
       },
       "hover": {
         "$extensions": {
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:3735:858"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
           "default": "{colors.text.onSurface.link-hover}"
@@ -9484,15 +7379,11 @@
       },
       "idle": {
         "$extensions": {
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:3735:857"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.link}",
           "default": "{colors.text.onSurface.link}"
@@ -9502,15 +7393,11 @@
     "container": {
       "gap": {
         "$extensions": {
-          "com.figma.scopes": [
-            "GAP"
-          ],
+          "com.figma.scopes": ["GAP"],
           "com.figma.variableId": "VariableID:3735:874"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
           "default": "{units.gap.4}"
@@ -9518,15 +7405,11 @@
       },
       "height": {
         "$extensions": {
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:3735:873"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.32}",
           "default": "{units.size.32}"
@@ -9542,9 +7425,7 @@
             "com.figma.variableId": "VariableID:3735:874"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
             "default": "{colors.text.onSurface.link-pressed}"
@@ -9557,9 +7438,7 @@
             "com.figma.variableId": "VariableID:3735:865"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
             "default": "{colors.text.onSurface.link-disabled}"
@@ -9572,9 +7451,7 @@
             "com.figma.variableId": "VariableID:3735:863"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
             "default": "{colors.text.onSurface.link-hover}"
@@ -9587,9 +7464,7 @@
             "com.figma.variableId": "VariableID:3735:862"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.link}",
             "default": "{colors.text.onSurface.link}"
@@ -9600,15 +7475,11 @@
     "textDecoration": {
       "active": {
         "$extensions": {
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3735:864"
         },
         "$type": "string",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "none",
           "default": "none"
@@ -9616,15 +7487,11 @@
       },
       "disabled": {
         "$extensions": {
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3735:865"
         },
         "$type": "string",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "none",
           "default": "none"
@@ -9632,15 +7499,11 @@
       },
       "hover": {
         "$extensions": {
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3735:863"
         },
         "$type": "string",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "underline",
           "default": "underline"
@@ -9648,15 +7511,11 @@
       },
       "idle": {
         "$extensions": {
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3735:862"
         },
         "$type": "string",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "none",
           "default": "none"
@@ -9666,15 +7525,11 @@
     "textStyle": {
       "active": {
         "$extensions": {
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3735:871"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.link.strong}",
           "default": "{typography.link.strong}"
@@ -9682,15 +7537,11 @@
       },
       "disabled": {
         "$extensions": {
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3735:872"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.link.strong}",
           "default": "{typography.link.strong}"
@@ -9698,15 +7549,11 @@
       },
       "hover": {
         "$extensions": {
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3735:870"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.link.strong-underline}",
           "default": "{typography.link.strong-underline}"
@@ -9714,15 +7561,11 @@
       },
       "idle": {
         "$extensions": {
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3735:861"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.link.strong}",
           "default": "{typography.link.strong}"
@@ -9736,16 +7579,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2597:1743"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.full}",
             "default": "{units.radius.full}"
@@ -9754,16 +7592,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2597:1744"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -9772,16 +7605,11 @@
         "marginY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2597:1745"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -9790,16 +7618,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2597:1742"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -9810,16 +7633,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2597:1737"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -9828,16 +7646,11 @@
         "widthMax": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2597:1739"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.632}",
             "default": "{units.size.632}"
@@ -9846,16 +7659,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2597:1738"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -9866,16 +7674,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2597:1740"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -9884,16 +7687,11 @@
         "widthMax": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2597:1741"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.632}",
             "default": "{units.size.632}"
@@ -9904,15 +7702,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2597:1747"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -9925,9 +7719,7 @@
             "com.figma.variableId": "VariableID:2597:1749"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -9938,15 +7730,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2597:1746"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -9959,9 +7747,7 @@
             "com.figma.variableId": "VariableID:2597:1748"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -9975,15 +7761,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1764"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -9992,15 +7774,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1765"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -10009,15 +7787,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1763"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -10026,15 +7800,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1762"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -10045,15 +7815,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2597:1760"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
               "default": "{colors.background.brand.secondary-active}"
@@ -10062,15 +7828,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2597:1761"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -10079,15 +7841,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2597:1759"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
               "default": "{colors.background.brand.secondary-hover}"
@@ -10096,15 +7854,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2597:1758"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary}",
               "default": "{colors.background.brand.secondary}"
@@ -10117,16 +7871,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1768"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -10135,16 +7884,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1769"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
               "default": "{colors.glyph.onSurface.disabled}"
@@ -10153,16 +7897,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1767"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -10171,16 +7910,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1766"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
               "default": "{colors.glyph.onBrand.primary}"
@@ -10195,15 +7929,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1756"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -10212,15 +7942,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1757"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.divider}",
               "default": "{colors.border.onSurface.divider}"
@@ -10229,15 +7955,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1755"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
               "default": "{colors.border.onSurface.border-active}"
@@ -10246,15 +7968,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2597:1754"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -10265,15 +7983,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2597:1752"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.active}"
@@ -10282,15 +7996,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2597:1753"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -10299,15 +8009,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2597:1751"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
               "default": "{colors.background.surface.hover}"
@@ -10316,15 +8022,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2597:1750"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
               "default": "{colors.background.surface.primary}"
@@ -10339,15 +8041,11 @@
       "borderRadius": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "CORNER_RADIUS"
-          ],
+          "com.figma.scopes": ["CORNER_RADIUS"],
           "com.figma.variableId": "VariableID:3459:3716"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.radius.4}",
           "default": "{units.radius.4}"
@@ -10356,15 +8054,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "FRAME_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL"],
           "com.figma.variableId": "VariableID:3459:3717"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.background.brand.secondary}",
           "default": "{colors.background.brand.secondary}"
@@ -10373,15 +8067,11 @@
       "height": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:3459:3715"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.32}",
           "default": "{units.size.32}"
@@ -10390,15 +8080,11 @@
       "width": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:3459:3713"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.7}",
           "default": "{units.size.7}"
@@ -10410,15 +8096,11 @@
         "active": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:3459:3712"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
             "default": "{colors.border.onSurface.border-active}"
@@ -10427,15 +8109,11 @@
         "hover": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:3459:3710"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
             "default": "{colors.border.onSurface.border-active}"
@@ -10445,15 +8123,11 @@
       "style": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3459:3709"
         },
         "$type": "string",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "solid",
           "default": "solid"
@@ -10462,15 +8136,11 @@
       "width": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_FLOAT"
-          ],
+          "com.figma.scopes": ["STROKE_FLOAT"],
           "com.figma.variableId": "VariableID:3459:3708"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.stroke.1}",
           "default": "{units.stroke.1}"
@@ -10480,15 +8150,11 @@
     "cursor": {
       "$extensions": {
         "com.figma.hiddenFromPublishing": true,
-        "com.figma.scopes": [
-          "ALL_SCOPES"
-        ],
+        "com.figma.scopes": ["ALL_SCOPES"],
         "com.figma.variableId": "VariableID:3459:3719"
       },
       "$type": "string",
-      "platforms": [
-        "PD"
-      ],
+      "platforms": ["PD"],
       "values": {
         "deep_sky_itkontoret": "ew-resize",
         "default": "ew-resize"
@@ -10500,15 +8166,11 @@
       "active": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:2962:669"
         },
         "$type": "string",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{gradients.ai.active}",
           "default": "{gradients.ai.active}"
@@ -10517,15 +8179,11 @@
       "hover": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:2962:668"
         },
         "$type": "string",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{gradients.ai.hover}",
           "default": "{gradients.ai.hover}"
@@ -10534,15 +8192,11 @@
       "idle": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:2962:667"
         },
         "$type": "string",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{gradients.ai.idle}",
           "default": "{gradients.ai.idle}"
@@ -10553,15 +8207,11 @@
       "borderRadius": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "CORNER_RADIUS"
-          ],
+          "com.figma.scopes": ["CORNER_RADIUS"],
           "com.figma.variableId": "VariableID:2959:657"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.radius.24}",
           "default": "{units.radius.24}"
@@ -10570,15 +8220,11 @@
       "borderStyle": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:2959:656"
         },
         "$type": "string",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "solid",
           "default": "solid"
@@ -10587,15 +8233,11 @@
       "borderWidth": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "STROKE_FLOAT"
-          ],
+          "com.figma.scopes": ["STROKE_FLOAT"],
           "com.figma.variableId": "VariableID:2959:655"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.stroke.2}",
           "default": "{units.stroke.2}"
@@ -10604,15 +8246,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "FRAME_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL"],
           "com.figma.variableId": "VariableID:2962:662"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.background.surface.primary}",
           "default": "{colors.background.surface.primary}"
@@ -10621,15 +8259,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP"
-          ],
+          "com.figma.scopes": ["GAP"],
           "com.figma.variableId": "VariableID:2962:663"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
           "default": "{units.gap.8}"
@@ -10638,15 +8272,11 @@
       "height": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:2959:648"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.48}",
           "default": "{units.size.48}"
@@ -10655,15 +8285,11 @@
       "paddingX": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP"
-          ],
+          "com.figma.scopes": ["GAP"],
           "com.figma.variableId": "VariableID:2959:649"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.16}",
           "default": "{units.gap.16}"
@@ -10672,15 +8298,11 @@
       "width": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:2959:647"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.512}",
           "default": "{units.size.512}"
@@ -10689,15 +8311,11 @@
       "widthMax": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:2984:3908"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.512}",
           "default": "{units.size.512}"
@@ -10706,15 +8324,11 @@
       "widthMin": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:2984:3909"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.256}",
           "default": "{units.size.256}"
@@ -10725,16 +8339,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "SHAPE_FILL",
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2959:658"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.glyph.onStatus.ai}",
           "default": "{colors.glyph.onStatus.ai}"
@@ -10743,15 +8352,11 @@
       "size": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:2959:659"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.16}",
           "default": "{units.size.16}"
@@ -10762,15 +8367,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:2962:660"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onStatus.ai}",
           "default": "{colors.text.onStatus.ai}"
@@ -10779,15 +8380,11 @@
       "textStyle": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:2962:661"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
           "default": "{typography.body.default}"
@@ -10798,15 +8395,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:2962:664"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
           "default": "{colors.text.onSurface.secondary}"
@@ -10815,15 +8408,11 @@
       "textStyle": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:2962:665"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
           "default": "{typography.body.default}"
@@ -10838,16 +8427,11 @@
           "gap": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2463:56486"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
               "default": "{units.gap.8}"
@@ -10856,16 +8440,11 @@
           "height": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "WIDTH_HEIGHT",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2463:56483"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.40}",
               "default": "{units.size.40}"
@@ -10874,16 +8453,11 @@
           "paddingX": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2463:56484"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.16}",
               "default": "{units.gap.16}"
@@ -10892,16 +8466,11 @@
           "paddingY": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2463:56485"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
               "default": "{units.gap.8}"
@@ -10912,16 +8481,11 @@
           "marginT": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2463:56488"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.4}",
               "default": "{units.gap.4}"
@@ -10930,16 +8494,11 @@
           "size": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "WIDTH_HEIGHT",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2463:56487"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.16}",
               "default": "{units.size.16}"
@@ -10954,9 +8513,7 @@
               "com.figma.variableId": "VariableID:2463:56489"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.body.strong}",
               "default": "{typography.body.strong}"
@@ -10970,15 +8527,11 @@
             "active": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2463:56501"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.brand.primary-active}",
                 "default": "{colors.background.brand.primary-active}"
@@ -10987,15 +8540,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2463:56500"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.brand.primary-active}",
                 "default": "{colors.background.brand.primary-active}"
@@ -11004,15 +8553,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2463:56499"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.brand.primary-active}",
                 "default": "{colors.background.brand.primary-active}"
@@ -11025,16 +8570,11 @@
             "active": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "SHAPE_FILL",
-                  "STROKE_COLOR"
-                ],
+                "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
                 "com.figma.variableId": "VariableID:2463:56504"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
                 "default": "{colors.glyph.onBrand.primary}"
@@ -11043,16 +8583,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "SHAPE_FILL",
-                  "STROKE_COLOR"
-                ],
+                "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
                 "com.figma.variableId": "VariableID:2463:56503"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
                 "default": "{colors.glyph.onBrand.primary}"
@@ -11061,16 +8596,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "SHAPE_FILL",
-                  "STROKE_COLOR"
-                ],
+                "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
                 "com.figma.variableId": "VariableID:2463:56502"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onBrand.secondary}",
                 "default": "{colors.glyph.onBrand.primary}"
@@ -11083,15 +8613,11 @@
             "active": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "TEXT_FILL"
-                ],
+                "com.figma.scopes": ["TEXT_FILL"],
                 "com.figma.variableId": "VariableID:2463:56507"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
                 "default": "{colors.text.onBrand.primary}"
@@ -11100,15 +8626,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "TEXT_FILL"
-                ],
+                "com.figma.scopes": ["TEXT_FILL"],
                 "com.figma.variableId": "VariableID:2463:56506"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
                 "default": "{colors.text.onBrand.primary}"
@@ -11117,15 +8639,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "TEXT_FILL"
-                ],
+                "com.figma.scopes": ["TEXT_FILL"],
                 "com.figma.variableId": "VariableID:2463:56505"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
                 "default": "{colors.text.onBrand.primary}"
@@ -11140,15 +8658,11 @@
             "active": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2463:56492"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.brand.primary-hover}",
                 "default": "{colors.background.brand.primary-hover}"
@@ -11157,15 +8671,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2463:56491"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.brand.primary-hover}",
                 "default": "{colors.background.brand.primary-hover}"
@@ -11174,15 +8684,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2463:56490"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.brand.primary}",
                 "default": "{colors.background.brand.primary}"
@@ -11195,16 +8701,11 @@
             "active": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "SHAPE_FILL",
-                  "STROKE_COLOR"
-                ],
+                "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
                 "com.figma.variableId": "VariableID:2463:56495"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
                 "default": "{colors.glyph.onBrand.primary}"
@@ -11213,16 +8714,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "SHAPE_FILL",
-                  "STROKE_COLOR"
-                ],
+                "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
                 "com.figma.variableId": "VariableID:2463:56494"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
                 "default": "{colors.glyph.onBrand.primary}"
@@ -11231,16 +8727,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "SHAPE_FILL",
-                  "STROKE_COLOR"
-                ],
+                "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
                 "com.figma.variableId": "VariableID:2463:56493"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onBrand.secondary}",
                 "default": "{colors.glyph.onBrand.secondary}"
@@ -11253,15 +8744,11 @@
             "active": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "TEXT_FILL"
-                ],
+                "com.figma.scopes": ["TEXT_FILL"],
                 "com.figma.variableId": "VariableID:2463:56498"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
                 "default": "{colors.text.onBrand.primary}"
@@ -11270,15 +8757,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "TEXT_FILL"
-                ],
+                "com.figma.scopes": ["TEXT_FILL"],
                 "com.figma.variableId": "VariableID:2463:56497"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
                 "default": "{colors.text.onBrand.primary}"
@@ -11287,15 +8770,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "TEXT_FILL"
-                ],
+                "com.figma.scopes": ["TEXT_FILL"],
                 "com.figma.variableId": "VariableID:2463:56496"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onBrand.secondary}",
                 "default": "{colors.text.onBrand.secondary}"
@@ -11311,16 +8790,11 @@
           "gap": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2463:56508"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
               "default": "{units.gap.8}"
@@ -11331,16 +8805,11 @@
           "color": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2463:56510"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.secondary}",
               "default": "{colors.glyph.onBrand.secondary}"
@@ -11349,16 +8818,11 @@
           "size": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "WIDTH_HEIGHT",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2463:56509"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.16}",
               "default": "{units.size.16}"
@@ -11369,15 +8833,11 @@
           "color": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2463:56511"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.secondary}",
               "default": "{colors.text.onBrand.secondary}"
@@ -11390,9 +8850,7 @@
               "com.figma.variableId": "VariableID:2463:56512"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.body.default}",
               "default": "{typography.body.default}"
@@ -11406,16 +8864,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56482"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -11426,15 +8879,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2463:56481"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onBrand.border}",
             "default": "{colors.border.onBrand.border}"
@@ -11443,16 +8892,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56480"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -11461,16 +8905,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56479"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -11483,15 +8922,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2463:56467"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.brand.primary}",
             "default": "{colors.background.brand.primary}"
@@ -11502,15 +8937,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2468:67776"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onBrand.border}",
             "default": "{colors.border.onBrand.border}"
@@ -11519,21 +8950,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS",
-              "WIDTH_HEIGHT",
-              "GAP",
-              "STROKE_FLOAT",
-              "EFFECT_FLOAT",
-              "OPACITY",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS", "WIDTH_HEIGHT", "GAP", "STROKE_FLOAT", "EFFECT_FLOAT", "OPACITY", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:67775"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -11544,16 +8965,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56469"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -11564,16 +8980,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2463:56470"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
             "default": "{colors.glyph.onBrand.primary}"
@@ -11584,16 +8995,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56468"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -11606,16 +9012,11 @@
         "width": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56475"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.48}",
             "default": "{units.size.48}"
@@ -11626,16 +9027,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56476"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -11644,16 +9040,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56477"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
             "default": "{units.gap.16}"
@@ -11664,16 +9055,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56478"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -11686,16 +9072,11 @@
         "width": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56471"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.256}",
             "default": "{units.size.256}"
@@ -11706,16 +9087,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56472"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
             "default": "{units.gap.16}"
@@ -11724,16 +9100,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56473"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -11744,16 +9115,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2463:56474"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.48}",
             "default": "{units.size.48}"
@@ -11769,15 +9135,11 @@
           "gap": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP"
-              ],
+              "com.figma.scopes": ["GAP"],
               "com.figma.variableId": "VariableID:2468:145008"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
               "default": "{units.gap.8}"
@@ -11786,15 +9148,11 @@
           "heightMin": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "WIDTH_HEIGHT"
-              ],
+              "com.figma.scopes": ["WIDTH_HEIGHT"],
               "com.figma.variableId": "VariableID:2468:145005"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.40}",
               "default": "{units.size.40}"
@@ -11803,15 +9161,11 @@
           "paddingX": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP"
-              ],
+              "com.figma.scopes": ["GAP"],
               "com.figma.variableId": "VariableID:2468:145006"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.16}",
               "default": "{units.gap.16}"
@@ -11820,15 +9174,11 @@
           "paddingY": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP"
-              ],
+              "com.figma.scopes": ["GAP"],
               "com.figma.variableId": "VariableID:2468:145007"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
               "default": "{units.gap.8}"
@@ -11840,16 +9190,11 @@
             "color": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "SHAPE_FILL",
-                  "STROKE_COLOR"
-                ],
+                "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
                 "com.figma.variableId": "VariableID:2468:145012"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
                 "default": "{colors.glyph.onSurface.primary}"
@@ -11859,15 +9204,11 @@
           "marginT": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP"
-              ],
+              "com.figma.scopes": ["GAP"],
               "com.figma.variableId": "VariableID:2468:145011"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.4}",
               "default": "{units.gap.4}"
@@ -11876,15 +9217,11 @@
           "size": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "WIDTH_HEIGHT"
-              ],
+              "com.figma.scopes": ["WIDTH_HEIGHT"],
               "com.figma.variableId": "VariableID:2468:145010"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.16}",
               "default": "{units.size.16}"
@@ -11896,15 +9233,11 @@
             "color": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "TEXT_FILL"
-                ],
+                "com.figma.scopes": ["TEXT_FILL"],
                 "com.figma.variableId": "VariableID:2468:145015"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
                 "default": "{colors.text.onSurface.primary}"
@@ -11918,9 +9251,7 @@
               "com.figma.variableId": "VariableID:2468:145018"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.body.default}",
               "default": "{typography.body.default}"
@@ -11934,15 +9265,11 @@
             "active": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2468:145024"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.active}",
                 "default": "{colors.background.surface.active}"
@@ -11951,15 +9278,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2468:145023"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.active}",
                 "default": "{colors.background.surface.active}"
@@ -11968,15 +9291,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2468:145022"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.active}",
                 "default": "{colors.background.surface.active}"
@@ -11991,15 +9310,11 @@
             "active": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2468:145021"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.hover}",
                 "default": "{colors.background.surface.hover}"
@@ -12008,15 +9323,11 @@
             "hover": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2468:145020"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.hover}",
                 "default": "{colors.background.surface.hover}"
@@ -12025,15 +9336,11 @@
             "idle": {
               "$extensions": {
                 "com.figma.hiddenFromPublishing": true,
-                "com.figma.scopes": [
-                  "FRAME_FILL"
-                ],
+                "com.figma.scopes": ["FRAME_FILL"],
                 "com.figma.variableId": "VariableID:2468:145019"
               },
               "$type": "color",
-              "platforms": [
-                "PD"
-              ],
+              "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.primary}",
                 "default": "{colors.background.surface.secondary}"
@@ -12049,15 +9356,11 @@
           "gap": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "GAP"
-              ],
+              "com.figma.scopes": ["GAP"],
               "com.figma.variableId": "VariableID:2468:145025"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
               "default": "{units.gap.8}"
@@ -12068,16 +9371,11 @@
           "color": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2468:145027"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -12086,15 +9384,11 @@
           "size": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "WIDTH_HEIGHT"
-              ],
+              "com.figma.scopes": ["WIDTH_HEIGHT"],
               "com.figma.variableId": "VariableID:2468:145026"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.16}",
               "default": "{units.size.16}"
@@ -12105,15 +9399,11 @@
           "color": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:2468:145028"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
               "default": "{colors.text.onSurface.secondary}"
@@ -12126,9 +9416,7 @@
               "com.figma.variableId": "VariableID:2468:145029"
             },
             "$type": "typography",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.body.default}",
               "default": "{typography.body.default}"
@@ -12142,15 +9430,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:145004"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -12161,15 +9445,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:144997"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.0}"
@@ -12180,15 +9460,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2914:13386"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -12197,15 +9473,11 @@
         "minWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2934:5009"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": 36,
             "default": 36
@@ -12214,15 +9486,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:145000"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
             "default": "{units.gap.16}"
@@ -12231,15 +9499,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:145001"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.2}"
@@ -12250,24 +9514,15 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2914:13387"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": {
               "colorSpace": "hsl",
-              "components": [
-                0,
-                0,
-                100
-              ]
+              "components": [0, 0, 100]
             },
             "default": "{colors.glyph.onSurface.primary}"
           }
@@ -12277,15 +9532,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2468:145002"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -12298,9 +9549,7 @@
             "com.figma.variableId": "VariableID:2468:145003"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
             "default": "{typography.body.strong}"
@@ -12313,15 +9562,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2468:144976"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
             "default": "{colors.border.onSurface.border}"
@@ -12330,16 +9575,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:144977"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -12348,15 +9588,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2468:144975"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
             "default": "{colors.background.surface.secondary}"
@@ -12367,15 +9603,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2468:144978"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
             "default": "{colors.border.onSurface.border}"
@@ -12384,16 +9616,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:144979"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -12404,15 +9631,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2931:3817"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
             "default": "{units.gap.16}"
@@ -12421,15 +9644,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2931:3818"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
             "default": "{units.gap.12}"
@@ -12440,15 +9659,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2468:144981"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -12461,9 +9676,7 @@
             "com.figma.variableId": "VariableID:2468:144982"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.headings.title}",
             "default": "{typography.headings.title}"
@@ -12474,16 +9687,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["GAP", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2468:144980"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -12496,15 +9704,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2468:144991"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
             "default": "{colors.text.onSurface.secondary}"
@@ -12517,9 +9721,7 @@
             "com.figma.variableId": "VariableID:2468:144992"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
             "default": "{typography.body.strong}"
@@ -12530,15 +9732,11 @@
         "width": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2468:144986"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.48}",
             "default": "{units.size.48}"
@@ -12549,15 +9747,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:144990"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -12566,15 +9760,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:144989"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
             "default": "{units.gap.16}"
@@ -12585,15 +9775,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:144987"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -12602,15 +9788,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:144988"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
             "default": "{units.gap.16}"
@@ -12621,16 +9803,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2468:144993"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.neutral}",
             "default": "{colors.glyph.onSurface.neutral}"
@@ -12639,15 +9816,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2468:144994"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -12658,15 +9831,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2468:144995"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -12679,9 +9848,7 @@
             "com.figma.variableId": "VariableID:2468:144996"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
             "default": "{typography.body.strong}"
@@ -12694,15 +9861,11 @@
         "width": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2468:144983"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.256}",
             "default": "{units.size.256}"
@@ -12713,15 +9876,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:144984"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
             "default": "{units.gap.16}"
@@ -12730,15 +9889,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2468:144985"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -12754,15 +9909,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2511:141823"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.transparent}",
               "default": "{colors.border.transparent}"
@@ -12771,15 +9922,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2511:141824"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
               "default": "{colors.border.onSurface.border}"
@@ -12788,15 +9935,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2511:141822"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.transparent}",
               "default": "{colors.border.transparent}"
@@ -12805,15 +9948,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["STROKE_COLOR"],
               "com.figma.variableId": "VariableID:2511:141821"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.transparent}",
               "default": "{colors.border.transparent}"
@@ -12823,15 +9962,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS"],
             "com.figma.variableId": "VariableID:2511:141816"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.full}",
             "default": "{units.radius.full}"
@@ -12844,9 +9979,7 @@
             "com.figma.variableId": "VariableID:2511:141820"
           },
           "$type": "string",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
             "default": "solid"
@@ -12855,15 +9988,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT"],
             "com.figma.variableId": "VariableID:2511:141819"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -12872,15 +10001,11 @@
         "height": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2511:141815"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -12889,15 +10014,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2511:141817"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.2}",
             "default": "{units.gap.2}"
@@ -12906,15 +10027,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2511:141818"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.2}",
             "default": "{units.gap.2}"
@@ -12923,15 +10040,11 @@
         "width": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2511:141814"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -12942,15 +10055,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2511:141813"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -12961,15 +10070,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2511:141831"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -12982,9 +10087,7 @@
             "com.figma.variableId": "VariableID:2511:141832"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -12995,15 +10098,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS"],
             "com.figma.variableId": "VariableID:2511:141826"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.full}",
             "default": "{units.radius.full}"
@@ -13013,15 +10112,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2511:141829"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.base}",
               "default": "{palette.base}"
@@ -13030,15 +10125,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2511:141830"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onStatus.disabled}",
               "default": "{colors.glyph.onStatus.disabled}"
@@ -13047,15 +10138,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2511:141828"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.base}",
               "default": "{palette.base}"
@@ -13064,15 +10151,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2511:141827"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.base}",
               "default": "{palette.base}"
@@ -13082,15 +10165,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2511:141825"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.12}",
             "default": "{units.size.12}"
@@ -13104,15 +10183,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2347:137058"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.off}",
               "default": "{colors.background.status.off}"
@@ -13121,15 +10196,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2347:137059"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -13138,15 +10209,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2347:137057"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.off}",
               "default": "{colors.background.status.off}"
@@ -13155,15 +10222,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2347:137056"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.off}",
               "default": "{colors.background.status.off}"
@@ -13178,15 +10241,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2347:137082"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.on}",
               "default": "{colors.background.status.on}"
@@ -13195,15 +10254,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2347:137083"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
               "default": "{colors.background.surface.secondary}"
@@ -13212,15 +10267,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2347:137081"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.on}",
               "default": "{colors.background.status.on}"
@@ -13229,15 +10280,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:2347:137080"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.on}",
               "default": "{colors.background.status.on}"
@@ -13252,15 +10299,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP"
-          ],
+          "com.figma.scopes": ["GAP"],
           "com.figma.variableId": "VariableID:3427:170"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
           "default": "{units.gap.8}"
@@ -13271,15 +10314,11 @@
           "disabled": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3427:173"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
               "default": "{colors.text.onSurface.disabled}"
@@ -13288,15 +10327,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "TEXT_FILL"
-              ],
+              "com.figma.scopes": ["TEXT_FILL"],
               "com.figma.variableId": "VariableID:3427:167"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
               "default": "{colors.text.onSurface.primary}"
@@ -13306,15 +10341,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3427:168"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
             "default": "{typography.body.default}"
@@ -13328,15 +10359,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3427:162"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.active}"
@@ -13345,15 +10372,11 @@
           "hover": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3427:161"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
               "default": "{colors.background.surface.hover}"
@@ -13362,15 +10385,11 @@
           "idle": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:3427:160"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -13380,15 +10399,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3389:2337"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -13398,15 +10413,11 @@
       "gap": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "ALL_SCOPES"
-          ],
+          "com.figma.scopes": ["ALL_SCOPES"],
           "com.figma.variableId": "VariableID:3427:166"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
           "default": "{units.gap.8}"
@@ -13416,15 +10427,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3427:159"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
             "default": "{colors.text.onSurface.primary}"
@@ -13433,15 +10440,11 @@
         "textStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3427:165"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
             "default": "{typography.body.strong}"
@@ -13453,16 +10456,11 @@
           "active": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3427:183"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
               "default": "{colors.glyph.onSurface.primary}"
@@ -13471,16 +10469,11 @@
           "inactive": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "SHAPE_FILL",
-                "STROKE_COLOR"
-              ],
+              "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
               "com.figma.variableId": "VariableID:3427:182"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.neutral}",
               "default": "{colors.glyph.onSurface.neutral}"
@@ -13490,15 +10483,11 @@
         "size": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3447:3616"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -13511,15 +10500,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:3389:2338"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
             "default": "{colors.border.onSurface.border}"
@@ -13528,15 +10513,11 @@
         "borderStyle": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:3389:2341"
           },
           "$type": "string",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
             "default": "solid"
@@ -13545,15 +10526,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT"],
             "com.figma.variableId": "VariableID:3389:2339"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -13562,15 +10539,11 @@
         "minHeight": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:3389:2336"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.40}",
             "default": "{units.size.40}"
@@ -13579,15 +10552,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3502:158"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
             "default": "{units.size.16}"
@@ -13596,15 +10565,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:3427:212"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.8}",
             "default": "{units.size.8}"
@@ -13615,15 +10580,11 @@
         "color": {
           "active": {
             "$extensions": {
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3699:293"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
               "default": "{colors.background.surface.active}"
@@ -13631,15 +10592,11 @@
           },
           "hover": {
             "$extensions": {
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3699:292"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
               "default": "{colors.background.surface.hover}"
@@ -13647,15 +10604,11 @@
           },
           "idle": {
             "$extensions": {
-              "com.figma.scopes": [
-                "ALL_SCOPES"
-              ],
+              "com.figma.scopes": ["ALL_SCOPES"],
               "com.figma.variableId": "VariableID:3699:291"
             },
             "$type": "color",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
               "default": "transparent"
@@ -13671,15 +10624,11 @@
         "borderRadius": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS"],
             "com.figma.variableId": "VariableID:2265:179"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.full}",
             "default": "{units.radius.full}"
@@ -13688,15 +10637,11 @@
         "borderWidth": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_FLOAT"
-            ],
+            "com.figma.scopes": ["STROKE_FLOAT"],
             "com.figma.variableId": "VariableID:2265:180"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
             "default": "{units.stroke.1}"
@@ -13705,15 +10650,11 @@
         "gap": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2265:186"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
             "default": "{units.gap.4}"
@@ -13722,15 +10663,11 @@
         "paddingX": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "GAP"
-            ],
+            "com.figma.scopes": ["GAP"],
             "com.figma.variableId": "VariableID:2265:185"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
             "default": "{units.gap.8}"
@@ -13739,21 +10676,11 @@
         "paddingY": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "CORNER_RADIUS",
-              "WIDTH_HEIGHT",
-              "GAP",
-              "STROKE_FLOAT",
-              "EFFECT_FLOAT",
-              "OPACITY",
-              "FONT_VARIATIONS"
-            ],
+            "com.figma.scopes": ["CORNER_RADIUS", "WIDTH_HEIGHT", "GAP", "STROKE_FLOAT", "EFFECT_FLOAT", "OPACITY", "FONT_VARIATIONS"],
             "com.figma.variableId": "VariableID:2313:42563"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
             "default": "{units.gap.0}"
@@ -13762,15 +10689,11 @@
         "widthMax": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2265:181"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.256}",
             "default": "{units.size.256}"
@@ -13779,15 +10702,11 @@
         "widthMin": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "WIDTH_HEIGHT"
-            ],
+            "com.figma.scopes": ["WIDTH_HEIGHT"],
             "com.figma.variableId": "VariableID:2265:182"
           },
           "$type": "dimension",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
             "default": "{units.size.32}"
@@ -13802,9 +10721,7 @@
             "com.figma.variableId": "VariableID:2265:265"
           },
           "$type": "typography",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.strong}",
             "default": "{typography.caption.strong}"
@@ -13816,15 +10733,11 @@
           "height": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "WIDTH_HEIGHT"
-              ],
+              "com.figma.scopes": ["WIDTH_HEIGHT"],
               "com.figma.variableId": "VariableID:2265:183"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.24}",
               "default": "{units.size.24}"
@@ -13835,15 +10748,11 @@
           "borderWidth": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "STROKE_FLOAT"
-              ],
+              "com.figma.scopes": ["STROKE_FLOAT"],
               "com.figma.variableId": "VariableID:2515:164762"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.stroke.1-6}",
               "default": "{units.stroke.1-6}"
@@ -13852,21 +10761,11 @@
           "size": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "CORNER_RADIUS",
-                "WIDTH_HEIGHT",
-                "GAP",
-                "STROKE_FLOAT",
-                "EFFECT_FLOAT",
-                "OPACITY",
-                "FONT_VARIATIONS"
-              ],
+              "com.figma.scopes": ["CORNER_RADIUS", "WIDTH_HEIGHT", "GAP", "STROKE_FLOAT", "EFFECT_FLOAT", "OPACITY", "FONT_VARIATIONS"],
               "com.figma.variableId": "VariableID:2265:264"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.16}",
               "default": "{units.size.16}"
@@ -13879,15 +10778,11 @@
           "height": {
             "$extensions": {
               "com.figma.hiddenFromPublishing": true,
-              "com.figma.scopes": [
-                "WIDTH_HEIGHT"
-              ],
+              "com.figma.scopes": ["WIDTH_HEIGHT"],
               "com.figma.variableId": "VariableID:2265:184"
             },
             "$type": "dimension",
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.20}",
               "default": "{units.size.20}"
@@ -13905,9 +10800,7 @@
             "com.figma.variableId": "VariableID:2313:42571"
           },
           "$type": "string",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{gradients.ai.idle}",
             "default": "{gradients.ai.idle}"
@@ -13916,15 +10809,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2265:205"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.ai}",
             "default": "{colors.background.status.ai}"
@@ -13935,16 +10824,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:260"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.ai}",
             "default": "{colors.glyph.onStatus.ai}"
@@ -13955,15 +10839,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2265:206"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.ai}",
             "default": "{colors.text.onStatus.ai}"
@@ -13976,15 +10856,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:197"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onStatus.critical}",
             "default": "{colors.border.onStatus.critical}"
@@ -13993,15 +10869,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2265:196"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.critical}",
             "default": "{colors.background.status.critical}"
@@ -14012,16 +10884,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:254"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.critical}",
             "default": "{colors.glyph.onStatus.critical}"
@@ -14032,15 +10899,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2265:198"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.critical}",
             "default": "{colors.text.onStatus.critical}"
@@ -14053,15 +10916,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:200"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onStatus.danger}",
             "default": "{colors.border.onStatus.danger}"
@@ -14070,15 +10929,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2265:199"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.danger}",
             "default": "{colors.background.status.danger}"
@@ -14089,16 +10944,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:256"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.danger}",
             "default": "{colors.glyph.onStatus.danger}"
@@ -14109,15 +10959,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2265:201"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.danger}",
             "default": "{colors.text.onStatus.danger}"
@@ -14130,15 +10976,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:188"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onStatus.info}",
             "default": "{colors.border.onStatus.info}"
@@ -14147,15 +10989,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2265:187"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.info}",
             "default": "{colors.background.status.info}"
@@ -14166,16 +11004,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:249"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.info}",
             "default": "{colors.glyph.onStatus.info}"
@@ -14186,15 +11019,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2265:189"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.info}",
             "default": "{colors.text.onStatus.info}"
@@ -14207,15 +11036,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:203"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onStatus.neutral}",
             "default": "{colors.border.onStatus.neutral}"
@@ -14224,15 +11049,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2265:202"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.neutral}",
             "default": "{colors.background.status.neutral}"
@@ -14243,16 +11064,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:258"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.neutral}",
             "default": "{colors.glyph.onStatus.neutral}"
@@ -14263,15 +11079,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2265:204"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.neutral}",
             "default": "{colors.text.onStatus.neutral}"
@@ -14284,15 +11096,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:191"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onStatus.success}",
             "default": "{colors.border.onStatus.success}"
@@ -14301,15 +11109,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2265:190"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.success}",
             "default": "{colors.background.status.success}"
@@ -14320,16 +11124,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:250"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.success}",
             "default": "{colors.glyph.onStatus.success}"
@@ -14340,15 +11139,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2265:192"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.success}",
             "default": "{colors.text.onStatus.success}"
@@ -14361,15 +11156,11 @@
         "borderColor": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:194"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onStatus.warning}",
             "default": "{colors.border.onStatus.warning}"
@@ -14378,15 +11169,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2265:193"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.warning}",
             "default": "{colors.background.status.warning}"
@@ -14397,16 +11184,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "SHAPE_FILL",
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL", "STROKE_COLOR"],
             "com.figma.variableId": "VariableID:2265:252"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.warning}",
             "default": "{colors.glyph.onStatus.warning}"
@@ -14417,15 +11199,11 @@
         "color": {
           "$extensions": {
             "com.figma.hiddenFromPublishing": true,
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:2265:195"
           },
           "$type": "color",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.warning}",
             "default": "{colors.text.onStatus.warning}"
@@ -14439,15 +11217,11 @@
       "borderRadius": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "CORNER_RADIUS"
-          ],
+          "com.figma.scopes": ["CORNER_RADIUS"],
           "com.figma.variableId": "VariableID:2235:1610"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.radius.4}",
           "default": "{units.radius.4}"
@@ -14456,15 +11230,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "FRAME_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL"],
           "com.figma.variableId": "VariableID:2235:1607"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.background.inverse.primary}",
           "default": "{colors.background.inverse.primary}"
@@ -14473,15 +11243,11 @@
       "paddingX": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP"
-          ],
+          "com.figma.scopes": ["GAP"],
           "com.figma.variableId": "VariableID:2235:1613"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.12}",
           "default": "{units.gap.12}"
@@ -14490,15 +11256,11 @@
       "paddingY": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "GAP"
-          ],
+          "com.figma.scopes": ["GAP"],
           "com.figma.variableId": "VariableID:2235:1614"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
           "default": "{units.gap.8}"
@@ -14507,15 +11269,11 @@
       "widthMax": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:2235:1612"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.256}",
           "default": "{units.size.256}"
@@ -14524,15 +11282,11 @@
       "widthMin": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "WIDTH_HEIGHT"
-          ],
+          "com.figma.scopes": ["WIDTH_HEIGHT"],
           "com.figma.variableId": "VariableID:2235:1611"
         },
         "$type": "dimension",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.48}",
           "default": "{units.size.48}"
@@ -14543,15 +11297,11 @@
       "color": {
         "$extensions": {
           "com.figma.hiddenFromPublishing": true,
-          "com.figma.scopes": [
-            "TEXT_FILL"
-          ],
+          "com.figma.scopes": ["TEXT_FILL"],
           "com.figma.variableId": "VariableID:2235:1608"
         },
         "$type": "color",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onInverse.primary}",
           "default": "{colors.text.onInverse.primary}"
@@ -14564,9 +11314,7 @@
           "com.figma.variableId": "VariableID:2235:1609"
         },
         "$type": "typography",
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.caption.strong}",
           "default": "{typography.caption.strong}"

--- a/packages/design-tokens/tiers/components.json
+++ b/packages/design-tokens/tiers/components.json
@@ -41,7 +41,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.radius.full}",
-              "default": "{units.radius.full}"
+              "default": "{units.radius.full}",
+              "virtuozzo": "{units.radius.full}"
             }
           },
           "borderStyle": {
@@ -54,7 +55,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "solid",
-              "default": "solid"
+              "default": "solid",
+              "virtuozzo": "solid"
             }
           },
           "borderWidth": {
@@ -67,7 +69,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.stroke.2}",
-              "default": "{units.stroke.2}"
+              "default": "{units.stroke.2}",
+              "virtuozzo": "{units.stroke.2}"
             }
           },
           "color": {
@@ -80,7 +83,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.base}",
-              "default": "{palette.base}"
+              "default": "{palette.base}",
+              "virtuozzo": "{palette.base}"
             }
           }
         },
@@ -95,7 +99,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.neg-6}",
-              "default": "{units.gap.neg-6}"
+              "default": "{units.gap.neg-6}",
+              "virtuozzo": "{units.gap.neg-6}"
             }
           }
         },
@@ -109,7 +114,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
-            "default": "{units.size.32}"
+            "default": "{units.size.32}",
+            "virtuozzo": "{units.size.32}"
           }
         }
       },
@@ -124,7 +130,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         }
       },
@@ -139,7 +146,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.strong}",
-            "default": "{typography.caption.strong}"
+            "default": "{typography.caption.strong}",
+            "virtuozzo": "{typography.caption.strong}"
           }
         }
       },
@@ -154,7 +162,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.text.onSurface.primary}"
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -167,7 +176,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
-            "default": "{typography.body.default}"
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
           }
         }
       }
@@ -183,7 +193,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.orange.3}",
-          "default": "{palette.orange.3}"
+          "default": "{palette.orange.3}",
+          "virtuozzo": "{palette.orange.3}"
         }
       },
       "red": {
@@ -196,7 +207,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.red.3}",
-          "default": "{palette.red.3}"
+          "default": "{palette.red.3}",
+          "virtuozzo": "{palette.red.3}"
         }
       },
       "teal": {
@@ -209,7 +221,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.teal.3}",
-          "default": "{palette.teal.3}"
+          "default": "{palette.teal.3}",
+          "virtuozzo": "{palette.teal.3}"
         }
       },
       "violet": {
@@ -222,7 +235,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.violet.3}",
-          "default": "{palette.violet.3}"
+          "default": "{palette.violet.3}",
+          "virtuozzo": "{palette.violet.3}"
         }
       },
       "yellow": {
@@ -235,7 +249,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.yellow.3}",
-          "default": "{palette.yellow.3}"
+          "default": "{palette.yellow.3}",
+          "virtuozzo": "{palette.yellow.3}"
         }
       }
     },
@@ -251,7 +266,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.11}",
-            "default": "{palette.orange.11}"
+            "default": "{palette.orange.11}",
+            "virtuozzo": "{palette.orange.11}"
           }
         },
         "red": {
@@ -264,7 +280,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.11}",
-            "default": "{palette.red.11}"
+            "default": "{palette.red.11}",
+            "virtuozzo": "{palette.red.11}"
           }
         },
         "teal": {
@@ -277,7 +294,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.teal.11}",
-            "default": "{palette.teal.11}"
+            "default": "{palette.teal.11}",
+            "virtuozzo": "{palette.teal.11}"
           }
         },
         "violet": {
@@ -290,7 +308,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.11}",
-            "default": "{palette.violet.11}"
+            "default": "{palette.violet.11}",
+            "virtuozzo": "{palette.violet.11}"
           }
         },
         "yellow": {
@@ -303,7 +322,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.11}",
-            "default": "{palette.yellow.11}"
+            "default": "{palette.yellow.11}",
+            "virtuozzo": "{palette.yellow.11}"
           }
         }
       }
@@ -323,7 +343,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           },
           "hover": {
@@ -336,7 +357,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           },
           "idle": {
@@ -349,7 +371,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.text.onSurface.secondary}"
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
             }
           }
         },
@@ -363,7 +386,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.link.default}",
-            "default": "{typography.link.default}"
+            "default": "{typography.link.default}",
+            "virtuozzo": "{typography.link.default}"
           }
         }
       }
@@ -380,7 +404,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.text.onSurface.primary}"
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -393,7 +418,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
-            "default": "{typography.body.default}"
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
           }
         }
       }
@@ -410,7 +436,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.neutral}",
-            "default": "{colors.glyph.onSurface.neutral}"
+            "default": "{colors.glyph.onSurface.neutral}",
+            "virtuozzo": "{colors.glyph.onSurface.neutral}"
           }
         },
         "size": {
@@ -423,7 +450,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
-            "default": "{units.size.16}"
+            "default": "{units.size.16}",
+            "virtuozzo": "{units.size.16}"
           }
         }
       }
@@ -439,7 +467,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
-          "default": "{units.gap.4}"
+          "default": "{units.gap.4}",
+          "virtuozzo": "{units.gap.4}"
         }
       }
     }
@@ -457,7 +486,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
-            "default": "{units.radius.4}"
+            "default": "{units.radius.4}",
+            "virtuozzo": "{units.radius.4}"
           }
         },
         "gap": {
@@ -470,7 +500,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         },
         "height": {
@@ -483,7 +514,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
-            "default": "{units.size.32}"
+            "default": "{units.size.32}",
+            "virtuozzo": "{units.size.32}"
           }
         },
         "paddingY": {
@@ -496,7 +528,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         }
       },
@@ -511,7 +544,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
-            "default": "{units.size.16}"
+            "default": "{units.size.16}",
+            "virtuozzo": "{units.size.16}"
           }
         }
       },
@@ -526,7 +560,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
-            "default": "{typography.body.strong}"
+            "default": "{typography.body.strong}",
+            "virtuozzo": "{typography.body.strong}"
           }
         }
       }
@@ -544,7 +579,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{gradients.ai.active}",
-              "default": "{gradients.ai.active}"
+              "default": "{gradients.ai.active}",
+              "virtuozzo": "{gradients.ai.active}"
             }
           },
           "disabled": {
@@ -557,7 +593,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{gradients.ai.disabled}",
-              "default": "{gradients.ai.disabled}"
+              "default": "{gradients.ai.disabled}",
+              "virtuozzo": "{gradients.ai.disabled}"
             }
           },
           "hover": {
@@ -570,7 +607,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{gradients.ai.hover}",
-              "default": "{gradients.ai.hover}"
+              "default": "{gradients.ai.hover}",
+              "virtuozzo": "{gradients.ai.hover}"
             }
           },
           "idle": {
@@ -583,7 +621,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{gradients.ai.idle}",
-              "default": "{gradients.ai.idle}"
+              "default": "{gradients.ai.idle}",
+              "virtuozzo": "{gradients.ai.idle}"
             }
           }
         },
@@ -597,7 +636,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
-            "default": "{units.gap.12}"
+            "default": "{units.gap.12}",
+            "virtuozzo": "{units.gap.12}"
           }
         },
         "widthMin": {
@@ -610,7 +650,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.64}",
-            "default": "{units.size.64}"
+            "default": "{units.size.64}",
+            "virtuozzo": "{units.size.64}"
           }
         }
       },
@@ -626,7 +667,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           },
           "disabled": {
@@ -639,7 +681,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           },
           "hover": {
@@ -652,7 +695,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           },
           "idle": {
@@ -665,7 +709,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           }
         }
@@ -682,7 +727,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
-              "default": "{colors.text.onBrand.primary}"
+              "default": "{colors.text.onBrand.primary}",
+              "virtuozzo": "{colors.text.onBrand.primary}"
             }
           },
           "disabled": {
@@ -695,7 +741,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.disabled}",
-              "default": "{colors.text.onBrand.disabled}"
+              "default": "{colors.text.onBrand.disabled}",
+              "virtuozzo": "{colors.text.onBrand.primary}"
             }
           },
           "hover": {
@@ -708,7 +755,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
-              "default": "{colors.text.onBrand.primary}"
+              "default": "{colors.text.onBrand.primary}",
+              "virtuozzo": "{colors.text.onBrand.primary}"
             }
           },
           "idle": {
@@ -721,7 +769,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
-              "default": "{colors.text.onBrand.primary}"
+              "default": "{colors.text.onBrand.primary}",
+              "virtuozzo": "{colors.text.onBrand.primary}"
             }
           }
         }
@@ -740,7 +789,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.statusStrong.danger-pressed}",
-              "default": "{colors.background.statusStrong.danger-pressed}"
+              "default": "{colors.background.statusStrong.danger-pressed}",
+              "virtuozzo": "{colors.background.statusStrong.danger-pressed}"
             }
           },
           "disabled": {
@@ -753,7 +803,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.danger}",
-              "default": "{colors.background.status.danger}"
+              "default": "{colors.background.status.danger}",
+              "virtuozzo": "{colors.background.status.danger}"
             }
           },
           "hover": {
@@ -766,7 +817,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.statusStrong.danger-hover}",
-              "default": "{colors.background.statusStrong.danger-hover}"
+              "default": "{colors.background.statusStrong.danger-hover}",
+              "virtuozzo": "{colors.background.statusStrong.danger-hover}"
             }
           },
           "idle": {
@@ -779,7 +831,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.statusStrong.danger}",
-              "default": "{colors.background.statusStrong.danger}"
+              "default": "{colors.background.statusStrong.danger}",
+              "virtuozzo": "{colors.background.statusStrong.danger}"
             }
           }
         },
@@ -793,7 +846,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
-            "default": "{units.gap.12}"
+            "default": "{units.gap.12}",
+            "virtuozzo": "{units.gap.12}"
           }
         },
         "widthMin": {
@@ -806,7 +860,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.64}",
-            "default": "{units.size.64}"
+            "default": "{units.size.64}",
+            "virtuozzo": "{units.size.64}"
           }
         }
       },
@@ -822,7 +877,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onInverse.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           },
           "disabled": {
@@ -835,7 +891,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onInverse.primary}",
-              "default": "{colors.glyph.onBrand.disabled}"
+              "default": "{colors.glyph.onBrand.disabled}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           },
           "hover": {
@@ -848,7 +905,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onInverse.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           },
           "idle": {
@@ -861,7 +919,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onInverse.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           }
         }
@@ -878,7 +937,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onInverse.primary}",
-              "default": "{colors.text.onBrand.primary}"
+              "default": "{colors.text.onBrand.primary}",
+              "virtuozzo": "{colors.text.onBrand.primary}"
             }
           },
           "disabled": {
@@ -891,7 +951,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.disabled}",
-              "default": "{colors.text.onBrand.disabled}"
+              "default": "{colors.text.onBrand.disabled}",
+              "virtuozzo": "{colors.text.onBrand.primary}"
             }
           },
           "hover": {
@@ -904,7 +965,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onInverse.primary}",
-              "default": "{colors.text.onBrand.primary}"
+              "default": "{colors.text.onBrand.primary}",
+              "virtuozzo": "{colors.text.onBrand.primary}"
             }
           },
           "idle": {
@@ -917,7 +979,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onInverse.primary}",
-              "default": "{colors.text.onBrand.primary}"
+              "default": "{colors.text.onBrand.primary}",
+              "virtuozzo": "{colors.text.onBrand.primary}"
             }
           }
         }
@@ -935,7 +998,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         }
       },
@@ -951,7 +1015,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           },
           "disabled": {
@@ -964,7 +1029,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
-              "default": "{colors.glyph.onSurface.disabled}"
+              "default": "{colors.glyph.onSurface.disabled}",
+              "virtuozzo": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -977,7 +1043,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           },
           "idle": {
@@ -990,7 +1057,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           }
         }
@@ -1007,7 +1075,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
-              "default": "{colors.text.onSurface.link-pressed}"
+              "default": "{colors.text.onSurface.link-pressed}",
+              "virtuozzo": "{colors.text.onSurface.link-pressed}"
             }
           },
           "disabled": {
@@ -1020,7 +1089,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
-              "default": "{colors.text.onSurface.link-disabled}"
+              "default": "{colors.text.onSurface.link-disabled}",
+              "virtuozzo": "{colors.text.onSurface.link-disabled}"
             }
           },
           "hover": {
@@ -1033,7 +1103,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
-              "default": "{colors.text.onSurface.link-hover}"
+              "default": "{colors.text.onSurface.link-hover}",
+              "virtuozzo": "{colors.text.onSurface.link-hover}"
             }
           },
           "idle": {
@@ -1046,7 +1117,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-              "default": "{colors.text.onSurface.link}"
+              "default": "{colors.text.onSurface.link}",
+              "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           }
         },
@@ -1061,7 +1133,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "none",
-              "default": "none"
+              "default": "none",
+              "virtuozzo": "none"
             }
           },
           "disabled": {
@@ -1074,7 +1147,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "none",
-              "default": "none"
+              "default": "none",
+              "virtuozzo": "none"
             }
           },
           "hover": {
@@ -1087,7 +1161,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "underline",
-              "default": "underline"
+              "default": "underline",
+              "virtuozzo": "underline"
             }
           },
           "idle": {
@@ -1100,7 +1175,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "none",
-              "default": "none"
+              "default": "none",
+              "virtuozzo": "none"
             }
           }
         },
@@ -1115,7 +1191,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.link.strong}",
-              "default": "{typography.link.strong}"
+              "default": "{typography.link.strong}",
+              "virtuozzo": "{typography.link.strong}"
             }
           },
           "disabled": {
@@ -1128,7 +1205,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.link.strong}",
-              "default": "{typography.link.strong}"
+              "default": "{typography.link.strong}",
+              "virtuozzo": "{typography.link.strong}"
             }
           },
           "hover": {
@@ -1141,7 +1219,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.link.strong-underline}",
-              "default": "{typography.link.strong-underline}"
+              "default": "{typography.link.strong-underline}",
+              "virtuozzo": "{typography.link.strong-underline}"
             }
           },
           "idle": {
@@ -1154,7 +1233,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.link.strong}",
-              "default": "{typography.link.strong}"
+              "default": "{typography.link.strong}",
+              "virtuozzo": "{typography.link.strong}"
             }
           }
         }
@@ -1173,7 +1253,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
-              "default": "{colors.background.brand.secondary-active}"
+              "default": "{colors.background.brand.secondary-active}",
+              "virtuozzo": "{colors.background.brand.secondary-active}"
             }
           },
           "disabled": {
@@ -1186,7 +1267,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-disabled}",
-              "default": "{colors.background.brand.secondary-disabled}"
+              "default": "{colors.background.brand.secondary-disabled}",
+              "virtuozzo": "{colors.background.brand.secondary-disabled}"
             }
           },
           "hover": {
@@ -1199,7 +1281,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
-              "default": "{colors.background.brand.secondary-hover}"
+              "default": "{colors.background.brand.secondary-hover}",
+              "virtuozzo": "{colors.background.brand.secondary-hover}"
             }
           },
           "idle": {
@@ -1212,7 +1295,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary}",
-              "default": "{colors.background.brand.secondary}"
+              "default": "{colors.background.brand.secondary}",
+              "virtuozzo": "{colors.background.brand.secondary}"
             }
           }
         },
@@ -1226,7 +1310,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
-            "default": "{units.gap.12}"
+            "default": "{units.gap.12}",
+            "virtuozzo": "{units.gap.12}"
           }
         },
         "widthMin": {
@@ -1239,7 +1324,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.64}",
-            "default": "{units.size.64}"
+            "default": "{units.size.64}",
+            "virtuozzo": "{units.size.64}"
           }
         }
       },
@@ -1255,7 +1341,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           },
           "disabled": {
@@ -1268,7 +1355,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.disabled}",
-              "default": "{colors.glyph.onBrand.disabled}"
+              "default": "{colors.glyph.onBrand.disabled}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           },
           "hover": {
@@ -1281,7 +1369,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           },
           "idle": {
@@ -1294,7 +1383,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           }
         }
@@ -1311,7 +1401,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
-              "default": "{colors.text.onBrand.primary}"
+              "default": "{colors.text.onBrand.primary}",
+              "virtuozzo": "{colors.text.onBrand.primary}"
             }
           },
           "disabled": {
@@ -1324,7 +1415,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.disabled}",
-              "default": "{colors.text.onBrand.disabled}"
+              "default": "{colors.text.onBrand.disabled}",
+              "virtuozzo": "{colors.text.onBrand.primary}"
             }
           },
           "hover": {
@@ -1337,7 +1429,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
-              "default": "{colors.text.onBrand.primary}"
+              "default": "{colors.text.onBrand.primary}",
+              "virtuozzo": "{colors.text.onBrand.primary}"
             }
           },
           "idle": {
@@ -1350,7 +1443,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
-              "default": "{colors.text.onBrand.primary}"
+              "default": "{colors.text.onBrand.primary}",
+              "virtuozzo": "{colors.text.onBrand.primary}"
             }
           }
         }
@@ -1369,7 +1463,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
-              "default": "transparent"
+              "default": "transparent",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "disabled": {
@@ -1382,7 +1477,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}"
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{palette.grayscale.3}"
             }
           },
           "hover": {
@@ -1395,7 +1491,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
-              "default": "transparent"
+              "default": "transparent",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -1408,7 +1505,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}"
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{palette.grayscale.3}"
             }
           }
         },
@@ -1422,7 +1520,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
-            "default": "solid"
+            "default": "solid",
+            "virtuozzo": "solid"
           }
         },
         "borderWidth": {
@@ -1435,7 +1534,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         },
         "color": {
@@ -1449,7 +1549,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
-              "default": "{colors.background.surface.active}"
+              "default": "{colors.background.surface.active}",
+              "virtuozzo": "{colors.background.surface.active}"
             }
           },
           "disabled": {
@@ -1462,7 +1563,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
-              "default": "transparent"
+              "default": "transparent",
+              "virtuozzo": "transparent"
             }
           },
           "hover": {
@@ -1475,7 +1577,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
-              "default": "{colors.background.surface.hover}"
+              "default": "{colors.background.surface.hover}",
+              "virtuozzo": "{colors.background.surface.hover}"
             }
           },
           "idle": {
@@ -1488,7 +1591,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
-              "default": "transparent"
+              "default": "transparent",
+              "virtuozzo": "transparent"
             }
           }
         },
@@ -1502,7 +1606,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
-            "default": "{units.gap.12}"
+            "default": "{units.gap.12}",
+            "virtuozzo": "{units.gap.12}"
           }
         },
         "widthMin": {
@@ -1515,7 +1620,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.64}",
-            "default": "{units.size.64}"
+            "default": "{units.size.64}",
+            "virtuozzo": "{units.size.64}"
           }
         }
       },
@@ -1531,7 +1637,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           },
           "disabled": {
@@ -1544,7 +1651,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
-              "default": "{colors.glyph.onSurface.disabled}"
+              "default": "{colors.glyph.onSurface.disabled}",
+              "virtuozzo": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -1557,7 +1665,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           },
           "idle": {
@@ -1570,7 +1679,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           }
         }
@@ -1587,7 +1697,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-pressed}",
-              "default": "{colors.text.onSurface.link}"
+              "default": "{colors.text.onSurface.link}",
+              "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           },
           "disabled": {
@@ -1600,7 +1711,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
-              "default": "{colors.text.onSurface.link-disabled}"
+              "default": "{colors.text.onSurface.link-disabled}",
+              "virtuozzo": "{colors.text.onSurface.link-disabled}"
             }
           },
           "hover": {
@@ -1613,7 +1725,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-hover}",
-              "default": "{colors.text.onSurface.link}"
+              "default": "{colors.text.onSurface.link}",
+              "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           },
           "idle": {
@@ -1626,7 +1739,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-              "default": "{colors.text.onSurface.link}"
+              "default": "{colors.text.onSurface.link}",
+              "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           }
         }
@@ -1842,7 +1956,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
-            "default": "{units.radius.4}"
+            "default": "{units.radius.4}",
+            "virtuozzo": "{units.radius.4}"
           }
         },
         "color": {
@@ -1856,7 +1971,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
-              "default": "{colors.background.surface.active}"
+              "default": "{colors.background.surface.active}",
+              "virtuozzo": "{colors.background.surface.active}"
             }
           },
           "disabled": {
@@ -1869,7 +1985,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.transparent}",
-              "default": "{colors.background.transparent}"
+              "default": "{colors.background.transparent}",
+              "virtuozzo": "{colors.background.transparent}"
             }
           },
           "hover": {
@@ -1882,7 +1999,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
-              "default": "{colors.background.surface.hover}"
+              "default": "{colors.background.surface.hover}",
+              "virtuozzo": "{colors.background.surface.hover}"
             }
           },
           "idle": {
@@ -1895,7 +2013,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.transparent}",
-              "default": "{colors.background.transparent}"
+              "default": "{colors.background.transparent}",
+              "virtuozzo": "{colors.background.transparent}"
             }
           }
         },
@@ -1909,7 +2028,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
-            "default": "{units.size.32}"
+            "default": "{units.size.32}",
+            "virtuozzo": "{units.size.32}"
           }
         },
         "paddingX": {
@@ -1922,7 +2042,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
-            "default": "{units.gap.4}"
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
           }
         },
         "paddingY": {
@@ -1966,7 +2087,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           },
           "disabled": {
@@ -1979,7 +2101,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
-              "default": "{colors.glyph.onSurface.disabled}"
+              "default": "{colors.glyph.onSurface.disabled}",
+              "virtuozzo": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -1992,7 +2115,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           },
           "idle": {
@@ -2005,7 +2129,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           }
         },
@@ -2019,7 +2144,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.24}",
-            "default": "{units.size.24}"
+            "default": "{units.size.24}",
+            "virtuozzo": "{units.size.16}"
           }
         }
       }
@@ -2037,7 +2163,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.transparent}",
-              "default": "{colors.border.transparent}"
+              "default": "{colors.border.transparent}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "disabled": {
@@ -2050,7 +2177,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}"
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{palette.grayscale.3}"
             }
           },
           "hover": {
@@ -2063,7 +2191,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.transparent}",
-              "default": "{colors.border.transparent}"
+              "default": "{colors.border.transparent}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -2076,7 +2205,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}"
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{palette.grayscale.3}"
             }
           }
         },
@@ -2090,7 +2220,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
-            "default": "solid"
+            "default": "solid",
+            "virtuozzo": "solid"
           }
         },
         "borderWidth": {
@@ -2103,7 +2234,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         }
       }
@@ -2456,7 +2588,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-            "default": "{colors.border.onSurface.border-active}"
+            "default": "{colors.border.onSurface.border-active}",
+            "virtuozzo": "{colors.border.onSurface.border-active}"
           }
         },
         "borderRadius": {
@@ -2469,7 +2602,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
-            "default": "{units.radius.4}"
+            "default": "{units.radius.4}",
+            "virtuozzo": "{units.radius.4}"
           }
         },
         "borderWidth": {
@@ -2482,7 +2616,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         },
         "color": {
@@ -2495,7 +2630,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
-            "default": "{colors.background.surface.primary}"
+            "default": "{colors.background.surface.primary}",
+            "virtuozzo": "{colors.background.surface.primary}"
           }
         },
         "gap": {
@@ -2508,7 +2644,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         },
         "paddingX": {
@@ -2521,7 +2658,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         },
         "paddingY": {
@@ -2534,7 +2672,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         },
         "widthMin": {
@@ -2566,7 +2705,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           }
         }
@@ -2583,7 +2723,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.text.onSurface.secondary}"
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
             }
           },
           "textStyle": {
@@ -2596,7 +2737,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.body.default}",
-              "default": "{typography.body.default}"
+              "default": "{typography.body.default}",
+              "virtuozzo": "{typography.body.default}"
             }
           }
         }
@@ -2615,7 +2757,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
-              "default": "{colors.background.surface.active}"
+              "default": "{colors.background.surface.active}",
+              "virtuozzo": "{colors.background.surface.active}"
             }
           },
           "hover": {
@@ -2628,7 +2771,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
-              "default": "{colors.background.surface.hover}"
+              "default": "{colors.background.surface.hover}",
+              "virtuozzo": "{colors.background.surface.hover}"
             }
           },
           "idle": {
@@ -2641,7 +2785,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
-              "default": "{colors.background.surface.primary}"
+              "default": "{colors.background.surface.primary}",
+              "virtuozzo": "{colors.background.surface.primary}"
             }
           }
         },
@@ -2655,7 +2800,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         },
         "height": {
@@ -2668,7 +2814,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.40}",
-            "default": "{units.size.40}"
+            "default": "{units.size.40}",
+            "virtuozzo": "{units.size.40}"
           }
         },
         "paddingX": {
@@ -2681,7 +2828,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
-            "default": "{units.gap.12}"
+            "default": "{units.gap.12}",
+            "virtuozzo": "{units.gap.12}"
           }
         },
         "paddingY": {
@@ -2694,7 +2842,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         }
       },
@@ -2709,7 +2858,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-            "default": "{colors.glyph.onSurface.primary}"
+            "default": "{colors.glyph.onSurface.primary}",
+            "virtuozzo": "{colors.glyph.onSurface.primary}"
           }
         }
       },
@@ -2724,7 +2874,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-            "default": "{colors.text.onSurface.link}"
+            "default": "{colors.text.onSurface.link}",
+            "virtuozzo": "{colors.text.onSurface.link-idle}"
           }
         },
         "textStyle": {
@@ -2737,7 +2888,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "String value",
-            "default": "{typography.body.strong}"
+            "default": "{typography.body.strong}",
+            "virtuozzo": "{typography.body.strong}"
           }
         }
       }
@@ -2754,7 +2906,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-            "default": "{colors.border.onSurface.border}"
+            "default": "{colors.border.onSurface.border}",
+            "virtuozzo": "{colors.border.onSurface.border}"
           }
         },
         "borderWidth": {
@@ -2767,7 +2920,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         },
         "paddingX": {
@@ -2780,7 +2934,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         },
         "paddingY": {
@@ -2793,7 +2948,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.8}"
           }
         }
       },
@@ -2808,7 +2964,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         }
       }
@@ -2825,7 +2982,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
-            "default": "{units.radius.4}"
+            "default": "{units.radius.4}",
+            "virtuozzo": "{units.radius.4}"
           }
         },
         "gap": {
@@ -2838,7 +2996,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         },
         "height": {
@@ -2851,7 +3010,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
-            "default": "{units.size.32}"
+            "default": "{units.size.32}",
+            "virtuozzo": "{units.size.32}"
           }
         },
         "paddingX": {
@@ -2864,7 +3024,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
-            "default": "{units.gap.12}"
+            "default": "{units.gap.12}",
+            "virtuozzo": "{units.gap.12}"
           }
         },
         "paddingY": {
@@ -2877,7 +3038,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         },
         "widthMin": {
@@ -2890,7 +3052,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.64}",
-            "default": "{units.size.64}"
+            "default": "{units.size.64}",
+            "virtuozzo": "{units.size.64}"
           }
         }
       },
@@ -2905,7 +3068,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
-            "default": "{units.size.16}"
+            "default": "{units.size.16}",
+            "virtuozzo": "{units.size.16}"
           }
         }
       },
@@ -2920,7 +3084,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
-            "default": "{typography.body.strong}"
+            "default": "{typography.body.strong}",
+            "virtuozzo": "{typography.body.strong}"
           }
         }
       }
@@ -2938,7 +3103,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
-              "default": "{colors.background.brand.secondary-active}"
+              "default": "{colors.background.brand.secondary-active}",
+              "virtuozzo": "{colors.background.brand.secondary-active}"
             }
           },
           "disabled": {
@@ -2951,7 +3117,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-disabled}",
-              "default": "{colors.background.brand.secondary-disabled}"
+              "default": "{colors.background.brand.secondary-disabled}",
+              "virtuozzo": "{colors.background.brand.secondary-disabled}"
             }
           },
           "hover": {
@@ -2964,7 +3131,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
-              "default": "{colors.background.brand.secondary-hover}"
+              "default": "{colors.background.brand.secondary-hover}",
+              "virtuozzo": "{colors.background.brand.secondary-hover}"
             }
           },
           "idle": {
@@ -2977,7 +3145,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary}",
-              "default": "{colors.background.brand.secondary}"
+              "default": "{colors.background.brand.secondary}",
+              "virtuozzo": "{colors.background.brand.secondary}"
             }
           }
         }
@@ -2993,7 +3162,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-            "default": "{colors.glyph.onBrand.primary}"
+            "default": "{colors.glyph.onBrand.primary}",
+            "virtuozzo": "{colors.glyph.onBrand.primary}"
           }
         }
       },
@@ -3008,7 +3178,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
-            "default": "{colors.text.onBrand.primary}"
+            "default": "{colors.text.onBrand.primary}",
+            "virtuozzo": "{colors.text.onBrand.primary}"
           }
         }
       }
@@ -3026,7 +3197,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
-              "default": "transparent"
+              "default": "transparent",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "disabled": {
@@ -3039,7 +3211,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}"
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{palette.grayscale.3}"
             }
           },
           "hover": {
@@ -3052,7 +3225,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
-              "default": "transparent"
+              "default": "transparent",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -3065,7 +3239,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}"
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{palette.grayscale.3}"
             }
           }
         },
@@ -3079,7 +3254,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
-            "default": "solid"
+            "default": "solid",
+            "virtuozzo": "solid"
           }
         },
         "borderWidth": {
@@ -3092,7 +3268,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         },
         "color": {
@@ -3106,7 +3283,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
-              "default": "{colors.background.surface.active}"
+              "default": "{colors.background.surface.active}",
+              "virtuozzo": "{colors.background.surface.active}"
             }
           },
           "disabled": {
@@ -3119,7 +3297,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
-              "default": "transparent"
+              "default": "transparent",
+              "virtuozzo": "transparent"
             }
           },
           "hover": {
@@ -3132,7 +3311,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
-              "default": "{colors.background.surface.hover}"
+              "default": "{colors.background.surface.hover}",
+              "virtuozzo": "{colors.background.surface.hover}"
             }
           },
           "idle": {
@@ -3145,7 +3325,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
-              "default": "transparent"
+              "default": "transparent",
+              "virtuozzo": "transparent"
             }
           }
         }
@@ -3162,7 +3343,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           },
           "disabled": {
@@ -3175,7 +3357,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
-              "default": "{colors.glyph.onSurface.disabled}"
+              "default": "{colors.glyph.onSurface.disabled}",
+              "virtuozzo": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -3188,7 +3371,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           },
           "idle": {
@@ -3201,7 +3385,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           }
         }
@@ -3218,7 +3403,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-              "default": "{colors.text.onSurface.link}"
+              "default": "{colors.text.onSurface.link}",
+              "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           },
           "disabled": {
@@ -3231,7 +3417,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link-disabled}",
-              "default": "{colors.text.onSurface.link-disabled}"
+              "default": "{colors.text.onSurface.link-disabled}",
+              "virtuozzo": "{colors.text.onSurface.link-disabled}"
             }
           },
           "hover": {
@@ -3244,7 +3431,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-              "default": "{colors.text.onSurface.link}"
+              "default": "{colors.text.onSurface.link}",
+              "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           },
           "idle": {
@@ -3257,7 +3445,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-              "default": "{colors.text.onSurface.link}"
+              "default": "{colors.text.onSurface.link}",
+              "virtuozzo": "{colors.text.onSurface.link-idle}"
             }
           }
         }
@@ -3277,7 +3466,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-            "default": "{colors.border.onSurface.border}"
+            "default": "{colors.border.onSurface.border}",
+            "virtuozzo": "{colors.border.onSurface.border-active}"
           }
         },
         "focused": {
@@ -3290,7 +3480,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-            "default": "{colors.border.onSurface.border}"
+            "default": "{colors.border.onSurface.border}",
+            "virtuozzo": "{colors.border.onSurface.border}"
           }
         },
         "hover": {
@@ -3303,7 +3494,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-            "default": "{colors.border.onSurface.border}"
+            "default": "{colors.border.onSurface.border}",
+            "virtuozzo": "{colors.border.onSurface.border-active}"
           }
         },
         "idle": {
@@ -3316,7 +3508,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-            "default": "{colors.border.onSurface.border}"
+            "default": "{colors.border.onSurface.border}",
+            "virtuozzo": "{colors.border.onSurface.border}"
           }
         }
       },
@@ -3331,7 +3524,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.8}",
-            "default": "{units.radius.8}"
+            "default": "{units.radius.8}",
+            "virtuozzo": "{units.radius.8}"
           }
         },
         "borderStyle": {
@@ -3344,7 +3538,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
-            "default": "solid"
+            "default": "solid",
+            "virtuozzo": "solid"
           }
         },
         "borderWidth": {
@@ -3357,7 +3552,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         },
         "color": {
@@ -3371,7 +3567,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
-              "default": "{colors.background.surface.active}"
+              "default": "{colors.background.surface.active}",
+              "virtuozzo": "{colors.background.surface.active}"
             }
           },
           "hover": {
@@ -3384,7 +3581,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
-              "default": "{colors.background.surface.hover}"
+              "default": "{colors.background.surface.hover}",
+              "virtuozzo": "{colors.background.surface.hover}"
             }
           },
           "idle": {
@@ -3397,7 +3595,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
-              "default": "{colors.background.surface.primary}"
+              "default": "{colors.background.surface.primary}",
+              "virtuozzo": "{colors.background.surface.primary}"
             }
           }
         },
@@ -3411,7 +3610,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.64}",
-            "default": "{units.size.64}"
+            "default": "{units.size.64}",
+            "virtuozzo": "{units.size.64}"
           }
         },
         "paddingX": {
@@ -3424,7 +3624,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
-            "default": "{units.gap.16}"
+            "default": "{units.gap.16}",
+            "virtuozzo": "{units.gap.16}"
           }
         },
         "paddingY": {
@@ -3437,7 +3638,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         }
       },
@@ -3452,7 +3654,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         }
       },
@@ -3467,7 +3670,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-            "default": "{colors.text.onSurface.secondary}"
+            "default": "{colors.text.onSurface.secondary}",
+            "virtuozzo": "{colors.text.onSurface.secondary}"
           }
         },
         "textStyle": {
@@ -3480,7 +3684,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
-            "default": "{typography.caption.default}"
+            "default": "{typography.caption.default}",
+            "virtuozzo": "{typography.caption.default}"
           }
         }
       },
@@ -3495,7 +3700,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.headings.title-accent}",
-            "default": "{typography.headings.title-accent}"
+            "default": "{typography.headings.title-accent}",
+            "virtuozzo": "{typography.headings.title-accent}"
           }
         }
       }
@@ -3512,7 +3718,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-            "default": "{colors.text.onSurface.link}"
+            "default": "{colors.text.onSurface.link}",
+            "virtuozzo": "{colors.text.onSurface.link-idle}"
           }
         }
       }
@@ -3530,7 +3737,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.text.onSurface.secondary}"
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
             }
           },
           "idle": {
@@ -3543,7 +3751,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           }
         }
@@ -3933,7 +4142,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.2}",
-            "default": "{units.radius.2}"
+            "default": "{units.radius.2}",
+            "virtuozzo": "{units.radius.2}"
           }
         },
         "borderWidth": {
@@ -3946,7 +4156,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         },
         "marginY": {
@@ -3959,7 +4170,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
-            "default": "{units.gap.4}"
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
           }
         },
         "size": {
@@ -3972,7 +4184,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
-            "default": "{units.size.16}"
+            "default": "{units.size.16}",
+            "virtuozzo": "{units.size.16}"
           }
         }
       },
@@ -3987,7 +4200,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         },
         "widthMax": {
@@ -4000,7 +4214,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.632}",
-            "default": "{units.size.632}"
+            "default": "{units.size.632}",
+            "virtuozzo": "{units.size.632}"
           }
         },
         "widthMin": {
@@ -4013,7 +4228,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
-            "default": "{units.size.16}"
+            "default": "{units.size.16}",
+            "virtuozzo": "{units.size.16}"
           }
         }
       },
@@ -4028,7 +4244,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         },
         "widthMax": {
@@ -4041,7 +4258,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.632}",
-            "default": "{units.size.632}"
+            "default": "{units.size.632}",
+            "virtuozzo": "{units.size.632}"
           }
         }
       },
@@ -4056,7 +4274,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-            "default": "{colors.text.onSurface.secondary}"
+            "default": "{colors.text.onSurface.secondary}",
+            "virtuozzo": "{colors.text.onSurface.secondary}"
           }
         },
         "textStyle": {
@@ -4069,7 +4288,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
-            "default": "{typography.body.default}"
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
           }
         }
       },
@@ -4084,7 +4304,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.text.onSurface.primary}"
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -4097,7 +4318,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
-            "default": "{typography.body.default}"
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
           }
         }
       }
@@ -4115,7 +4337,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "disabled": {
@@ -4128,7 +4351,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}"
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{colors.border.onSurface.border}"
             }
           },
           "hover": {
@@ -4141,7 +4365,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -4154,7 +4379,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           }
         },
@@ -4169,7 +4395,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
-              "default": "{colors.background.brand.secondary-active}"
+              "default": "{colors.background.brand.secondary-active}",
+              "virtuozzo": "{colors.background.brand.secondary-active}"
             }
           },
           "disabled": {
@@ -4182,7 +4409,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
-              "default": "{colors.background.surface.secondary}"
+              "default": "{colors.background.surface.secondary}",
+              "virtuozzo": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -4195,7 +4423,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
-              "default": "{colors.background.brand.secondary-hover}"
+              "default": "{colors.background.brand.secondary-hover}",
+              "virtuozzo": "{colors.background.brand.secondary-hover}"
             }
           },
           "idle": {
@@ -4208,7 +4437,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary}",
-              "default": "{colors.background.brand.secondary}"
+              "default": "{colors.background.brand.secondary}",
+              "virtuozzo": "{colors.background.brand.secondary}"
             }
           }
         }
@@ -4225,7 +4455,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           },
           "disabled": {
@@ -4238,7 +4469,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
-              "default": "{colors.glyph.onSurface.disabled}"
+              "default": "{colors.glyph.onSurface.disabled}",
+              "virtuozzo": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -4251,7 +4483,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           },
           "idle": {
@@ -4264,7 +4497,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           }
         }
@@ -4283,7 +4517,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "disabled": {
@@ -4296,7 +4531,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}"
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{colors.border.onSurface.border}"
             }
           },
           "hover": {
@@ -4309,7 +4545,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -4322,7 +4559,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           }
         },
@@ -4337,7 +4575,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
-              "default": "{colors.background.brand.secondary-active}"
+              "default": "{colors.background.brand.secondary-active}",
+              "virtuozzo": "{colors.background.brand.secondary-active}"
             }
           },
           "disabled": {
@@ -4350,7 +4589,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
-              "default": "{colors.background.surface.secondary}"
+              "default": "{colors.background.surface.secondary}",
+              "virtuozzo": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -4363,7 +4603,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
-              "default": "{colors.background.brand.secondary-hover}"
+              "default": "{colors.background.brand.secondary-hover}",
+              "virtuozzo": "{colors.background.brand.secondary-hover}"
             }
           },
           "idle": {
@@ -4376,7 +4617,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary}",
-              "default": "{colors.background.brand.secondary}"
+              "default": "{colors.background.brand.secondary}",
+              "virtuozzo": "{colors.background.brand.secondary}"
             }
           }
         }
@@ -4393,7 +4635,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           },
           "disabled": {
@@ -4406,7 +4649,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
-              "default": "{colors.glyph.onSurface.disabled}"
+              "default": "{colors.glyph.onSurface.disabled}",
+              "virtuozzo": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -4419,7 +4663,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           },
           "idle": {
@@ -4432,7 +4677,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           }
         }
@@ -4451,7 +4697,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "disabled": {
@@ -4464,7 +4711,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.divider}",
-              "default": "{colors.border.onSurface.divider}"
+              "default": "{colors.border.onSurface.divider}",
+              "virtuozzo": "{colors.border.onSurface.divider}"
             }
           },
           "hover": {
@@ -4477,7 +4725,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -4490,7 +4739,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}"
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{colors.border.onSurface.border}"
             }
           }
         },
@@ -4505,7 +4755,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
-              "default": "{colors.background.surface.active}"
+              "default": "{colors.background.surface.active}",
+              "virtuozzo": "{colors.background.surface.active}"
             }
           },
           "disabled": {
@@ -4518,7 +4769,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
-              "default": "{colors.background.surface.secondary}"
+              "default": "{colors.background.surface.secondary}",
+              "virtuozzo": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -4531,7 +4783,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
-              "default": "{colors.background.surface.hover}"
+              "default": "{colors.background.surface.hover}",
+              "virtuozzo": "{colors.background.surface.hover}"
             }
           },
           "idle": {
@@ -4544,7 +4797,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
-              "default": "{colors.background.surface.primary}"
+              "default": "{colors.background.surface.primary}",
+              "virtuozzo": "{colors.background.surface.primary}"
             }
           }
         }
@@ -4565,7 +4819,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "hover": {
@@ -4578,7 +4833,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -4591,7 +4847,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.electricblue.3}",
-              "default": "{palette.electricblue.3}"
+              "default": "{palette.electricblue.3}",
+              "virtuozzo": "{palette.electricblue.3}"
             }
           }
         },
@@ -4605,7 +4862,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.12}",
-            "default": "{units.radius.12}"
+            "default": "{units.radius.12}",
+            "virtuozzo": "{units.radius.12}"
           }
         },
         "style": {
@@ -4618,7 +4876,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
-            "default": "solid"
+            "default": "solid",
+            "virtuozzo": "solid"
           }
         },
         "width": {
@@ -4631,7 +4890,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         }
       },
@@ -4647,7 +4907,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
-              "default": "{colors.background.surface.active}"
+              "default": "{colors.background.surface.active}",
+              "virtuozzo": "{colors.background.surface.active}"
             }
           },
           "hover": {
@@ -4660,7 +4921,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
-              "default": "{colors.background.surface.hover}"
+              "default": "{colors.background.surface.hover}",
+              "virtuozzo": "{colors.background.surface.hover}"
             }
           },
           "idle": {
@@ -4673,7 +4935,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
-              "default": "{colors.background.surface.secondary}"
+              "default": "{colors.background.surface.secondary}",
+              "virtuozzo": "{colors.background.surface.secondary}"
             }
           }
         },
@@ -4687,7 +4950,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
-            "default": "{units.gap.4}"
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
           }
         },
         "height": {
@@ -4700,7 +4964,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.24}",
-            "default": "{units.size.24}"
+            "default": "{units.size.24}",
+            "virtuozzo": "{units.size.24}"
           }
         },
         "marginY": {
@@ -4713,7 +4978,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
-            "default": "{units.gap.4}"
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
           }
         },
         "paddingX": {
@@ -4726,7 +4992,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         },
         "widthMin": {
@@ -4739,7 +5006,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.48}",
-            "default": "{units.size.48}"
+            "default": "{units.size.48}",
+            "virtuozzo": "{units.size.48}"
           }
         }
       },
@@ -4754,7 +5022,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-            "default": "{colors.glyph.onSurface.primary}"
+            "default": "{colors.glyph.onSurface.primary}",
+            "virtuozzo": "{colors.glyph.onSurface.primary}"
           }
         },
         "size": {
@@ -4767,7 +5036,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
-            "default": "{units.size.16}"
+            "default": "{units.size.16}",
+            "virtuozzo": "{units.size.16}"
           }
         }
       }
@@ -4784,7 +5054,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.link}",
-            "default": "{colors.text.onSurface.link}"
+            "default": "{colors.text.onSurface.link}",
+            "virtuozzo": "{colors.text.onSurface.link-idle}"
           }
         },
         "textStyle": {
@@ -4797,7 +5068,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.link.strong}",
-            "default": "{typography.link.strong}"
+            "default": "{typography.link.strong}",
+            "virtuozzo": "{typography.link.default}"
           }
         }
       }
@@ -4814,7 +5086,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.text.onSurface.primary}"
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -4826,7 +5099,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
-            "default": "{typography.body.default}"
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
           }
         }
       }
@@ -4843,7 +5117,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.text.onSurface.primary}"
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -4855,7 +5130,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
-            "default": "{typography.body.default}"
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
           }
         }
       }
@@ -5258,7 +5534,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
-            "default": "{units.radius.4}"
+            "default": "{units.radius.4}",
+            "virtuozzo": "{units.radius.4}"
           }
         },
         "borderWidth": {
@@ -5271,7 +5548,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         },
         "color": {
@@ -5285,7 +5563,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
-              "default": "{colors.background.surface.secondary}"
+              "default": "{colors.background.surface.secondary}",
+              "virtuozzo": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -5298,7 +5577,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
-              "default": "{colors.background.surface.primary}"
+              "default": "{colors.background.surface.primary}",
+              "virtuozzo": "{colors.background.surface.primary}"
             }
           },
           "idle": {
@@ -5311,7 +5591,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
-              "default": "{colors.background.surface.primary}"
+              "default": "{colors.background.surface.primary}",
+              "virtuozzo": "{colors.background.surface.primary}"
             }
           }
         },
@@ -5325,7 +5606,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
-            "default": "{units.gap.12}"
+            "default": "{units.gap.12}",
+            "virtuozzo": "{units.gap.12}"
           }
         },
         "gapRange": {
@@ -5338,7 +5620,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         },
         "height": {
@@ -5351,7 +5634,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
-            "default": "{units.size.32}"
+            "default": "{units.size.32}",
+            "virtuozzo": "{units.size.32}"
           }
         },
         "paddingX": {
@@ -5364,7 +5648,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
-            "default": "{units.gap.12}"
+            "default": "{units.gap.12}",
+            "virtuozzo": "{units.gap.12}"
           }
         },
         "paddingY": {
@@ -5377,7 +5662,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
-            "default": "{units.gap.4}"
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
           }
         }
       },
@@ -5392,7 +5678,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
-            "default": "{units.gap.4}"
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
           }
         },
         "widthMin": {
@@ -5405,7 +5692,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.128}",
-            "default": "{units.size.128}"
+            "default": "{units.size.128}",
+            "virtuozzo": "{units.size.128}"
           }
         }
       },
@@ -5420,7 +5708,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
-            "default": "{units.gap.4}"
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
           }
         }
       },
@@ -5452,7 +5741,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-              "default": "{colors.text.onSurface.disabled}"
+              "default": "{colors.text.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -5465,7 +5755,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           },
           "idle": {
@@ -5478,7 +5769,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           }
         },
@@ -5492,7 +5784,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.form-label}",
-            "default": "{typography.body.form-label}"
+            "default": "{typography.body.form-label}",
+            "virtuozzo": "{typography.body.form-label}"
           }
         }
       },
@@ -5508,7 +5801,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-              "default": "{colors.text.onSurface.disabled}"
+              "default": "{colors.text.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -5521,7 +5815,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.text.onSurface.secondary}"
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
             }
           },
           "idle": {
@@ -5534,7 +5829,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.text.onSurface.secondary}"
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
             }
           }
         },
@@ -5548,7 +5844,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
-            "default": "{typography.body.default}"
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
           }
         }
       },
@@ -5563,7 +5860,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
-            "default": "{colors.text.onSurface.destructive}"
+            "default": "{colors.text.onSurface.destructive}",
+            "virtuozzo": "{colors.text.onSurface.destructive}"
           }
         },
         "textStyle": {
@@ -5576,7 +5874,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
-            "default": "{typography.caption.default}"
+            "default": "{typography.caption.default}",
+            "virtuozzo": "{typography.caption.default}"
           }
         }
       },
@@ -5592,7 +5891,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-              "default": "{colors.text.onSurface.disabled}"
+              "default": "{colors.text.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -5605,7 +5905,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           },
           "idle": {
@@ -5618,7 +5919,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           }
         },
@@ -5632,7 +5934,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
-            "default": "{typography.body.default}"
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
           }
         }
       },
@@ -5648,7 +5951,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-              "default": "{colors.text.onSurface.disabled}"
+              "default": "{colors.text.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -5661,7 +5965,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           },
           "idle": {
@@ -5674,7 +5979,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           }
         },
@@ -5688,7 +5994,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
-            "default": "{typography.body.default}"
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
           }
         }
       }
@@ -5706,7 +6013,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
-              "default": "{colors.border.onSurface.border-error}"
+              "default": "{colors.border.onSurface.border-error}",
+              "virtuozzo": "{colors.border.onSurface.border-error}"
             }
           },
           "hover": {
@@ -5719,7 +6027,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
-              "default": "{colors.border.onSurface.border-error}"
+              "default": "{colors.border.onSurface.border-error}",
+              "virtuozzo": "{colors.border.onSurface.border-error}"
             }
           },
           "idle": {
@@ -5732,7 +6041,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
-              "default": "{colors.border.onSurface.border-error}"
+              "default": "{colors.border.onSurface.border-error}",
+              "virtuozzo": "{colors.border.onSurface.border-error}"
             }
           }
         }
@@ -5748,7 +6058,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
-            "default": "{colors.text.onSurface.destructive}"
+            "default": "{colors.text.onSurface.destructive}",
+            "virtuozzo": "{colors.text.onSurface.destructive}"
           }
         },
         "textStyle": {
@@ -5761,7 +6072,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
-            "default": "{typography.caption.default}"
+            "default": "{typography.caption.default}",
+            "virtuozzo": "{typography.caption.default}"
           }
         }
       },
@@ -5777,7 +6089,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.destructive}",
-              "default": "{colors.glyph.onSurface.destructive}"
+              "default": "{colors.glyph.onSurface.destructive}",
+              "virtuozzo": "{colors.glyph.onSurface.destructive}"
             }
           },
           "idle": {
@@ -5790,7 +6103,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.destructive}",
-              "default": "{colors.glyph.onSurface.destructive}"
+              "default": "{colors.glyph.onSurface.destructive}",
+              "virtuozzo": "{colors.glyph.onSurface.destructive}"
             }
           }
         }
@@ -5809,7 +6123,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "disabled": {
@@ -5822,7 +6137,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}"
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{colors.border.onSurface.border}"
             }
           },
           "hover": {
@@ -5835,7 +6151,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -5848,7 +6165,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}"
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{colors.border.onSurface.border}"
             }
           }
         }
@@ -5865,7 +6183,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-              "default": "{colors.text.onSurface.disabled}"
+              "default": "{colors.text.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -5878,7 +6197,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.text.onSurface.secondary}"
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
             }
           },
           "idle": {
@@ -5891,7 +6211,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.text.onSurface.secondary}"
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
             }
           }
         },
@@ -5905,7 +6226,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
-            "default": "{typography.caption.default}"
+            "default": "{typography.caption.default}",
+            "virtuozzo": "{typography.caption.default}"
           }
         }
       },
@@ -5921,7 +6243,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
-              "default": "{colors.glyph.onSurface.disabled}"
+              "default": "{colors.glyph.onSurface.disabled}",
+              "virtuozzo": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -5934,7 +6257,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           },
           "idle": {
@@ -5947,7 +6271,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           }
         }
@@ -6780,7 +7105,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-          "default": "{colors.border.onSurface.border}"
+          "default": "{colors.border.onSurface.border}",
+          "virtuozzo": "{colors.border.onSurface.border}"
         }
       },
       "hover": {
@@ -6793,7 +7119,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-          "default": "{colors.border.onSurface.border-active}"
+          "default": "{colors.border.onSurface.border-active}",
+          "virtuozzo": "{colors.border.onSurface.border-active}"
         }
       },
       "idle": {
@@ -6806,7 +7133,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-          "default": "{colors.border.onSurface.border}"
+          "default": "{colors.border.onSurface.border}",
+          "virtuozzo": "{colors.border.onSurface.border}"
         }
       }
     },
@@ -6821,7 +7149,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.radius.4}",
-          "default": "{units.radius.4}"
+          "default": "{units.radius.4}",
+          "virtuozzo": "{units.radius.4}"
         }
       },
       "borderWidth": {
@@ -6834,7 +7163,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.stroke.1}",
-          "default": "{units.stroke.1}"
+          "default": "{units.stroke.1}",
+          "virtuozzo": "{units.stroke.1}"
         }
       },
       "color": {
@@ -6848,7 +7178,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.secondary}",
-            "default": "{colors.background.surface.secondary}"
+            "default": "{colors.background.surface.secondary}",
+            "virtuozzo": "{colors.background.surface.secondary}"
           }
         },
         "hover": {
@@ -6861,7 +7192,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
-            "default": "{colors.background.surface.primary}"
+            "default": "{colors.background.surface.primary}",
+            "virtuozzo": "{colors.background.surface.primary}"
           }
         },
         "idle": {
@@ -6874,7 +7206,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
-            "default": "{colors.background.surface.primary}"
+            "default": "{colors.background.surface.primary}",
+            "virtuozzo": "{colors.background.surface.primary}"
           }
         }
       },
@@ -6888,7 +7221,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
-          "default": "{units.gap.8}"
+          "default": "{units.gap.8}",
+          "virtuozzo": "{units.gap.8}"
         }
       },
       "height": {
@@ -6901,7 +7235,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.32}",
-          "default": "{units.size.32}"
+          "default": "{units.size.32}",
+          "virtuozzo": "{units.size.32}"
         }
       },
       "paddingX": {
@@ -6914,7 +7249,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.12}",
-          "default": "{units.gap.12}"
+          "default": "{units.gap.12}",
+          "virtuozzo": "{units.gap.12}"
         }
       },
       "paddingY": {
@@ -6927,7 +7263,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
-          "default": "{units.gap.4}"
+          "default": "{units.gap.4}",
+          "virtuozzo": "{units.gap.4}"
         }
       }
     },
@@ -6942,7 +7279,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-          "default": "{colors.text.onSurface.disabled}"
+          "default": "{colors.text.onSurface.disabled}",
+          "virtuozzo": "{colors.text.onSurface.disabled}"
         }
       },
       "hover": {
@@ -6955,7 +7293,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-          "default": "{colors.text.onSurface.primary}"
+          "default": "{colors.text.onSurface.primary}",
+          "virtuozzo": "{colors.text.onSurface.primary}"
         }
       },
       "idle": {
@@ -6968,7 +7307,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-          "default": "{colors.text.onSurface.primary}"
+          "default": "{colors.text.onSurface.primary}",
+          "virtuozzo": "{colors.text.onSurface.primary}"
         }
       }
     },
@@ -6983,7 +7323,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
-          "default": "{units.gap.4}"
+          "default": "{units.gap.4}",
+          "virtuozzo": "{units.gap.4}"
         }
       },
       "widthMin": {
@@ -6996,7 +7337,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.128}",
-          "default": "{units.size.128}"
+          "default": "{units.size.128}",
+          "virtuozzo": "{units.size.128}"
         }
       }
     },
@@ -7011,7 +7353,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
-          "default": "{units.gap.4}"
+          "default": "{units.gap.4}",
+          "virtuozzo": "{units.gap.4}"
         }
       }
     },
@@ -7027,7 +7370,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
-            "default": "{colors.glyph.onSurface.disabled}"
+            "default": "{colors.glyph.onSurface.disabled}",
+            "virtuozzo": "{colors.glyph.onSurface.disabled}"
           }
         },
         "hover": {
@@ -7040,7 +7384,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-            "default": "{colors.glyph.onSurface.primary}"
+            "default": "{colors.glyph.onSurface.primary}",
+            "virtuozzo": "{colors.glyph.onSurface.primary}"
           }
         },
         "idle": {
@@ -7053,7 +7398,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-            "default": "{colors.glyph.onSurface.primary}"
+            "default": "{colors.glyph.onSurface.primary}",
+            "virtuozzo": "{colors.glyph.onSurface.primary}"
           }
         }
       }
@@ -7069,7 +7415,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.form-label}",
-          "default": "{typography.body.form-label}"
+          "default": "{typography.body.form-label}",
+          "virtuozzo": "{typography.body.form-label}"
         }
       }
     },
@@ -7085,7 +7432,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-            "default": "{colors.text.onSurface.disabled}"
+            "default": "{colors.text.onSurface.disabled}",
+            "virtuozzo": "{colors.text.onSurface.disabled}"
           }
         },
         "hover": {
@@ -7098,7 +7446,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-            "default": "{colors.text.onSurface.secondary}"
+            "default": "{colors.text.onSurface.secondary}",
+            "virtuozzo": "{colors.text.onSurface.secondary}"
           }
         },
         "idle": {
@@ -7111,7 +7460,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-            "default": "{colors.text.onSurface.secondary}"
+            "default": "{colors.text.onSurface.secondary}",
+            "virtuozzo": "{colors.text.onSurface.secondary}"
           }
         }
       }
@@ -7127,7 +7477,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
-          "default": "{colors.text.onSurface.destructive}"
+          "default": "{colors.text.onSurface.destructive}",
+          "virtuozzo": "{colors.text.onSurface.destructive}"
         }
       },
       "textStyle": {
@@ -7140,7 +7491,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
-          "default": "{typography.body.default}"
+          "default": "{typography.body.default}",
+          "virtuozzo": "{typography.body.default}"
         }
       }
     },
@@ -7156,7 +7508,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-            "default": "{colors.text.onSurface.disabled}"
+            "default": "{colors.text.onSurface.disabled}",
+            "virtuozzo": "{colors.text.onSurface.disabled}"
           }
         },
         "hover": {
@@ -7169,7 +7522,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.text.onSurface.primary}"
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         },
         "idle": {
@@ -7182,7 +7536,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.text.onSurface.primary}"
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         }
       },
@@ -7196,7 +7551,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
-          "default": "{typography.body.default}"
+          "default": "{typography.body.default}",
+          "virtuozzo": "{typography.body.default}"
         }
       }
     }
@@ -7214,7 +7570,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         },
         "label": {
@@ -7229,7 +7586,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-                "default": "{colors.text.onSurface.secondary}"
+                "default": "{colors.text.onSurface.secondary}",
+                "virtuozzo": "{colors.text.onSurface.secondary}"
               }
             },
             "value": {
@@ -7242,7 +7600,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-                "default": "{colors.text.onSurface.primary}"
+                "default": "{colors.text.onSurface.primary}",
+                "virtuozzo": "{colors.text.onSurface.primary}"
               }
             }
           },
@@ -7256,7 +7615,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.body.default}",
-              "default": "{typography.body.default}"
+              "default": "{typography.body.default}",
+              "virtuozzo": "{typography.body.default}"
             }
           }
         },
@@ -7270,7 +7630,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
-            "default": "{units.gap.12}"
+            "default": "{units.gap.12}",
+            "virtuozzo": "{units.gap.12}"
           }
         },
         "paddingY": {
@@ -7283,7 +7644,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
-            "default": "{units.gap.12}"
+            "default": "{units.gap.12}",
+            "virtuozzo": "{units.gap.12}"
           }
         }
       },
@@ -7298,7 +7660,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-            "default": "{colors.border.onSurface.border-active}"
+            "default": "{colors.border.onSurface.border-active}",
+            "virtuozzo": "{colors.border.onSurface.border-active}"
           }
         },
         "borderRadius": {
@@ -7311,7 +7674,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
-            "default": "{units.radius.4}"
+            "default": "{units.radius.4}",
+            "virtuozzo": "{units.radius.4}"
           }
         },
         "borderWidth": {
@@ -7324,7 +7688,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         },
         "color": {
@@ -7337,7 +7702,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
-            "default": "{colors.background.surface.primary}"
+            "default": "{colors.background.surface.primary}",
+            "virtuozzo": "{colors.background.surface.primary}"
           }
         },
         "gap": {
@@ -7350,7 +7716,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         },
         "paddingX": {
@@ -7363,7 +7730,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         },
         "paddingY": {
@@ -7376,7 +7744,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         }
       },
@@ -7391,7 +7760,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.size.8}"
           }
         },
         "paddingX": {
@@ -7404,7 +7774,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
-            "default": "{units.gap.16}"
+            "default": "{units.gap.16}",
+            "virtuozzo": "{units.gap.16}"
           }
         },
         "paddingY": {
@@ -7417,7 +7788,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
-            "default": "{units.gap.16}"
+            "default": "{units.gap.16}",
+            "virtuozzo": "{units.size.16}"
           }
         },
         "widthMin": {
@@ -7430,7 +7802,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.128}",
-            "default": "{units.size.128}"
+            "default": "{units.size.128}",
+            "virtuozzo": "{units.size.128}"
           }
         }
       }
@@ -7448,7 +7821,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
-              "default": "{units.gap.8}"
+              "default": "{units.gap.8}",
+              "virtuozzo": "{units.gap.8}"
             }
           },
           "height": {
@@ -7461,7 +7835,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.40}",
-              "default": "{units.size.40}"
+              "default": "{units.size.40}",
+              "virtuozzo": "{units.size.40}"
             }
           },
           "paddingX": {
@@ -7474,7 +7849,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.12}",
-              "default": "{units.gap.12}"
+              "default": "{units.gap.12}",
+              "virtuozzo": "{units.gap.12}"
             }
           },
           "paddingY": {
@@ -7487,7 +7863,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
-              "default": "{units.gap.8}"
+              "default": "{units.gap.8}",
+              "virtuozzo": "{units.gap.8}"
             }
           }
         },
@@ -7501,7 +7878,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.glyph.onSurface.primary}"
+            "default": "{colors.glyph.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         },
         "iconCollapse": {
@@ -7514,7 +7892,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.glyph.onSurface.primary}"
+            "default": "{colors.glyph.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         },
         "iconTenant": {
@@ -7527,7 +7906,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.glyph.onSurface.primary}"
+            "default": "{colors.glyph.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         },
         "label": {
@@ -7541,7 +7921,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           }
         }
@@ -7559,7 +7940,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.secondary}",
-                "default": "{colors.background.surface.secondary}"
+                "default": "{colors.background.surface.secondary}",
+                "virtuozzo": "{colors.background.surface.secondary}"
               }
             },
             "hover": {
@@ -7572,7 +7954,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.active}",
-                "default": "{colors.background.surface.active}"
+                "default": "{colors.background.surface.active}",
+                "virtuozzo": "{colors.background.surface.active}"
               }
             },
             "idle": {
@@ -7585,7 +7968,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.active}",
-                "default": "{colors.background.surface.active}"
+                "default": "{colors.background.surface.active}",
+                "virtuozzo": "{colors.background.surface.active}"
               }
             }
           }
@@ -7604,7 +7988,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.secondary}",
-                "default": "{colors.background.surface.secondary}"
+                "default": "{colors.background.surface.secondary}",
+                "virtuozzo": "{colors.background.surface.secondary}"
               }
             },
             "hover": {
@@ -7617,7 +8002,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.hover}",
-                "default": "{colors.background.surface.hover}"
+                "default": "{colors.background.surface.hover}",
+                "virtuozzo": "{colors.background.surface.hover}"
               }
             },
             "idle": {
@@ -7630,7 +8016,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.primary}",
-                "default": "{colors.background.surface.primary}"
+                "default": "{colors.background.surface.primary}",
+                "virtuozzo": "{colors.background.surface.primary}"
               }
             }
           }
@@ -7649,7 +8036,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-            "default": "{colors.border.onSurface.border}"
+            "default": "{colors.border.onSurface.border}",
+            "virtuozzo": "{colors.border.onSurface.border}"
           }
         },
         "borderWidth": {
@@ -7662,7 +8050,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         },
         "paddingY": {
@@ -7675,7 +8064,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.8}"
           }
         }
       },
@@ -7690,7 +8080,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
-            "default": "{units.gap.12}"
+            "default": "{units.gap.12}",
+            "virtuozzo": "{units.gap.12}"
           }
         },
         "paddingY": {
@@ -7703,7 +8094,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         }
       },
@@ -7718,7 +8110,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.text.onSurface.primary}"
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -7731,7 +8124,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
-            "default": "{typography.body.strong}"
+            "default": "{typography.body.strong}",
+            "virtuozzo": "{typography.body.strong}"
           }
         }
       },
@@ -7746,7 +8140,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         }
       }
@@ -7763,7 +8158,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
-            "default": "{units.radius.4}"
+            "default": "{units.radius.4}",
+            "virtuozzo": "{units.radius.4}"
           }
         },
         "borderWidth": {
@@ -7776,7 +8172,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         },
         "color": {
@@ -7790,7 +8187,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
-              "default": "{colors.background.surface.secondary}"
+              "default": "{colors.background.surface.secondary}",
+              "virtuozzo": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -7803,7 +8201,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
-              "default": "{colors.background.surface.primary}"
+              "default": "{colors.background.surface.primary}",
+              "virtuozzo": "{colors.background.surface.primary}"
             }
           },
           "idle": {
@@ -7816,7 +8215,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
-              "default": "{colors.background.surface.primary}"
+              "default": "{colors.background.surface.primary}",
+              "virtuozzo": "{colors.background.surface.primary}"
             }
           }
         },
@@ -7830,7 +8230,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         },
         "height": {
@@ -7843,7 +8244,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
-            "default": "{units.size.32}"
+            "default": "{units.size.32}",
+            "virtuozzo": "{units.size.32}"
           }
         },
         "paddingX": {
@@ -7856,7 +8258,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
-            "default": "{units.gap.12}"
+            "default": "{units.gap.12}",
+            "virtuozzo": "{units.gap.12}"
           }
         },
         "paddingY": {
@@ -7869,7 +8272,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
-            "default": "{units.gap.4}"
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
           }
         }
       },
@@ -7884,7 +8288,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
-            "default": "{units.gap.4}"
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
           }
         },
         "widthMin": {
@@ -7897,7 +8302,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.128}",
-            "default": "{units.size.128}"
+            "default": "{units.size.128}",
+            "virtuozzo": "{units.size.128}"
           }
         }
       },
@@ -7912,7 +8318,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
-            "default": "{units.gap.4}"
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
           }
         }
       },
@@ -7944,7 +8351,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-              "default": "{colors.text.onSurface.disabled}"
+              "default": "{colors.text.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -7957,7 +8365,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           },
           "idle": {
@@ -7970,7 +8379,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           }
         },
@@ -7984,7 +8394,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.form-label}",
-            "default": "{typography.body.form-label}"
+            "default": "{typography.body.form-label}",
+            "virtuozzo": "{typography.body.form-label}"
           }
         }
       },
@@ -8000,7 +8411,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-              "default": "{colors.text.onSurface.disabled}"
+              "default": "{colors.text.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -8013,7 +8425,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.text.onSurface.secondary}"
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
             }
           },
           "idle": {
@@ -8026,7 +8439,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.text.onSurface.secondary}"
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
             }
           }
         }
@@ -8042,7 +8456,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
-            "default": "{colors.text.onSurface.destructive}"
+            "default": "{colors.text.onSurface.destructive}",
+            "virtuozzo": "{colors.text.onSurface.destructive}"
           }
         },
         "textStyle": {
@@ -8055,7 +8470,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
-            "default": "{typography.body.default}"
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
           }
         }
       },
@@ -8071,7 +8487,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-              "default": "{colors.text.onSurface.disabled}"
+              "default": "{colors.text.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -8084,7 +8501,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           },
           "idle": {
@@ -8097,7 +8515,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           }
         },
@@ -8111,7 +8530,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
-            "default": "{typography.body.default}"
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
           }
         }
       }
@@ -8129,7 +8549,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
-              "default": "{colors.border.onSurface.border-error}"
+              "default": "{colors.border.onSurface.border-error}",
+              "virtuozzo": "{colors.border.onSurface.border-error}"
             }
           },
           "idle": {
@@ -8142,7 +8563,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
-              "default": "{colors.border.onSurface.border-error}"
+              "default": "{colors.border.onSurface.border-error}",
+              "virtuozzo": "{colors.border.onSurface.border-error}"
             }
           }
         }
@@ -8158,7 +8580,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
-            "default": "{colors.text.onSurface.destructive}"
+            "default": "{colors.text.onSurface.destructive}",
+            "virtuozzo": "{colors.text.onSurface.destructive}"
           }
         },
         "textStyle": {
@@ -8171,7 +8594,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
-            "default": "{typography.caption.default}"
+            "default": "{typography.caption.default}",
+            "virtuozzo": "{typography.caption.default}"
           }
         }
       },
@@ -8187,7 +8611,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.glyph.onSurface.destructive}"
+              "default": "{colors.glyph.onSurface.destructive}",
+              "virtuozzo": "{colors.glyph.onSurface.destructive}"
             }
           },
           "idle": {
@@ -8200,7 +8625,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.glyph.onSurface.destructive}"
+              "default": "{colors.glyph.onSurface.destructive}",
+              "virtuozzo": "{colors.glyph.onSurface.destructive}"
             }
           }
         }
@@ -8217,7 +8643,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
-              "default": "{colors.glyph.onSurface.disabled}"
+              "default": "{colors.glyph.onSurface.disabled}",
+              "virtuozzo": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -8230,7 +8657,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.destructive}"
+              "default": "{colors.glyph.onSurface.destructive}",
+              "virtuozzo": "{colors.glyph.onSurface.destructive}"
             }
           },
           "idle": {
@@ -8243,7 +8671,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.destructive}"
+              "default": "{colors.glyph.onSurface.destructive}",
+              "virtuozzo": "{colors.glyph.onSurface.destructive}"
             }
           }
         }
@@ -8262,7 +8691,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}"
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{colors.border.onSurface.border}"
             }
           },
           "hover": {
@@ -8275,7 +8705,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -8288,7 +8719,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}"
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{colors.border.onSurface.border}"
             }
           }
         }
@@ -8305,7 +8737,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-              "default": "{colors.text.onSurface.disabled}"
+              "default": "{colors.text.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -8318,7 +8751,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.text.onSurface.secondary}"
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
             }
           },
           "idle": {
@@ -8331,7 +8765,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.text.onSurface.secondary}"
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
             }
           }
         },
@@ -8345,7 +8780,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
-            "default": "{typography.caption.default}"
+            "default": "{typography.caption.default}",
+            "virtuozzo": "{typography.caption.default}"
           }
         }
       },
@@ -8361,7 +8797,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-              "default": "{colors.glyph.onSurface.disabled}"
+              "default": "{colors.glyph.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -8374,7 +8811,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           },
           "idle": {
@@ -8387,7 +8825,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           }
         }
@@ -8404,7 +8843,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
-              "default": "{colors.glyph.onSurface.disabled}"
+              "default": "{colors.glyph.onSurface.disabled}",
+              "virtuozzo": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -8417,7 +8857,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           },
           "idle": {
@@ -8430,7 +8871,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           }
         }
@@ -8450,7 +8892,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.4}",
-            "default": "{units.radius.4}"
+            "default": "{units.radius.4}",
+            "virtuozzo": "{units.radius.4}"
           }
         },
         "borderWidth": {
@@ -8463,7 +8906,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         },
         "color": {
@@ -8477,7 +8921,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
-              "default": "{colors.background.surface.secondary}"
+              "default": "{colors.background.surface.secondary}",
+              "virtuozzo": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -8490,7 +8935,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
-              "default": "{colors.background.surface.primary}"
+              "default": "{colors.background.surface.primary}",
+              "virtuozzo": "{colors.background.surface.primary}"
             }
           },
           "idle": {
@@ -8503,7 +8949,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
-              "default": "{colors.background.surface.primary}"
+              "default": "{colors.background.surface.primary}",
+              "virtuozzo": "{colors.background.surface.primary}"
             }
           }
         },
@@ -8517,7 +8964,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
-            "default": "{units.gap.12}"
+            "default": "{units.gap.12}",
+            "virtuozzo": "{units.gap.12}"
           }
         },
         "height": {
@@ -8530,7 +8978,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
-            "default": "{units.size.32}"
+            "default": "{units.size.32}",
+            "virtuozzo": "{units.size.32}"
           }
         },
         "paddingX": {
@@ -8543,7 +8992,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
-            "default": "{units.gap.12}"
+            "default": "{units.gap.12}",
+            "virtuozzo": "{units.gap.12}"
           }
         },
         "paddingY": {
@@ -8556,7 +9006,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
-            "default": "{units.gap.4}"
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
           }
         }
       },
@@ -8571,7 +9022,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
-            "default": "{units.gap.4}"
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
           }
         },
         "widthMin": {
@@ -8584,7 +9036,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.128}",
-            "default": "{units.size.128}"
+            "default": "{units.size.128}",
+            "virtuozzo": "{units.size.128}"
           }
         }
       },
@@ -8599,7 +9052,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
-            "default": "{units.gap.4}"
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
           }
         }
       },
@@ -8615,7 +9069,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-              "default": "{colors.text.onSurface.disabled}"
+              "default": "{colors.text.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -8628,7 +9083,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           },
           "idle": {
@@ -8641,7 +9097,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           }
         },
@@ -8655,7 +9112,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.form-label}",
-            "default": "{typography.body.form-label}"
+            "default": "{typography.body.form-label}",
+            "virtuozzo": "{typography.body.form-label}"
           }
         }
       },
@@ -8671,7 +9129,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.text.onSurface.disabled}"
+              "default": "{colors.text.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -8684,7 +9143,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.text.onSurface.secondary}"
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
             }
           },
           "idle": {
@@ -8697,7 +9157,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.text.onSurface.secondary}"
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
             }
           }
         }
@@ -8713,7 +9174,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
-            "default": "{colors.text.onSurface.destructive}"
+            "default": "{colors.text.onSurface.destructive}",
+            "virtuozzo": "{colors.text.onSurface.destructive}"
           }
         },
         "textStyle": {
@@ -8726,7 +9188,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
-            "default": "{typography.body.default}"
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
           }
         }
       },
@@ -8742,7 +9205,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-              "default": "{colors.text.onSurface.disabled}"
+              "default": "{colors.text.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -8755,7 +9219,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           },
           "idle": {
@@ -8768,7 +9233,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           }
         },
@@ -8782,7 +9248,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
-            "default": "{typography.body.default}"
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
           }
         }
       }
@@ -8800,7 +9267,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
-              "default": "{colors.border.onSurface.border-error}"
+              "default": "{colors.border.onSurface.border-error}",
+              "virtuozzo": "{colors.border.onSurface.border-error}"
             }
           },
           "idle": {
@@ -8813,7 +9281,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
-              "default": "{colors.border.onSurface.border-error}"
+              "default": "{colors.border.onSurface.border-error}",
+              "virtuozzo": "{colors.border.onSurface.border-error}"
             }
           }
         }
@@ -8829,7 +9298,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
-            "default": "{colors.text.onSurface.destructive}"
+            "default": "{colors.text.onSurface.destructive}",
+            "virtuozzo": "{colors.text.onSurface.destructive}"
           }
         },
         "textStyle": {
@@ -8842,7 +9312,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
-            "default": "{typography.caption.default}"
+            "default": "{typography.caption.default}",
+            "virtuozzo": "{typography.caption.default}"
           }
         }
       }
@@ -8860,7 +9331,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}"
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{colors.border.onSurface.border}"
             }
           },
           "hover": {
@@ -8873,7 +9345,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -8886,7 +9359,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}"
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{colors.border.onSurface.border}"
             }
           }
         }
@@ -8903,7 +9377,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-              "default": "{colors.text.onSurface.disabled}"
+              "default": "{colors.text.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
             }
           },
           "hover": {
@@ -8916,7 +9391,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.text.onSurface.secondary}"
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
             }
           },
           "idle": {
@@ -8929,7 +9405,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.text.onSurface.secondary}"
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
             }
           }
         },
@@ -8943,7 +9420,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
-            "default": "{typography.caption.default}"
+            "default": "{typography.caption.default}",
+            "virtuozzo": "{typography.caption.default}"
           }
         }
       }
@@ -8961,7 +9439,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-          "default": "{colors.border.onSurface.border}"
+          "default": "{colors.border.onSurface.border}",
+          "virtuozzo": "{colors.border.onSurface.border}"
         }
       },
       "focus": {
@@ -8974,7 +9453,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-          "default": "{colors.border.onSurface.border-active}"
+          "default": "{colors.border.onSurface.border-active}",
+          "virtuozzo": "{colors.border.onSurface.border-active}"
         }
       },
       "hover": {
@@ -8987,7 +9467,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-          "default": "{colors.border.onSurface.border-active}"
+          "default": "{colors.border.onSurface.border-active}",
+          "virtuozzo": "{colors.border.onSurface.border-active}"
         }
       },
       "idle": {
@@ -9000,7 +9481,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-          "default": "{colors.border.onSurface.border}"
+          "default": "{colors.border.onSurface.border}",
+          "virtuozzo": "{colors.border.onSurface.border}"
         }
       }
     },
@@ -9015,7 +9497,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.radius.4}",
-          "default": "{units.radius.4}"
+          "default": "{units.radius.4}",
+          "virtuozzo": "{units.radius.4}"
         }
       },
       "borderWidth": {
@@ -9028,7 +9511,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.stroke.1}",
-          "default": "{units.stroke.1}"
+          "default": "{units.stroke.1}",
+          "virtuozzo": "{units.stroke.1}"
         }
       },
       "color": {
@@ -9042,7 +9526,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.secondary}",
-            "default": "{colors.background.surface.secondary}"
+            "default": "{colors.background.surface.secondary}",
+            "virtuozzo": "{colors.background.surface.secondary}"
           }
         },
         "hover": {
@@ -9055,7 +9540,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
-            "default": "{colors.background.surface.primary}"
+            "default": "{colors.background.surface.primary}",
+            "virtuozzo": "{colors.background.surface.primary}"
           }
         },
         "idle": {
@@ -9068,7 +9554,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
-            "default": "{colors.background.surface.primary}"
+            "default": "{colors.background.surface.primary}",
+            "virtuozzo": "{colors.background.surface.primary}"
           }
         }
       },
@@ -9082,7 +9569,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.12}",
-          "default": "{units.gap.12}"
+          "default": "{units.gap.12}",
+          "virtuozzo": "{units.gap.12}"
         }
       },
       "heightMin": {
@@ -9095,7 +9583,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.96}",
-          "default": "{units.size.96}"
+          "default": "{units.size.96}",
+          "virtuozzo": "{units.size.96}"
         }
       },
       "paddingX": {
@@ -9108,7 +9597,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.12}",
-          "default": "{units.gap.12}"
+          "default": "{units.gap.12}",
+          "virtuozzo": "{units.gap.12}"
         }
       },
       "paddingY": {
@@ -9121,7 +9611,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
-          "default": "{units.gap.8}"
+          "default": "{units.gap.8}",
+          "virtuozzo": "{units.gap.8}"
         }
       }
     },
@@ -9136,7 +9627,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
-          "default": "{units.gap.4}"
+          "default": "{units.gap.4}",
+          "virtuozzo": "{units.gap.4}"
         }
       },
       "widthMin": {
@@ -9149,7 +9641,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.256}",
-          "default": "{units.size.256}"
+          "default": "{units.size.256}",
+          "virtuozzo": "{units.size.256}"
         }
       }
     },
@@ -9164,7 +9657,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.4}",
-          "default": "{units.gap.4}"
+          "default": "{units.gap.4}",
+          "virtuozzo": "{units.gap.4}"
         }
       }
     },
@@ -9180,7 +9674,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-            "default": "{colors.text.onSurface.disabled}"
+            "default": "{colors.text.onSurface.disabled}",
+            "virtuozzo": "{colors.text.onSurface.disabled}"
           }
         },
         "hover": {
@@ -9193,7 +9688,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-            "default": "{colors.text.onSurface.secondary}"
+            "default": "{colors.text.onSurface.secondary}",
+            "virtuozzo": "{colors.text.onSurface.secondary}"
           }
         },
         "idle": {
@@ -9206,7 +9702,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-            "default": "{colors.text.onSurface.secondary}"
+            "default": "{colors.text.onSurface.secondary}",
+            "virtuozzo": "{colors.text.onSurface.secondary}"
           }
         }
       },
@@ -9220,7 +9717,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.caption.default}",
-          "default": "{typography.caption.default}"
+          "default": "{typography.caption.default}",
+          "virtuozzo": "{typography.caption.default}"
         }
       }
     },
@@ -9237,7 +9735,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
-              "default": "{colors.border.onSurface.border-error}"
+              "default": "{colors.border.onSurface.border-error}",
+              "virtuozzo": "{colors.border.onSurface.border-error}"
             }
           },
           "idle": {
@@ -9250,7 +9749,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-error}",
-              "default": "{colors.border.onSurface.border-error}"
+              "default": "{colors.border.onSurface.border-error}",
+              "virtuozzo": "{colors.border.onSurface.border-error}"
             }
           }
         }
@@ -9266,7 +9766,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
-            "default": "{colors.text.onSurface.destructive}"
+            "default": "{colors.text.onSurface.destructive}",
+            "virtuozzo": "{colors.text.onSurface.destructive}"
           }
         },
         "textStyle": {
@@ -9279,7 +9780,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.default}",
-            "default": "{typography.caption.default}"
+            "default": "{typography.caption.default}",
+            "virtuozzo": "{typography.caption.default}"
           }
         }
       }
@@ -9296,7 +9798,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-            "default": "{colors.text.onSurface.disabled}"
+            "default": "{colors.text.onSurface.disabled}",
+            "virtuozzo": "{colors.text.onSurface.disabled}"
           }
         },
         "hover": {
@@ -9309,7 +9812,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.text.onSurface.primary}"
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         },
         "idle": {
@@ -9322,7 +9826,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.text.onSurface.primary}"
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         }
       },
@@ -9336,7 +9841,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.form-label}",
-          "default": "{typography.body.form-label}"
+          "default": "{typography.body.form-label}",
+          "virtuozzo": "{typography.body.form-label}"
         }
       }
     },
@@ -9352,7 +9858,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-            "default": "{colors.text.onSurface.disabled}"
+            "default": "{colors.text.onSurface.disabled}",
+            "virtuozzo": "{colors.text.onSurface.disabled}"
           }
         },
         "hover": {
@@ -9365,7 +9872,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-            "default": "{colors.text.onSurface.secondary}"
+            "default": "{colors.text.onSurface.secondary}",
+            "virtuozzo": "{colors.text.onSurface.secondary}"
           }
         },
         "idle": {
@@ -9378,7 +9886,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-            "default": "{colors.text.onSurface.secondary}"
+            "default": "{colors.text.onSurface.secondary}",
+            "virtuozzo": "{colors.text.onSurface.secondary}"
           }
         }
       },
@@ -9392,7 +9901,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
-          "default": "{typography.body.default}"
+          "default": "{typography.body.default}",
+          "virtuozzo": "{typography.body.default}"
         }
       }
     },
@@ -9407,7 +9917,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.destructive}",
-          "default": "{colors.text.onSurface.destructive}"
+          "default": "{colors.text.onSurface.destructive}",
+          "virtuozzo": "{colors.text.onSurface.destructive}"
         }
       },
       "textStyle": {
@@ -9420,7 +9931,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
-          "default": "{typography.body.default}"
+          "default": "{typography.body.default}",
+          "virtuozzo": "{typography.body.default}"
         }
       }
     },
@@ -9436,7 +9948,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-            "default": "{colors.text.onSurface.disabled}"
+            "default": "{colors.text.onSurface.disabled}",
+            "virtuozzo": "{colors.text.onSurface.disabled}"
           }
         },
         "hover": {
@@ -9449,7 +9962,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.text.onSurface.primary}"
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         },
         "idle": {
@@ -9462,7 +9976,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.text.onSurface.primary}"
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         }
       },
@@ -9476,7 +9991,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
-          "default": "{typography.body.default}"
+          "default": "{typography.body.default}",
+          "virtuozzo": "{typography.body.default}"
         }
       }
     }
@@ -10342,7 +10858,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.full}",
-            "default": "{units.radius.full}"
+            "default": "{units.radius.full}",
+            "virtuozzo": "{units.radius.full}"
           }
         },
         "borderWidth": {
@@ -10355,7 +10872,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         },
         "marginY": {
@@ -10368,7 +10886,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
-            "default": "{units.gap.4}"
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
           }
         },
         "size": {
@@ -10381,7 +10900,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
-            "default": "{units.size.16}"
+            "default": "{units.size.16}",
+            "virtuozzo": "{units.size.16}"
           }
         }
       },
@@ -10396,7 +10916,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         },
         "widthMax": {
@@ -10409,7 +10930,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.632}",
-            "default": "{units.size.632}"
+            "default": "{units.size.632}",
+            "virtuozzo": "{units.size.632}"
           }
         },
         "widthMin": {
@@ -10422,7 +10944,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
-            "default": "{units.size.16}"
+            "default": "{units.size.16}",
+            "virtuozzo": "{units.size.16}"
           }
         }
       },
@@ -10437,7 +10960,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         },
         "widthMax": {
@@ -10450,7 +10974,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.632}",
-            "default": "{units.size.632}"
+            "default": "{units.size.632}",
+            "virtuozzo": "{units.size.632}"
           }
         }
       },
@@ -10465,7 +10990,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-            "default": "{colors.text.onSurface.secondary}"
+            "default": "{colors.text.onSurface.secondary}",
+            "virtuozzo": "{colors.text.onSurface.secondary}"
           }
         },
         "textStyle": {
@@ -10478,7 +11004,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
-            "default": "{typography.body.default}"
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
           }
         }
       },
@@ -10493,7 +11020,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.text.onSurface.primary}"
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -10506,7 +11034,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
-            "default": "{typography.body.default}"
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
           }
         }
       }
@@ -10524,7 +11053,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "disabled": {
@@ -10537,7 +11067,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}"
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{colors.border.onSurface.border}"
             }
           },
           "hover": {
@@ -10550,7 +11081,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -10563,7 +11095,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           }
         },
@@ -10578,7 +11111,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-active}",
-              "default": "{colors.background.brand.secondary-active}"
+              "default": "{colors.background.brand.secondary-active}",
+              "virtuozzo": "{colors.background.brand.secondary-active}"
             }
           },
           "disabled": {
@@ -10591,7 +11125,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
-              "default": "{colors.background.surface.secondary}"
+              "default": "{colors.background.surface.secondary}",
+              "virtuozzo": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -10604,7 +11139,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary-hover}",
-              "default": "{colors.background.brand.secondary-hover}"
+              "default": "{colors.background.brand.secondary-hover}",
+              "virtuozzo": "{colors.background.brand.secondary-hover}"
             }
           },
           "idle": {
@@ -10617,7 +11153,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.brand.secondary}",
-              "default": "{colors.background.brand.secondary}"
+              "default": "{colors.background.brand.secondary}",
+              "virtuozzo": "{colors.background.brand.secondary}"
             }
           }
         }
@@ -10634,7 +11171,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           },
           "disabled": {
@@ -10647,7 +11185,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.disabled}",
-              "default": "{colors.glyph.onSurface.disabled}"
+              "default": "{colors.glyph.onSurface.disabled}",
+              "virtuozzo": "{colors.glyph.onSurface.disabled}"
             }
           },
           "hover": {
@@ -10660,7 +11199,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           },
           "idle": {
@@ -10673,7 +11213,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-              "default": "{colors.glyph.onBrand.primary}"
+              "default": "{colors.glyph.onBrand.primary}",
+              "virtuozzo": "{colors.glyph.onBrand.primary}"
             }
           }
         }
@@ -10692,7 +11233,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "disabled": {
@@ -10705,7 +11247,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.divider}",
-              "default": "{colors.border.onSurface.divider}"
+              "default": "{colors.border.onSurface.divider}",
+              "virtuozzo": "{colors.border.onSurface.divider}"
             }
           },
           "hover": {
@@ -10718,7 +11261,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-              "default": "{colors.border.onSurface.border-active}"
+              "default": "{colors.border.onSurface.border-active}",
+              "virtuozzo": "{colors.border.onSurface.border-active}"
             }
           },
           "idle": {
@@ -10731,7 +11275,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}"
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{colors.border.onSurface.border}"
             }
           }
         },
@@ -10746,7 +11291,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
-              "default": "{colors.background.surface.active}"
+              "default": "{colors.background.surface.active}",
+              "virtuozzo": "{colors.background.surface.active}"
             }
           },
           "disabled": {
@@ -10759,7 +11305,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
-              "default": "{colors.background.surface.secondary}"
+              "default": "{colors.background.surface.secondary}",
+              "virtuozzo": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -10772,7 +11319,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
-              "default": "{colors.background.surface.hover}"
+              "default": "{colors.background.surface.hover}",
+              "virtuozzo": "{colors.background.surface.hover}"
             }
           },
           "idle": {
@@ -10785,7 +11333,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.primary}",
-              "default": "{colors.background.surface.primary}"
+              "default": "{colors.background.surface.primary}",
+              "virtuozzo": "{colors.background.surface.primary}"
             }
           }
         }
@@ -10805,7 +11354,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-            "default": "{colors.border.onSurface.border-active}"
+            "default": "{colors.border.onSurface.border-active}",
+            "virtuozzo": "{colors.border.onSurface.border-active}"
           }
         },
         "hover": {
@@ -10818,7 +11368,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border-active}",
-            "default": "{colors.border.onSurface.border-active}"
+            "default": "{colors.border.onSurface.border-active}",
+            "virtuozzo": "{colors.border.onSurface.border-active}"
           }
         }
       },
@@ -10832,7 +11383,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "solid",
-          "default": "solid"
+          "default": "solid",
+          "virtuozzo": "solid"
         }
       },
       "width": {
@@ -10845,7 +11397,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.stroke.1}",
-          "default": "{units.stroke.1}"
+          "default": "{units.stroke.1}",
+          "virtuozzo": "{units.stroke.1}"
         }
       }
     },
@@ -10859,7 +11412,8 @@
       "platforms": ["PD"],
       "values": {
         "deep_sky_itkontoret": "ew-resize",
-        "default": "ew-resize"
+        "default": "ew-resize",
+        "virtuozzo": "ew-resize"
       }
     }
   },
@@ -10875,7 +11429,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{gradients.ai.active}",
-          "default": "{gradients.ai.active}"
+          "default": "{gradients.ai.active}",
+          "virtuozzo": "{gradients.ai.active}"
         }
       },
       "hover": {
@@ -10888,7 +11443,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{gradients.ai.hover}",
-          "default": "{gradients.ai.hover}"
+          "default": "{gradients.ai.hover}",
+          "virtuozzo": "{gradients.ai.hover}"
         }
       },
       "idle": {
@@ -10901,7 +11457,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{gradients.ai.idle}",
-          "default": "{gradients.ai.idle}"
+          "default": "{gradients.ai.idle}",
+          "virtuozzo": "{gradients.ai.idle}"
         }
       }
     },
@@ -10916,7 +11473,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.radius.24}",
-          "default": "{units.radius.24}"
+          "default": "{units.radius.24}",
+          "virtuozzo": "{units.radius.24}"
         }
       },
       "borderStyle": {
@@ -10929,7 +11487,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "solid",
-          "default": "solid"
+          "default": "solid",
+          "virtuozzo": "solid"
         }
       },
       "borderWidth": {
@@ -10942,7 +11501,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.stroke.2}",
-          "default": "{units.stroke.2}"
+          "default": "{units.stroke.2}",
+          "virtuozzo": "{units.stroke.2}"
         }
       },
       "color": {
@@ -10955,7 +11515,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.background.surface.primary}",
-          "default": "{colors.background.surface.primary}"
+          "default": "{colors.background.surface.primary}",
+          "virtuozzo": "{colors.background.surface.primary}"
         }
       },
       "gap": {
@@ -10968,7 +11529,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
-          "default": "{units.gap.8}"
+          "default": "{units.gap.8}",
+          "virtuozzo": "{units.gap.8}"
         }
       },
       "height": {
@@ -10981,7 +11543,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.48}",
-          "default": "{units.size.48}"
+          "default": "{units.size.48}",
+          "virtuozzo": "{units.size.48}"
         }
       },
       "paddingX": {
@@ -10994,7 +11557,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.16}",
-          "default": "{units.gap.16}"
+          "default": "{units.gap.16}",
+          "virtuozzo": "{units.gap.16}"
         }
       },
       "width": {
@@ -11007,7 +11571,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.512}",
-          "default": "{units.size.512}"
+          "default": "{units.size.512}",
+          "virtuozzo": "{units.size.512}"
         }
       },
       "widthMax": {
@@ -11020,7 +11585,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.512}",
-          "default": "{units.size.512}"
+          "default": "{units.size.512}",
+          "virtuozzo": "{units.size.512}"
         }
       },
       "widthMin": {
@@ -11033,7 +11599,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.256}",
-          "default": "{units.size.256}"
+          "default": "{units.size.256}",
+          "virtuozzo": "{units.size.256}"
         }
       }
     },
@@ -11048,7 +11615,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.glyph.onStatus.ai}",
-          "default": "{colors.glyph.onStatus.ai}"
+          "default": "{colors.glyph.onStatus.ai}",
+          "virtuozzo": "{colors.glyph.onStatus.ai}"
         }
       },
       "size": {
@@ -11061,7 +11629,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.16}",
-          "default": "{units.size.16}"
+          "default": "{units.size.16}",
+          "virtuozzo": "{units.size.16}"
         }
       }
     },
@@ -11076,7 +11645,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onStatus.ai}",
-          "default": "{colors.text.onStatus.ai}"
+          "default": "{colors.text.onStatus.ai}",
+          "virtuozzo": "{colors.text.onStatus.ai}"
         }
       },
       "textStyle": {
@@ -11089,7 +11659,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
-          "default": "{typography.body.default}"
+          "default": "{typography.body.default}",
+          "virtuozzo": "{typography.body.default}"
         }
       }
     },
@@ -11104,7 +11675,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-          "default": "{colors.text.onSurface.secondary}"
+          "default": "{colors.text.onSurface.secondary}",
+          "virtuozzo": "{colors.text.onSurface.secondary}"
         }
       },
       "textStyle": {
@@ -11117,7 +11689,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.body.default}",
-          "default": "{typography.body.default}"
+          "default": "{typography.body.default}",
+          "virtuozzo": "{typography.body.default}"
         }
       }
     }
@@ -11136,7 +11709,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
-              "default": "{units.gap.8}"
+              "default": "{units.gap.8}",
+              "virtuozzo": "{units.gap.8}"
             }
           },
           "height": {
@@ -11149,7 +11723,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.40}",
-              "default": "{units.size.40}"
+              "default": "{units.size.40}",
+              "virtuozzo": "{units.size.40}"
             }
           },
           "paddingX": {
@@ -11162,7 +11737,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.16}",
-              "default": "{units.gap.16}"
+              "default": "{units.gap.16}",
+              "virtuozzo": "{units.gap.16}"
             }
           },
           "paddingY": {
@@ -11175,7 +11751,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
-              "default": "{units.gap.8}"
+              "default": "{units.gap.8}",
+              "virtuozzo": "{units.gap.8}"
             }
           }
         },
@@ -11190,7 +11767,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.4}",
-              "default": "{units.gap.4}"
+              "default": "{units.gap.4}",
+              "virtuozzo": "{units.gap.4}"
             }
           },
           "size": {
@@ -11203,7 +11781,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.16}",
-              "default": "{units.size.16}"
+              "default": "{units.size.16}",
+              "virtuozzo": "{units.size.16}"
             }
           }
         },
@@ -11218,7 +11797,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.body.strong}",
-              "default": "{typography.body.strong}"
+              "default": "{typography.body.strong}",
+              "virtuozzo": "{typography.body.strong}"
             }
           }
         }
@@ -11236,7 +11816,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.brand.primary-active}",
-                "default": "{colors.background.brand.primary-active}"
+                "default": "{colors.background.brand.primary-active}",
+                "virtuozzo": "{colors.background.brand.primary-active}"
               }
             },
             "hover": {
@@ -11249,7 +11830,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.brand.primary-active}",
-                "default": "{colors.background.brand.primary-active}"
+                "default": "{colors.background.brand.primary-active}",
+                "virtuozzo": "{colors.background.brand.primary-active}"
               }
             },
             "idle": {
@@ -11262,7 +11844,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.brand.primary-active}",
-                "default": "{colors.background.brand.primary-active}"
+                "default": "{colors.background.brand.primary-active}",
+                "virtuozzo": "{colors.background.brand.primary-active}"
               }
             }
           }
@@ -11279,7 +11862,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-                "default": "{colors.glyph.onBrand.primary}"
+                "default": "{colors.glyph.onBrand.primary}",
+                "virtuozzo": "{colors.glyph.onBrand.primary}"
               }
             },
             "hover": {
@@ -11292,7 +11876,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-                "default": "{colors.glyph.onBrand.primary}"
+                "default": "{colors.glyph.onBrand.primary}",
+                "virtuozzo": "{colors.glyph.onBrand.primary}"
               }
             },
             "idle": {
@@ -11305,7 +11890,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onBrand.secondary}",
-                "default": "{colors.glyph.onBrand.primary}"
+                "default": "{colors.glyph.onBrand.primary}",
+                "virtuozzo": "{colors.glyph.onBrand.primary}"
               }
             }
           }
@@ -11322,7 +11908,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
-                "default": "{colors.text.onBrand.primary}"
+                "default": "{colors.text.onBrand.primary}",
+                "virtuozzo": "{colors.text.onBrand.primary}"
               }
             },
             "hover": {
@@ -11335,7 +11922,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
-                "default": "{colors.text.onBrand.primary}"
+                "default": "{colors.text.onBrand.primary}",
+                "virtuozzo": "{colors.text.onBrand.primary}"
               }
             },
             "idle": {
@@ -11348,7 +11936,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
-                "default": "{colors.text.onBrand.primary}"
+                "default": "{colors.text.onBrand.primary}",
+                "virtuozzo": "{colors.text.onBrand.primary}"
               }
             }
           }
@@ -11367,7 +11956,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.brand.primary-hover}",
-                "default": "{colors.background.brand.primary-hover}"
+                "default": "{colors.background.brand.primary-hover}",
+                "virtuozzo": "{colors.background.brand.primary-hover}"
               }
             },
             "hover": {
@@ -11380,7 +11970,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.brand.primary-hover}",
-                "default": "{colors.background.brand.primary-hover}"
+                "default": "{colors.background.brand.primary-hover}",
+                "virtuozzo": "{colors.background.brand.primary-hover}"
               }
             },
             "idle": {
@@ -11393,7 +11984,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.brand.primary}",
-                "default": "{colors.background.brand.primary}"
+                "default": "{colors.background.brand.primary}",
+                "virtuozzo": "{colors.background.brand.primary}"
               }
             }
           }
@@ -11410,7 +12002,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-                "default": "{colors.glyph.onBrand.primary}"
+                "default": "{colors.glyph.onBrand.primary}",
+                "virtuozzo": "{colors.glyph.onBrand.primary}"
               }
             },
             "hover": {
@@ -11423,7 +12016,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-                "default": "{colors.glyph.onBrand.primary}"
+                "default": "{colors.glyph.onBrand.primary}",
+                "virtuozzo": "{colors.glyph.onBrand.primary}"
               }
             },
             "idle": {
@@ -11436,7 +12030,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onBrand.secondary}",
-                "default": "{colors.glyph.onBrand.secondary}"
+                "default": "{colors.glyph.onBrand.secondary}",
+                "virtuozzo": "{colors.glyph.onBrand.secondary}"
               }
             }
           }
@@ -11453,7 +12048,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
-                "default": "{colors.text.onBrand.primary}"
+                "default": "{colors.text.onBrand.primary}",
+                "virtuozzo": "{colors.text.onBrand.primary}"
               }
             },
             "hover": {
@@ -11466,7 +12062,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onBrand.primary}",
-                "default": "{colors.text.onBrand.primary}"
+                "default": "{colors.text.onBrand.primary}",
+                "virtuozzo": "{colors.text.onBrand.primary}"
               }
             },
             "idle": {
@@ -11479,7 +12076,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onBrand.secondary}",
-                "default": "{colors.text.onBrand.secondary}"
+                "default": "{colors.text.onBrand.secondary}",
+                "virtuozzo": "{colors.text.onBrand.secondary}"
               }
             }
           }
@@ -11499,7 +12097,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
-              "default": "{units.gap.8}"
+              "default": "{units.gap.8}",
+              "virtuozzo": "{units.gap.8}"
             }
           }
         },
@@ -11514,7 +12113,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onBrand.secondary}",
-              "default": "{colors.glyph.onBrand.secondary}"
+              "default": "{colors.glyph.onBrand.secondary}",
+              "virtuozzo": "{colors.glyph.onBrand.secondary}"
             }
           },
           "size": {
@@ -11527,7 +12127,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.16}",
-              "default": "{units.size.16}"
+              "default": "{units.size.16}",
+              "virtuozzo": "{units.size.16}"
             }
           }
         },
@@ -11542,7 +12143,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onBrand.secondary}",
-              "default": "{colors.text.onBrand.secondary}"
+              "default": "{colors.text.onBrand.secondary}",
+              "virtuozzo": "{colors.text.onBrand.secondary}"
             }
           },
           "textStyle": {
@@ -11555,7 +12157,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.body.default}",
-              "default": "{typography.body.default}"
+              "default": "{typography.body.default}",
+              "virtuozzo": "{typography.body.default}"
             }
           }
         }
@@ -11573,7 +12176,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         }
       },
@@ -11588,7 +12192,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onBrand.border}",
-            "default": "{colors.border.onBrand.border}"
+            "default": "{colors.border.onBrand.border}",
+            "virtuozzo": "{colors.border.onBrand.border}"
           }
         },
         "borderWidth": {
@@ -11601,7 +12206,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         },
         "paddingY": {
@@ -11614,7 +12220,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         }
       }
@@ -11631,7 +12238,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.brand.primary}",
-            "default": "{colors.background.brand.primary}"
+            "default": "{colors.background.brand.primary}",
+            "virtuozzo": "{colors.background.brand.primary}"
           }
         }
       },
@@ -11646,7 +12254,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onBrand.border}",
-            "default": "{colors.border.onBrand.border}"
+            "default": "{colors.border.onBrand.border}",
+            "virtuozzo": "{colors.border.onBrand.border}"
           }
         },
         "borderWidth": {
@@ -11659,7 +12268,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         }
       },
@@ -11674,7 +12284,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         }
       },
@@ -11689,7 +12300,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onBrand.primary}",
-            "default": "{colors.glyph.onBrand.primary}"
+            "default": "{colors.glyph.onBrand.primary}",
+            "virtuozzo": "{colors.glyph.onBrand.primary}"
           }
         }
       },
@@ -11704,7 +12316,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         }
       }
@@ -11721,7 +12334,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.48}",
-            "default": "{units.size.48}"
+            "default": "{units.size.48}",
+            "virtuozzo": "{units.size.48}"
           }
         }
       },
@@ -11736,7 +12350,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         },
         "paddingY": {
@@ -11749,7 +12364,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
-            "default": "{units.gap.16}"
+            "default": "{units.gap.16}",
+            "virtuozzo": "{units.gap.16}"
           }
         }
       },
@@ -11764,7 +12380,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
-            "default": "{units.size.32}"
+            "default": "{units.size.32}",
+            "virtuozzo": "{units.size.32}"
           }
         }
       }
@@ -11781,7 +12398,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.256}",
-            "default": "{units.size.256}"
+            "default": "{units.size.256}",
+            "virtuozzo": "{units.size.256}"
           }
         }
       },
@@ -11796,7 +12414,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
-            "default": "{units.gap.16}"
+            "default": "{units.gap.16}",
+            "virtuozzo": "{units.gap.16}"
           }
         },
         "paddingY": {
@@ -11809,7 +12428,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         }
       },
@@ -11824,7 +12444,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.48}",
-            "default": "{units.size.48}"
+            "default": "{units.size.48}",
+            "virtuozzo": "{units.size.48}"
           }
         }
       }
@@ -11844,7 +12465,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
-              "default": "{units.gap.8}"
+              "default": "{units.gap.8}",
+              "virtuozzo": "{units.gap.8}"
             }
           },
           "heightMin": {
@@ -11857,7 +12479,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.40}",
-              "default": "{units.size.40}"
+              "default": "{units.size.40}",
+              "virtuozzo": "{units.size.40}"
             }
           },
           "paddingX": {
@@ -11870,7 +12493,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.16}",
-              "default": "{units.gap.16}"
+              "default": "{units.gap.16}",
+              "virtuozzo": "{units.gap.16}"
             }
           },
           "paddingY": {
@@ -11883,7 +12507,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
-              "default": "{units.gap.8}"
+              "default": "{units.gap.8}",
+              "virtuozzo": "{units.gap.8}"
             }
           }
         },
@@ -11899,7 +12524,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-                "default": "{colors.glyph.onSurface.primary}"
+                "default": "{colors.glyph.onSurface.primary}",
+                "virtuozzo": "{colors.glyph.onSurface.primary}"
               }
             }
           },
@@ -11913,7 +12539,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.4}",
-              "default": "{units.gap.4}"
+              "default": "{units.gap.4}",
+              "virtuozzo": "{units.gap.4}"
             }
           },
           "size": {
@@ -11926,7 +12553,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.16}",
-              "default": "{units.size.16}"
+              "default": "{units.size.16}",
+              "virtuozzo": "{units.size.16}"
             }
           }
         },
@@ -11942,7 +12570,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-                "default": "{colors.text.onSurface.primary}"
+                "default": "{colors.text.onSurface.primary}",
+                "virtuozzo": "{colors.text.onSurface.primary}"
               }
             }
           },
@@ -11956,7 +12585,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.body.default}",
-              "default": "{typography.body.default}"
+              "default": "{typography.body.default}",
+              "virtuozzo": "{typography.body.default}"
             }
           }
         }
@@ -11974,7 +12604,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.active}",
-                "default": "{colors.background.surface.active}"
+                "default": "{colors.background.surface.active}",
+                "virtuozzo": "{colors.background.surface.active}"
               }
             },
             "hover": {
@@ -11987,7 +12618,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.active}",
-                "default": "{colors.background.surface.active}"
+                "default": "{colors.background.surface.active}",
+                "virtuozzo": "{colors.background.surface.active}"
               }
             },
             "idle": {
@@ -12000,7 +12632,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.active}",
-                "default": "{colors.background.surface.active}"
+                "default": "{colors.background.surface.active}",
+                "virtuozzo": "{colors.background.surface.active}"
               }
             }
           }
@@ -12019,7 +12652,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.hover}",
-                "default": "{colors.background.surface.hover}"
+                "default": "{colors.background.surface.hover}",
+                "virtuozzo": "{colors.background.surface.active}"
               }
             },
             "hover": {
@@ -12032,7 +12666,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.hover}",
-                "default": "{colors.background.surface.hover}"
+                "default": "{colors.background.surface.hover}",
+                "virtuozzo": "{colors.background.surface.hover}"
               }
             },
             "idle": {
@@ -12045,7 +12680,8 @@
               "platforms": ["PD"],
               "values": {
                 "deep_sky_itkontoret": "{colors.background.surface.primary}",
-                "default": "{colors.background.surface.secondary}"
+                "default": "{colors.background.surface.secondary}",
+                "virtuozzo": "{colors.background.surface.secondary}"
               }
             }
           }
@@ -12065,7 +12701,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.gap.8}",
-              "default": "{units.gap.8}"
+              "default": "{units.gap.8}",
+              "virtuozzo": "{units.gap.8}"
             }
           }
         },
@@ -12080,7 +12717,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           },
           "size": {
@@ -12093,7 +12731,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.16}",
-              "default": "{units.size.16}"
+              "default": "{units.size.16}",
+              "virtuozzo": "{units.size.16}"
             }
           }
         },
@@ -12108,7 +12747,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-              "default": "{colors.text.onSurface.secondary}"
+              "default": "{colors.text.onSurface.secondary}",
+              "virtuozzo": "{colors.text.onSurface.secondary}"
             }
           },
           "textStyle": {
@@ -12121,7 +12761,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{typography.body.default}",
-              "default": "{typography.body.default}"
+              "default": "{typography.body.default}",
+              "virtuozzo": "{typography.body.default}"
             }
           }
         }
@@ -12139,7 +12780,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         }
       },
@@ -12154,7 +12796,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         }
       },
@@ -12169,7 +12812,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         },
         "minWidth": {
@@ -12182,7 +12826,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": 36,
-            "default": 36
+            "default": 36,
+            "virtuozzo": "{units.size.40}"
           }
         },
         "paddingX": {
@@ -12195,7 +12840,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
-            "default": "{units.gap.16}"
+            "default": "{units.gap.16}",
+            "virtuozzo": "{units.gap.16}"
           }
         },
         "paddingY": {
@@ -12208,7 +12854,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.2}"
+            "default": "{units.gap.2}",
+            "virtuozzo": "{units.gap.2}"
           }
         }
       },
@@ -12226,7 +12873,8 @@
               "colorSpace": "hsl",
               "components": [0, 0, 100]
             },
-            "default": "{colors.glyph.onSurface.primary}"
+            "default": "{colors.glyph.onSurface.primary}",
+            "virtuozzo": "{colors.glyph.onSurface.primary}"
           }
         }
       },
@@ -12241,7 +12889,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.text.onSurface.primary}"
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -12254,7 +12903,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
-            "default": "{typography.body.strong}"
+            "default": "{typography.body.strong}",
+            "virtuozzo": "{typography.body.strong}"
           }
         }
       }
@@ -12271,7 +12921,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-            "default": "{colors.border.onSurface.border}"
+            "default": "{colors.border.onSurface.border}",
+            "virtuozzo": "{colors.border.onSurface.border}"
           }
         },
         "borderWidth": {
@@ -12284,7 +12935,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         },
         "color": {
@@ -12297,7 +12949,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.surface.primary}",
-            "default": "{colors.background.surface.secondary}"
+            "default": "{colors.background.surface.secondary}",
+            "virtuozzo": "{colors.background.surface.secondary}"
           }
         }
       },
@@ -12312,7 +12965,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-            "default": "{colors.border.onSurface.border}"
+            "default": "{colors.border.onSurface.border}",
+            "virtuozzo": "{colors.border.onSurface.border}"
           }
         },
         "borderWidth": {
@@ -12325,7 +12979,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         }
       },
@@ -12340,7 +12995,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
-            "default": "{units.gap.16}"
+            "default": "{units.gap.16}",
+            "virtuozzo": "{units.gap.16}"
           }
         },
         "paddingY": {
@@ -12353,7 +13009,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.12}",
-            "default": "{units.gap.12}"
+            "default": "{units.gap.12}",
+            "virtuozzo": "{units.gap.16}"
           }
         }
       },
@@ -12368,7 +13025,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.text.onSurface.primary}"
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -12381,7 +13039,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.headings.title}",
-            "default": "{typography.headings.title}"
+            "default": "{typography.headings.title}",
+            "virtuozzo": "{typography.headings.title}"
           }
         }
       },
@@ -12396,7 +13055,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         }
       }
@@ -12413,7 +13073,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.secondary}",
-            "default": "{colors.text.onSurface.secondary}"
+            "default": "{colors.text.onSurface.secondary}",
+            "virtuozzo": "{colors.text.onSurface.secondary}"
           }
         },
         "textStyle": {
@@ -12426,7 +13087,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
-            "default": "{typography.body.strong}"
+            "default": "{typography.body.strong}",
+            "virtuozzo": "{typography.body.strong}"
           }
         }
       },
@@ -12441,7 +13103,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.48}",
-            "default": "{units.size.48}"
+            "default": "{units.size.48}",
+            "virtuozzo": "{units.size.48}"
           }
         }
       },
@@ -12456,7 +13119,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
-            "default": "{units.gap.4}"
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
           }
         },
         "paddingY": {
@@ -12469,7 +13133,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
-            "default": "{units.gap.16}"
+            "default": "{units.gap.16}",
+            "virtuozzo": "{units.gap.16}"
           }
         }
       },
@@ -12484,7 +13149,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         },
         "paddingY": {
@@ -12497,7 +13163,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
-            "default": "{units.gap.16}"
+            "default": "{units.gap.16}",
+            "virtuozzo": "{units.gap.16}"
           }
         }
       },
@@ -12512,7 +13179,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onSurface.neutral}",
-            "default": "{colors.glyph.onSurface.neutral}"
+            "default": "{colors.glyph.onSurface.neutral}",
+            "virtuozzo": "{colors.glyph.onSurface.neutral}"
           }
         },
         "size": {
@@ -12525,7 +13193,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
-            "default": "{units.size.16}"
+            "default": "{units.size.16}",
+            "virtuozzo": "{units.size.16}"
           }
         }
       },
@@ -12540,7 +13209,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.text.onSurface.primary}"
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -12553,7 +13223,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
-            "default": "{typography.body.strong}"
+            "default": "{typography.body.strong}",
+            "virtuozzo": "{typography.body.strong}"
           }
         }
       }
@@ -12570,7 +13241,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.256}",
-            "default": "{units.size.256}"
+            "default": "{units.size.256}",
+            "virtuozzo": "{units.size.256}"
           }
         }
       },
@@ -12585,7 +13257,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.16}",
-            "default": "{units.gap.16}"
+            "default": "{units.gap.16}",
+            "virtuozzo": "{units.gap.16}"
           }
         },
         "paddingY": {
@@ -12598,7 +13271,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         }
       }
@@ -12618,7 +13292,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.transparent}",
-              "default": "{colors.border.transparent}"
+              "default": "{colors.border.transparent}",
+              "virtuozzo": "{colors.border.transparent}"
             }
           },
           "disabled": {
@@ -12631,7 +13306,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.onSurface.border}",
-              "default": "{colors.border.onSurface.border}"
+              "default": "{colors.border.onSurface.border}",
+              "virtuozzo": "{colors.border.onSurface.border}"
             }
           },
           "hover": {
@@ -12644,7 +13320,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.transparent}",
-              "default": "{colors.border.transparent}"
+              "default": "{colors.border.transparent}",
+              "virtuozzo": "{colors.border.transparent}"
             }
           },
           "idle": {
@@ -12657,7 +13334,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.border.transparent}",
-              "default": "{colors.border.transparent}"
+              "default": "{colors.border.transparent}",
+              "virtuozzo": "{colors.border.transparent}"
             }
           }
         },
@@ -12671,7 +13349,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.full}",
-            "default": "{units.radius.full}"
+            "default": "{units.radius.full}",
+            "virtuozzo": "{units.radius.full}"
           }
         },
         "borderStyle": {
@@ -12684,7 +13363,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "solid",
-            "default": "solid"
+            "default": "solid",
+            "virtuozzo": "solid"
           }
         },
         "borderWidth": {
@@ -12697,7 +13377,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         },
         "height": {
@@ -12710,7 +13391,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
-            "default": "{units.size.16}"
+            "default": "{units.size.16}",
+            "virtuozzo": "{units.size.16}"
           }
         },
         "paddingX": {
@@ -12723,7 +13405,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.2}",
-            "default": "{units.gap.2}"
+            "default": "{units.gap.2}",
+            "virtuozzo": "{units.gap.2}"
           }
         },
         "paddingY": {
@@ -12736,7 +13419,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.2}",
-            "default": "{units.gap.2}"
+            "default": "{units.gap.2}",
+            "virtuozzo": "{units.gap.2}"
           }
         },
         "width": {
@@ -12749,7 +13433,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
-            "default": "{units.size.32}"
+            "default": "{units.size.32}",
+            "virtuozzo": "{units.size.32}"
           }
         }
       },
@@ -12764,7 +13449,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         }
       },
@@ -12779,7 +13465,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.text.onSurface.primary}"
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -12792,7 +13479,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
-            "default": "{typography.body.default}"
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
           }
         }
       },
@@ -12807,7 +13495,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.full}",
-            "default": "{units.radius.full}"
+            "default": "{units.radius.full}",
+            "virtuozzo": "{units.radius.full}"
           }
         },
         "color": {
@@ -12821,7 +13510,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.base}",
-              "default": "{palette.base}"
+              "default": "{palette.base}",
+              "virtuozzo": "{palette.base}"
             }
           },
           "disabled": {
@@ -12834,7 +13524,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onStatus.disabled}",
-              "default": "{colors.glyph.onStatus.disabled}"
+              "default": "{colors.glyph.onStatus.disabled}",
+              "virtuozzo": "{colors.glyph.onStatus.disabled}"
             }
           },
           "hover": {
@@ -12847,7 +13538,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.base}",
-              "default": "{palette.base}"
+              "default": "{palette.base}",
+              "virtuozzo": "{palette.base}"
             }
           },
           "idle": {
@@ -12860,7 +13552,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.base}",
-              "default": "{palette.base}"
+              "default": "{palette.base}",
+              "virtuozzo": "{palette.base}"
             }
           }
         },
@@ -12874,7 +13567,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.12}",
-            "default": "{units.size.12}"
+            "default": "{units.size.12}",
+            "virtuozzo": "{units.size.12}"
           }
         }
       }
@@ -12892,7 +13586,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.off}",
-              "default": "{colors.background.status.off}"
+              "default": "{colors.background.status.off}",
+              "virtuozzo": "{colors.background.status.off}"
             }
           },
           "disabled": {
@@ -12905,7 +13600,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
-              "default": "{colors.background.surface.secondary}"
+              "default": "{colors.background.surface.secondary}",
+              "virtuozzo": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -12918,7 +13614,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.off}",
-              "default": "{colors.background.status.off}"
+              "default": "{colors.background.status.off}",
+              "virtuozzo": "{colors.background.status.off}"
             }
           },
           "idle": {
@@ -12931,7 +13628,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.off}",
-              "default": "{colors.background.status.off}"
+              "default": "{colors.background.status.off}",
+              "virtuozzo": "{colors.background.status.off}"
             }
           }
         }
@@ -12950,7 +13648,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.on}",
-              "default": "{colors.background.status.on}"
+              "default": "{colors.background.status.on}",
+              "virtuozzo": "{colors.background.status.on}"
             }
           },
           "disabled": {
@@ -12963,7 +13662,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.secondary}",
-              "default": "{colors.background.surface.secondary}"
+              "default": "{colors.background.surface.secondary}",
+              "virtuozzo": "{colors.background.surface.secondary}"
             }
           },
           "hover": {
@@ -12976,7 +13676,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.on}",
-              "default": "{colors.background.status.on}"
+              "default": "{colors.background.status.on}",
+              "virtuozzo": "{colors.background.status.on}"
             }
           },
           "idle": {
@@ -12989,7 +13690,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.status.on}",
-              "default": "{colors.background.status.on}"
+              "default": "{colors.background.status.on}",
+              "virtuozzo": "{colors.background.status.on}"
             }
           }
         }
@@ -13054,7 +13756,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
-          "default": "{units.gap.8}"
+          "default": "{units.gap.8}",
+          "virtuozzo": "{units.gap.8}"
         }
       },
       "row": {
@@ -13115,7 +13818,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.disabled}",
-              "default": "{colors.text.onSurface.disabled}"
+              "default": "{colors.text.onSurface.disabled}",
+              "virtuozzo": "{colors.text.onSurface.disabled}"
             }
           },
           "idle": {
@@ -13128,7 +13832,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-              "default": "{colors.text.onSurface.primary}"
+              "default": "{colors.text.onSurface.primary}",
+              "virtuozzo": "{colors.text.onSurface.primary}"
             }
           }
         },
@@ -13142,7 +13847,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.default}",
-            "default": "{typography.body.default}"
+            "default": "{typography.body.default}",
+            "virtuozzo": "{typography.body.default}"
           }
         }
       }
@@ -13160,7 +13866,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.active}",
-              "default": "{colors.background.surface.active}"
+              "default": "{colors.background.surface.active}",
+              "virtuozzo": "{colors.background.surface.active}"
             }
           },
           "hover": {
@@ -13173,7 +13880,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.background.surface.hover}",
-              "default": "{colors.background.surface.hover}"
+              "default": "{colors.background.surface.hover}",
+              "virtuozzo": "{colors.background.surface.hover}"
             }
           },
           "idle": {
@@ -13186,7 +13894,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "transparent",
-              "default": "transparent"
+              "default": "transparent",
+              "virtuozzo": "transparent"
             }
           }
         }
@@ -13201,7 +13910,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
-          "default": "{units.gap.8}"
+          "default": "{units.gap.8}",
+          "virtuozzo": "{units.gap.8}"
         }
       },
       "label": {
@@ -13215,7 +13925,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onSurface.primary}",
-            "default": "{colors.text.onSurface.primary}"
+            "default": "{colors.text.onSurface.primary}",
+            "virtuozzo": "{colors.text.onSurface.primary}"
           }
         },
         "textStyle": {
@@ -13228,7 +13939,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.body.strong}",
-            "default": "{typography.body.strong}"
+            "default": "{typography.body.strong}",
+            "virtuozzo": "{typography.body.strong}"
           }
         }
       },
@@ -13244,7 +13956,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.primary}",
-              "default": "{colors.glyph.onSurface.primary}"
+              "default": "{colors.glyph.onSurface.primary}",
+              "virtuozzo": "{colors.glyph.onSurface.primary}"
             }
           },
           "inactive": {
@@ -13257,7 +13970,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{colors.glyph.onSurface.neutral}",
-              "default": "{colors.glyph.onSurface.neutral}"
+              "default": "{colors.glyph.onSurface.neutral}",
+              "virtuozzo": "{colors.glyph.onSurface.neutral}"
             }
           }
         },
@@ -13271,7 +13985,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
-            "default": "{units.size.16}"
+            "default": "{units.size.16}",
+            "virtuozzo": "{units.size.16}"
           }
         }
       }
@@ -13304,7 +14019,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.40}",
-            "default": "{units.size.40}"
+            "default": "{units.size.40}",
+            "virtuozzo": "{units.size.40}"
           }
         },
         "paddingX": {
@@ -13317,7 +14033,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.16}",
-            "default": "{units.size.16}"
+            "default": "{units.size.16}",
+            "virtuozzo": "{units.size.16}"
           }
         },
         "paddingY": {
@@ -13330,7 +14047,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.8}",
-            "default": "{units.size.8}"
+            "default": "{units.size.8}",
+            "virtuozzo": "{units.size.8}"
           }
         },
         "tag": {
@@ -13409,7 +14127,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.radius.full}",
-            "default": "{units.radius.full}"
+            "default": "{units.radius.full}",
+            "virtuozzo": "{units.radius.full}"
           }
         },
         "borderWidth": {
@@ -13422,7 +14141,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.stroke.1}",
-            "default": "{units.stroke.1}"
+            "default": "{units.stroke.1}",
+            "virtuozzo": "{units.stroke.1}"
           }
         },
         "gap": {
@@ -13435,7 +14155,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.4}",
-            "default": "{units.gap.4}"
+            "default": "{units.gap.4}",
+            "virtuozzo": "{units.gap.4}"
           }
         },
         "paddingX": {
@@ -13448,7 +14169,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.8}",
-            "default": "{units.gap.8}"
+            "default": "{units.gap.8}",
+            "virtuozzo": "{units.gap.8}"
           }
         },
         "paddingY": {
@@ -13461,7 +14183,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.gap.0}",
-            "default": "{units.gap.0}"
+            "default": "{units.gap.0}",
+            "virtuozzo": "{units.gap.0}"
           }
         },
         "widthMax": {
@@ -13474,7 +14197,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.256}",
-            "default": "{units.size.256}"
+            "default": "{units.size.256}",
+            "virtuozzo": "{units.size.256}"
           }
         },
         "widthMin": {
@@ -13487,7 +14211,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{units.size.32}",
-            "default": "{units.size.32}"
+            "default": "{units.size.32}",
+            "virtuozzo": "{units.size.32}"
           }
         }
       },
@@ -13502,7 +14227,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{typography.caption.strong}",
-            "default": "{typography.caption.strong}"
+            "default": "{typography.caption.strong}",
+            "virtuozzo": "{typography.caption.strong}"
           }
         }
       },
@@ -13518,7 +14244,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.24}",
-              "default": "{units.size.24}"
+              "default": "{units.size.24}",
+              "virtuozzo": "{units.size.24}"
             }
           }
         },
@@ -13533,7 +14260,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.stroke.1-6}",
-              "default": "{units.stroke.1-6}"
+              "default": "{units.stroke.1-6}",
+              "virtuozzo": "{units.stroke.1-6}"
             }
           },
           "size": {
@@ -13546,7 +14274,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.16}",
-              "default": "{units.size.16}"
+              "default": "{units.size.16}",
+              "virtuozzo": "{units.size.16}"
             }
           }
         }
@@ -13563,7 +14292,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{units.size.20}",
-              "default": "{units.size.20}"
+              "default": "{units.size.20}",
+              "virtuozzo": "{units.size.20}"
             }
           }
         }
@@ -13581,7 +14311,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{gradients.ai.idle}",
-            "default": "{gradients.ai.idle}"
+            "default": "{gradients.ai.idle}",
+            "virtuozzo": "{gradients.ai.idle}"
           }
         },
         "color": {
@@ -13594,7 +14325,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.ai}",
-            "default": "{colors.background.status.ai}"
+            "default": "{colors.background.status.ai}",
+            "virtuozzo": "{colors.background.status.ai}"
           }
         }
       },
@@ -13609,7 +14341,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.ai}",
-            "default": "{colors.glyph.onStatus.ai}"
+            "default": "{colors.glyph.onStatus.ai}",
+            "virtuozzo": "{colors.glyph.onStatus.ai}"
           }
         }
       },
@@ -13624,7 +14357,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.ai}",
-            "default": "{colors.text.onStatus.ai}"
+            "default": "{colors.text.onStatus.ai}",
+            "virtuozzo": "{colors.text.onStatus.ai}"
           }
         }
       }
@@ -13641,7 +14375,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onStatus.critical}",
-            "default": "{colors.border.onStatus.critical}"
+            "default": "{colors.border.onStatus.critical}",
+            "virtuozzo": "{colors.border.onStatus.critical}"
           }
         },
         "color": {
@@ -13654,7 +14389,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.critical}",
-            "default": "{colors.background.status.critical}"
+            "default": "{colors.background.status.critical}",
+            "virtuozzo": "{colors.background.status.critical}"
           }
         }
       },
@@ -13669,7 +14405,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.critical}",
-            "default": "{colors.glyph.onStatus.critical}"
+            "default": "{colors.glyph.onStatus.critical}",
+            "virtuozzo": "{colors.glyph.onStatus.critical}"
           }
         }
       },
@@ -13684,7 +14421,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.critical}",
-            "default": "{colors.text.onStatus.critical}"
+            "default": "{colors.text.onStatus.critical}",
+            "virtuozzo": "{colors.text.onStatus.critical}"
           }
         }
       }
@@ -13701,7 +14439,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onStatus.danger}",
-            "default": "{colors.border.onStatus.danger}"
+            "default": "{colors.border.onStatus.danger}",
+            "virtuozzo": "{colors.border.onStatus.danger}"
           }
         },
         "color": {
@@ -13714,7 +14453,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.danger}",
-            "default": "{colors.background.status.danger}"
+            "default": "{colors.background.status.danger}",
+            "virtuozzo": "{colors.background.status.danger}"
           }
         }
       },
@@ -13729,7 +14469,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.danger}",
-            "default": "{colors.glyph.onStatus.danger}"
+            "default": "{colors.glyph.onStatus.danger}",
+            "virtuozzo": "{colors.glyph.onStatus.danger}"
           }
         }
       },
@@ -13744,7 +14485,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.danger}",
-            "default": "{colors.text.onStatus.danger}"
+            "default": "{colors.text.onStatus.danger}",
+            "virtuozzo": "{colors.text.onStatus.danger}"
           }
         }
       }
@@ -13761,7 +14503,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onStatus.info}",
-            "default": "{colors.border.onStatus.info}"
+            "default": "{colors.border.onStatus.info}",
+            "virtuozzo": "{colors.border.onStatus.info}"
           }
         },
         "color": {
@@ -13774,7 +14517,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.info}",
-            "default": "{colors.background.status.info}"
+            "default": "{colors.background.status.info}",
+            "virtuozzo": "{colors.background.status.info}"
           }
         }
       },
@@ -13789,7 +14533,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.info}",
-            "default": "{colors.glyph.onStatus.info}"
+            "default": "{colors.glyph.onStatus.info}",
+            "virtuozzo": "{colors.glyph.onStatus.info}"
           }
         }
       },
@@ -13804,7 +14549,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.info}",
-            "default": "{colors.text.onStatus.info}"
+            "default": "{colors.text.onStatus.info}",
+            "virtuozzo": "{colors.text.onStatus.info}"
           }
         }
       }
@@ -13821,7 +14567,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onStatus.neutral}",
-            "default": "{colors.border.onStatus.neutral}"
+            "default": "{colors.border.onStatus.neutral}",
+            "virtuozzo": "{colors.border.onStatus.neutral}"
           }
         },
         "color": {
@@ -13834,7 +14581,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.neutral}",
-            "default": "{colors.background.status.neutral}"
+            "default": "{colors.background.status.neutral}",
+            "virtuozzo": "{colors.background.status.neutral}"
           }
         }
       },
@@ -13849,7 +14597,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.neutral}",
-            "default": "{colors.glyph.onStatus.neutral}"
+            "default": "{colors.glyph.onStatus.neutral}",
+            "virtuozzo": "{colors.glyph.onStatus.neutral}"
           }
         }
       },
@@ -13864,7 +14613,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.neutral}",
-            "default": "{colors.text.onStatus.neutral}"
+            "default": "{colors.text.onStatus.neutral}",
+            "virtuozzo": "{colors.text.onStatus.neutral}"
           }
         }
       }
@@ -13881,7 +14631,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onStatus.success}",
-            "default": "{colors.border.onStatus.success}"
+            "default": "{colors.border.onStatus.success}",
+            "virtuozzo": "{colors.border.onStatus.success}"
           }
         },
         "color": {
@@ -13894,7 +14645,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.success}",
-            "default": "{colors.background.status.success}"
+            "default": "{colors.background.status.success}",
+            "virtuozzo": "{colors.background.status.success}"
           }
         }
       },
@@ -13909,7 +14661,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.success}",
-            "default": "{colors.glyph.onStatus.success}"
+            "default": "{colors.glyph.onStatus.success}",
+            "virtuozzo": "{colors.glyph.onStatus.success}"
           }
         }
       },
@@ -13924,7 +14677,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.success}",
-            "default": "{colors.text.onStatus.success}"
+            "default": "{colors.text.onStatus.success}",
+            "virtuozzo": "{colors.text.onStatus.success}"
           }
         }
       }
@@ -13941,7 +14695,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.border.onStatus.warning}",
-            "default": "{colors.border.onStatus.warning}"
+            "default": "{colors.border.onStatus.warning}",
+            "virtuozzo": "{colors.border.onStatus.warning}"
           }
         },
         "color": {
@@ -13954,7 +14709,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.background.status.warning}",
-            "default": "{colors.background.status.warning}"
+            "default": "{colors.background.status.warning}",
+            "virtuozzo": "{colors.background.status.warning}"
           }
         }
       },
@@ -13969,7 +14725,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.glyph.onStatus.warning}",
-            "default": "{colors.glyph.onStatus.warning}"
+            "default": "{colors.glyph.onStatus.warning}",
+            "virtuozzo": "{colors.glyph.onStatus.warning}"
           }
         }
       },
@@ -13984,7 +14741,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{colors.text.onStatus.warning}",
-            "default": "{colors.text.onStatus.warning}"
+            "default": "{colors.text.onStatus.warning}",
+            "virtuozzo": "{colors.text.onStatus.warning}"
           }
         }
       }
@@ -14002,7 +14760,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.radius.4}",
-          "default": "{units.radius.4}"
+          "default": "{units.radius.4}",
+          "virtuozzo": "{units.radius.4}"
         }
       },
       "color": {
@@ -14015,7 +14774,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.background.inverse.primary}",
-          "default": "{colors.background.inverse.primary}"
+          "default": "{colors.background.inverse.primary}",
+          "virtuozzo": "{colors.background.inverse.primary}"
         }
       },
       "paddingX": {
@@ -14028,7 +14788,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.12}",
-          "default": "{units.gap.12}"
+          "default": "{units.gap.12}",
+          "virtuozzo": "{units.gap.12}"
         }
       },
       "paddingY": {
@@ -14041,7 +14802,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.gap.8}",
-          "default": "{units.gap.8}"
+          "default": "{units.gap.8}",
+          "virtuozzo": "{units.gap.8}"
         }
       },
       "widthMax": {
@@ -14054,7 +14816,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.256}",
-          "default": "{units.size.256}"
+          "default": "{units.size.256}",
+          "virtuozzo": "{units.size.256}"
         }
       },
       "widthMin": {
@@ -14067,7 +14830,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{units.size.48}",
-          "default": "{units.size.48}"
+          "default": "{units.size.48}",
+          "virtuozzo": "{units.size.48}"
         }
       }
     },
@@ -14082,7 +14846,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{colors.text.onInverse.primary}",
-          "default": "{colors.text.onInverse.primary}"
+          "default": "{colors.text.onInverse.primary}",
+          "virtuozzo": "{colors.text.onInverse.primary}"
         }
       },
       "textStyle": {
@@ -14095,7 +14860,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{typography.caption.strong}",
-          "default": "{typography.caption.strong}"
+          "default": "{typography.caption.strong}",
+          "virtuozzo": "{typography.caption.default}"
         }
       }
     }

--- a/packages/design-tokens/tiers/primitives.json
+++ b/packages/design-tokens/tiers/primitives.json
@@ -1704,6 +1704,114 @@
         }
       }
     },
+    "red_home_pl": {
+      "ButtonPrimary": {
+        "active": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:5242:10313"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "dark": { "colorSpace": "hsl", "components": [215.24, 79.89, 35.1] },
+            "light": { "colorSpace": "hsl", "components": [220, 5.88, 20] }
+          }
+        },
+        "disabled": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:5242:10314"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "dark": { "colorSpace": "hsl", "components": [220, 5.88, 20] },
+            "light": { "colorSpace": "hsl", "components": [210, 5.26, 85.1] }
+          }
+        },
+        "hover": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:5242:10312"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "dark": { "colorSpace": "hsl", "components": [215.22, 80, 45.1] },
+            "light": { "colorSpace": "hsl", "components": [220, 4.69, 25.1] }
+          }
+        },
+        "idle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:5242:10311"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "dark": {
+              "colorSpace": "hsl",
+              "components": [212.36, 90.16, 64.12]
+            },
+            "light": { "colorSpace": "hsl", "components": [214.29, 4.58, 30] }
+          }
+        }
+      },
+      "SidebarPrimary": {
+        "active": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:4031:9608"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "dark": {
+              "colorSpace": "hsl",
+              "components": [212.36, 90.16, 64.12]
+            },
+            "light": { "colorSpace": "hsl", "components": [0, 100, 88.04] }
+          }
+        },
+        "disabled": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:5242:10306"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "dark": { "colorSpace": "hsl", "components": [213.33, 5.03, 35.1] },
+            "light": { "colorSpace": "hsl", "components": [0, 100, 96.08] }
+          }
+        },
+        "hover": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:5242:10305"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "dark": { "colorSpace": "hsl", "components": [220, 4.69, 25.1] },
+            "light": { "colorSpace": "hsl", "components": [0, 100, 53.92] }
+          }
+        },
+        "idle": {
+          "$extensions": {
+            "com.figma.hiddenFromPublishing": true,
+            "com.figma.scopes": [],
+            "com.figma.variableId": "VariableID:4031:9609"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "dark": { "colorSpace": "hsl", "components": [240, 7.69, 5.1] },
+            "light": { "colorSpace": "hsl", "components": [0, 100, 44.12] }
+          }
+        }
+      }
+    },
     "sand": {
       "ButtonPrimary": {
         "active": {
@@ -2874,7 +2982,7 @@
         },
         "platforms": ["PD"],
         "values": {
-          "dark": { "colorSpace": "hsl", "components": [38.82, 100, 50] },
+          "dark": { "colorSpace": "hsl", "components": [212.2, 80.39, 70] },
           "light": { "colorSpace": "hsl", "components": [214.81, 85.62, 30] }
         }
       },
@@ -4277,7 +4385,7 @@
         "platforms": ["PD"],
         "values": {
           "dark": { "colorSpace": "hsl", "components": [300, 50.82, 11.96] },
-          "light": { "colorSpace": "hsl", "components": [0, 0, 100] }
+          "light": { "colorSpace": "hsl", "components": [300, 80, 98.04] }
         }
       },
       "1": {
@@ -4935,6 +5043,14 @@
         "$value": { "unit": "px", "value": 72 },
         "platforms": ["PD"]
       },
+      "76": {
+        "$extensions": {
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
+          "com.figma.variableId": "VariableID:6327:19743"
+        },
+        "$value": { "unit": "px", "value": 76 },
+        "platforms": ["PD"]
+      },
       "96": {
         "$extensions": {
           "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
@@ -4965,6 +5081,14 @@
           "com.figma.variableId": "VariableID:1330:10895"
         },
         "$value": { "unit": "px", "value": 256 },
+        "platforms": ["PD"]
+      },
+      "320": {
+        "$extensions": {
+          "com.figma.scopes": ["WIDTH_HEIGHT", "FONT_VARIATIONS"],
+          "com.figma.variableId": "VariableID:6364:18086"
+        },
+        "$value": { "unit": "px", "value": 320 },
         "platforms": ["PD"]
       },
       "512": {

--- a/packages/design-tokens/tiers/semantics.json
+++ b/packages/design-tokens/tiers/semantics.json
@@ -23,7 +23,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.transparent.white.inverse-95}",
-              "default": "{palette.transparent.white.inverse-95}"
+              "default": "{palette.transparent.white.inverse-95}",
+              "virtuozzo": "{palette.transparent.white.inverse-95}"
             }
           },
           "secondary": {
@@ -34,7 +35,8 @@
             "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.transparent.blue.inverse-95}",
-              "default": "{palette.transparent.blue.inverse-95}"
+              "default": "{palette.transparent.blue.inverse-95}",
+              "virtuozzo": "{palette.transparent.blue.inverse-95}"
             }
           }
         },
@@ -46,7 +48,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.dark.fixed-90}",
-            "default": "{palette.transparent.dark.fixed-90}"
+            "default": "{palette.transparent.dark.fixed-90}",
+            "virtuozzo": "{palette.transparent.dark.fixed-90}"
           }
         }
       },
@@ -59,7 +62,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.SidebarPrimary.idle}",
-            "default": "{palette.blue.13}"
+            "default": "{palette.blue.13}",
+            "virtuozzo": "{branding.virtuozzo.SidebarPrimary.idle}"
           }
         },
         "primary-active": {
@@ -70,7 +74,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.SidebarPrimary.active}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{branding.virtuozzo.SidebarPrimary.active}"
           }
         },
         "primary-disabled": {
@@ -81,7 +86,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.SidebarPrimary.disabled}",
-            "default": "{palette.blue.5}"
+            "default": "{palette.blue.5}",
+            "virtuozzo": "{branding.virtuozzo.SidebarPrimary.disabled}"
           }
         },
         "primary-hover": {
@@ -92,7 +98,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.SidebarPrimary.hover}",
-            "default": "{palette.blue.12}"
+            "default": "{palette.blue.12}",
+            "virtuozzo": "{branding.virtuozzo.SidebarPrimary.hover}"
           }
         },
         "secondary": {
@@ -103,7 +110,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.ButtonPrimary.idle}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{branding.virtuozzo.ButtonPrimary.idle}"
           }
         },
         "secondary-active": {
@@ -114,7 +122,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.ButtonPrimary.active}",
-            "default": "{palette.blue.9}"
+            "default": "{palette.blue.9}",
+            "virtuozzo": "{branding.virtuozzo.ButtonPrimary.active}"
           }
         },
         "secondary-disabled": {
@@ -125,7 +134,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.ButtonPrimary.disabled}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{branding.virtuozzo.ButtonPrimary.disabled}"
           }
         },
         "secondary-hover": {
@@ -136,7 +146,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.ButtonPrimary.hover}",
-            "default": "{palette.blue.8}"
+            "default": "{palette.blue.8}",
+            "virtuozzo": "{branding.virtuozzo.ButtonPrimary.hover}"
           }
         }
       },
@@ -149,7 +160,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.dark.inverse-100}",
-            "default": "{palette.transparent.dark.inverse-100}"
+            "default": "{palette.transparent.dark.inverse-100}",
+            "virtuozzo": "{palette.transparent.dark.inverse-100}"
           }
         }
       },
@@ -162,7 +174,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.1}",
-            "default": "{palette.violet.1}"
+            "default": "{palette.violet.1}",
+            "virtuozzo": "{palette.violet.1}"
           }
         },
         "ai-hover": {
@@ -173,7 +186,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.2}",
-            "default": "{palette.violet.2}"
+            "default": "{palette.violet.2}",
+            "virtuozzo": "{palette.violet.2}"
           }
         },
         "ai-pressed": {
@@ -184,7 +198,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.3}",
-            "default": "{palette.violet.3}"
+            "default": "{palette.violet.3}",
+            "virtuozzo": "{palette.violet.3}"
           }
         },
         "critical": {
@@ -195,7 +210,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.1}",
-            "default": "{palette.orange.1}"
+            "default": "{palette.orange.1}",
+            "virtuozzo": "{palette.orange.1}"
           }
         },
         "critical-hover": {
@@ -206,7 +222,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.2}",
-            "default": "{palette.orange.2}"
+            "default": "{palette.orange.2}",
+            "virtuozzo": "{palette.orange.2}"
           }
         },
         "critical-pressed": {
@@ -217,7 +234,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.3}",
-            "default": "{palette.orange.3}"
+            "default": "{palette.orange.3}",
+            "virtuozzo": "{palette.orange.3}"
           }
         },
         "danger": {
@@ -228,7 +246,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.1}",
-            "default": "{palette.red.1}"
+            "default": "{palette.red.1}",
+            "virtuozzo": "{palette.red.1}"
           }
         },
         "danger-hover": {
@@ -239,7 +258,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.2}",
-            "default": "{palette.red.2}"
+            "default": "{palette.red.2}",
+            "virtuozzo": "{palette.red.2}"
           }
         },
         "danger-pressed": {
@@ -250,7 +270,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.3}",
-            "default": "{palette.red.3}"
+            "default": "{palette.red.3}",
+            "virtuozzo": "{palette.red.3}"
           }
         },
         "info": {
@@ -261,7 +282,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.1}",
-            "default": "{palette.electricblue.1}"
+            "default": "{palette.electricblue.1}",
+            "virtuozzo": "{palette.electricblue.1}"
           }
         },
         "info-hover": {
@@ -272,7 +294,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.2}",
-            "default": "{palette.electricblue.2}"
+            "default": "{palette.electricblue.2}",
+            "virtuozzo": "{palette.electricblue.2}"
           }
         },
         "info-pressed": {
@@ -283,7 +306,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.3}",
-            "default": "{palette.electricblue.3}"
+            "default": "{palette.electricblue.3}",
+            "virtuozzo": "{palette.electricblue.3}"
           }
         },
         "neutral": {
@@ -294,7 +318,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.base}",
-            "default": "{palette.base}"
+            "default": "{palette.base}",
+            "virtuozzo": "{palette.base}"
           }
         },
         "neutral-hover": {
@@ -305,7 +330,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.1}",
-            "default": "{palette.grayscale.1}"
+            "default": "{palette.grayscale.1}",
+            "virtuozzo": "{palette.grayscale.1}"
           }
         },
         "neutral-pressed": {
@@ -316,7 +342,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.2}",
-            "default": "{palette.grayscale.2}"
+            "default": "{palette.grayscale.2}",
+            "virtuozzo": "{palette.grayscale.2}"
           }
         },
         "off": {
@@ -327,7 +354,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.3}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.grayscale.3}"
           }
         },
         "on": {
@@ -338,7 +366,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.6}",
-            "default": "{palette.green.6}"
+            "default": "{palette.green.6}",
+            "virtuozzo": "{palette.green.6}"
           }
         },
         "success": {
@@ -349,7 +378,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.1}",
-            "default": "{palette.green.1}"
+            "default": "{palette.green.1}",
+            "virtuozzo": "{palette.green.1}"
           }
         },
         "success-hover": {
@@ -360,7 +390,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.2}",
-            "default": "{palette.green.2}"
+            "default": "{palette.green.2}",
+            "virtuozzo": "{palette.green.2}"
           }
         },
         "success-pressed": {
@@ -371,7 +402,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.3}",
-            "default": "{palette.green.3}"
+            "default": "{palette.green.3}",
+            "virtuozzo": "{palette.green.3}"
           }
         },
         "warning": {
@@ -382,7 +414,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.1}",
-            "default": "{palette.yellow.1}"
+            "default": "{palette.yellow.1}",
+            "virtuozzo": "{palette.yellow.1}"
           }
         },
         "warning-hover": {
@@ -393,7 +426,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.2}",
-            "default": "{palette.yellow.2}"
+            "default": "{palette.yellow.2}",
+            "virtuozzo": "{palette.yellow.2}"
           }
         },
         "warning-pressed": {
@@ -404,7 +438,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.3}",
-            "default": "{palette.yellow.3}"
+            "default": "{palette.yellow.3}",
+            "virtuozzo": "{palette.yellow.3}"
           }
         }
       },
@@ -417,7 +452,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.7}",
-            "default": "{palette.orange.7}"
+            "default": "{palette.orange.7}",
+            "virtuozzo": "{palette.orange.7}"
           }
         },
         "critical-hover": {
@@ -428,7 +464,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.8}",
-            "default": "{palette.orange.8}"
+            "default": "{palette.orange.8}",
+            "virtuozzo": "{palette.orange.8}"
           }
         },
         "critical-pressed": {
@@ -439,7 +476,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.9}",
-            "default": "{palette.orange.9}"
+            "default": "{palette.orange.9}",
+            "virtuozzo": "{palette.orange.9}"
           }
         },
         "danger": {
@@ -450,7 +488,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.7}",
-            "default": "{palette.red.7}"
+            "default": "{palette.red.7}",
+            "virtuozzo": "{palette.red.7}"
           }
         },
         "danger-hover": {
@@ -461,7 +500,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.9}",
-            "default": "{palette.red.9}"
+            "default": "{palette.red.9}",
+            "virtuozzo": "{palette.red.9}"
           }
         },
         "danger-pressed": {
@@ -472,7 +512,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.10}",
-            "default": "{palette.red.10}"
+            "default": "{palette.red.10}",
+            "virtuozzo": "{palette.red.10}"
           }
         },
         "info": {
@@ -483,7 +524,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.7}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{palette.blue.7}"
           }
         },
         "info-hover": {
@@ -494,7 +536,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.8}",
-            "default": "{palette.blue.8}"
+            "default": "{palette.blue.8}",
+            "virtuozzo": "{palette.blue.8}"
           }
         },
         "info-pressed": {
@@ -505,7 +548,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.9}",
-            "default": "{palette.blue.9}"
+            "default": "{palette.blue.9}",
+            "virtuozzo": "{palette.blue.9}"
           }
         },
         "neutral": {
@@ -516,7 +560,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.7}",
-            "default": "{palette.grayscale.7}"
+            "default": "{palette.grayscale.7}",
+            "virtuozzo": "{palette.grayscale.7}"
           }
         },
         "neutral-hover": {
@@ -527,7 +572,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.8}",
-            "default": "{palette.grayscale.8}"
+            "default": "{palette.grayscale.8}",
+            "virtuozzo": "{palette.grayscale.8}"
           }
         },
         "neutral-pressed": {
@@ -538,7 +584,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.9}",
-            "default": "{palette.grayscale.9}"
+            "default": "{palette.grayscale.9}",
+            "virtuozzo": "{palette.grayscale.9}"
           }
         },
         "success": {
@@ -549,7 +596,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.7}",
-            "default": "{palette.green.7}"
+            "default": "{palette.green.7}",
+            "virtuozzo": "{palette.green.7}"
           }
         },
         "success-hover": {
@@ -560,7 +608,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.8}",
-            "default": "{palette.green.8}"
+            "default": "{palette.green.8}",
+            "virtuozzo": "{palette.green.8}"
           }
         },
         "success-pressed": {
@@ -571,7 +620,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.9}",
-            "default": "{palette.green.9}"
+            "default": "{palette.green.9}",
+            "virtuozzo": "{palette.green.9}"
           }
         },
         "warning": {
@@ -582,7 +632,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.7}",
-            "default": "{palette.yellow.7}"
+            "default": "{palette.yellow.7}",
+            "virtuozzo": "{palette.yellow.7}"
           }
         },
         "warning-hover": {
@@ -593,7 +644,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.8}",
-            "default": "{palette.yellow.8}"
+            "default": "{palette.yellow.8}",
+            "virtuozzo": "{palette.yellow.8}"
           }
         },
         "warning-pressed": {
@@ -604,7 +656,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.9}",
-            "default": "{palette.yellow.9}"
+            "default": "{palette.yellow.9}",
+            "virtuozzo": "{palette.yellow.9}"
           }
         }
       },
@@ -617,7 +670,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.2}",
-            "default": "{palette.blue.2}"
+            "default": "{palette.blue.2}",
+            "virtuozzo": "{palette.grayscale.2}"
           }
         },
         "hover": {
@@ -628,7 +682,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.1}",
-            "default": "{palette.blue.1}"
+            "default": "{palette.blue.1}",
+            "virtuozzo": "{palette.grayscale.1}"
           }
         },
         "primary": {
@@ -639,7 +694,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.base}",
-            "default": "{palette.base}"
+            "default": "{palette.base}",
+            "virtuozzo": "{palette.base}"
           }
         },
         "secondary": {
@@ -650,7 +706,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.0}",
-            "default": "{palette.blue.0}"
+            "default": "{palette.blue.0}",
+            "virtuozzo": "{palette.grayscale.0}"
           }
         }
       },
@@ -662,7 +719,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.transparent.clear}",
-          "default": "{palette.transparent.clear}"
+          "default": "{palette.transparent.clear}",
+          "virtuozzo": "{palette.transparent.clear}"
         }
       }
     },
@@ -676,7 +734,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-10}",
-            "default": "{palette.transparent.white.fixed-10}"
+            "default": "{palette.transparent.white.fixed-10}",
+            "virtuozzo": "{palette.transparent.white.fixed-10}"
           }
         },
         "border-active": {
@@ -687,7 +746,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.0}",
-            "default": "{palette.grayscale.0}"
+            "default": "{palette.grayscale.0}",
+            "virtuozzo": "{palette.grayscale.0}"
           }
         },
         "divider": {
@@ -698,7 +758,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-10}",
-            "default": "{palette.transparent.white.fixed-10}"
+            "default": "{palette.transparent.white.fixed-10}",
+            "virtuozzo": "{palette.transparent.white.fixed-10}"
           }
         }
       },
@@ -711,7 +772,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.4}",
-            "default": "{palette.violet.4}"
+            "default": "{palette.violet.4}",
+            "virtuozzo": "{palette.violet.4}"
           }
         },
         "aiStrong": {
@@ -723,7 +785,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{gradients.ai.idle}",
-            "default": "{gradients.ai.idle}"
+            "default": "{gradients.ai.idle}",
+            "virtuozzo": "{gradients.ai.idle}"
           }
         },
         "critical": {
@@ -734,7 +797,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.4}",
-            "default": "{palette.orange.4}"
+            "default": "{palette.orange.4}",
+            "virtuozzo": "{palette.orange.4}"
           }
         },
         "criticalStrong": {
@@ -745,7 +809,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.8}",
-            "default": "{palette.orange.8}"
+            "default": "{palette.orange.8}",
+            "virtuozzo": "{palette.orange.8}"
           }
         },
         "danger": {
@@ -756,7 +821,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.4}",
-            "default": "{palette.red.4}"
+            "default": "{palette.red.4}",
+            "virtuozzo": "{palette.red.4}"
           }
         },
         "dangerStrong": {
@@ -767,7 +833,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.8}",
-            "default": "{palette.red.8}"
+            "default": "{palette.red.8}",
+            "virtuozzo": "{palette.red.8}"
           }
         },
         "info": {
@@ -778,7 +845,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
-            "default": "{palette.electricblue.4}"
+            "default": "{palette.electricblue.4}",
+            "virtuozzo": "{palette.electricblue.4}"
           }
         },
         "infoStrong": {
@@ -789,7 +857,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.8}",
-            "default": "{palette.electricblue.8}"
+            "default": "{palette.electricblue.8}",
+            "virtuozzo": "{palette.electricblue.8}"
           }
         },
         "neutral": {
@@ -800,7 +869,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.4}",
-            "default": "{palette.grayscale.4}"
+            "default": "{palette.grayscale.4}",
+            "virtuozzo": "{palette.grayscale.4}"
           }
         },
         "neutralStrong": {
@@ -811,7 +881,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.8}",
-            "default": "{palette.grayscale.8}"
+            "default": "{palette.grayscale.8}",
+            "virtuozzo": "{palette.grayscale.8}"
           }
         },
         "success": {
@@ -822,7 +893,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.4}",
-            "default": "{palette.green.4}"
+            "default": "{palette.green.4}",
+            "virtuozzo": "{palette.green.4}"
           }
         },
         "successStrong": {
@@ -833,7 +905,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.8}",
-            "default": "{palette.green.8}"
+            "default": "{palette.green.8}",
+            "virtuozzo": "{palette.green.8}"
           }
         },
         "warning": {
@@ -844,7 +917,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.4}",
-            "default": "{palette.yellow.4}"
+            "default": "{palette.yellow.4}",
+            "virtuozzo": "{palette.yellow.4}"
           }
         },
         "warningStrong": {
@@ -855,7 +929,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.8}",
-            "default": "{palette.yellow.8}"
+            "default": "{palette.yellow.8}",
+            "virtuozzo": "{palette.yellow.8}"
           }
         }
       },
@@ -868,7 +943,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.3}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.grayscale.3}"
           }
         },
         "border-active": {
@@ -879,7 +955,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.7}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{palette.grayscale.7}"
           }
         },
         "border-error": {
@@ -890,7 +967,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.7}",
-            "default": "{palette.red.7}"
+            "default": "{palette.red.7}",
+            "virtuozzo": "{palette.red.7}"
           }
         },
         "divider": {
@@ -901,7 +979,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.3}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.grayscale.3}"
           }
         }
       },
@@ -913,7 +992,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.transparent.clear}",
-          "default": "{palette.transparent.clear}"
+          "default": "{palette.transparent.clear}",
+          "virtuozzo": "{palette.transparent.clear}"
         }
       }
     },
@@ -926,7 +1006,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.blue.4}",
-          "default": "{palette.blue.4}"
+          "default": "{palette.blue.4}",
+          "virtuozzo": "{palette.blue.4}"
         }
       },
       "error": {
@@ -937,7 +1018,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.red.4}",
-          "default": "{palette.red.4}"
+          "default": "{palette.red.4}",
+          "virtuozzo": "{palette.red.4}"
         }
       },
       "primary": {
@@ -948,7 +1030,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.blue.4}",
-          "default": "{palette.blue.4}"
+          "default": "{palette.blue.4}",
+          "virtuozzo": "{palette.blue.4}"
         }
       },
       "secondary": {
@@ -959,7 +1042,8 @@
         "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.blue.4}",
-          "default": "{palette.blue.4}"
+          "default": "{palette.blue.4}",
+          "virtuozzo": "{palette.blue.4}"
         }
       }
     },
@@ -973,7 +1057,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.7}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{palette.grayscale.7}"
           }
         },
         "screenPrimary": {
@@ -984,7 +1069,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         }
       },
@@ -997,7 +1083,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-10}",
-            "default": "{palette.transparent.white.fixed-10}"
+            "default": "{palette.transparent.white.fixed-10}",
+            "virtuozzo": "{palette.transparent.white.fixed-10}"
           }
         },
         "primary": {
@@ -1008,7 +1095,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "secondary": {
@@ -1019,7 +1107,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
-            "default": "{palette.transparent.white.fixed-60}"
+            "default": "{palette.transparent.white.fixed-60}",
+            "virtuozzo": "{palette.transparent.white.fixed-60}"
           }
         }
       },
@@ -1032,7 +1121,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         }
       },
@@ -1045,7 +1135,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.11}",
-            "default": "{palette.violet.11}"
+            "default": "{palette.violet.11}",
+            "virtuozzo": "{palette.violet.11}"
           }
         },
         "critical": {
@@ -1056,7 +1147,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.11}",
-            "default": "{palette.orange.11}"
+            "default": "{palette.orange.11}",
+            "virtuozzo": "{palette.orange.11}"
           }
         },
         "danger": {
@@ -1067,7 +1159,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.11}",
-            "default": "{palette.red.11}"
+            "default": "{palette.red.11}",
+            "virtuozzo": "{palette.red.11}"
           }
         },
         "disabled": {
@@ -1078,7 +1171,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.3}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.grayscale.3}"
           }
         },
         "info": {
@@ -1089,7 +1183,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.11}",
-            "default": "{palette.electricblue.11}"
+            "default": "{palette.electricblue.11}",
+            "virtuozzo": "{palette.electricblue.11}"
           }
         },
         "neutral": {
@@ -1100,7 +1195,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.11}",
-            "default": "{palette.grayscale.11}"
+            "default": "{palette.grayscale.11}",
+            "virtuozzo": "{palette.grayscale.11}"
           }
         },
         "primary": {
@@ -1111,7 +1207,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.11}",
-            "default": "{palette.electricblue.11}"
+            "default": "{palette.electricblue.11}",
+            "virtuozzo": "{palette.electricblue.11}"
           }
         },
         "success": {
@@ -1122,7 +1219,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.11}",
-            "default": "{palette.green.11}"
+            "default": "{palette.green.11}",
+            "virtuozzo": "{palette.green.11}"
           }
         },
         "warning": {
@@ -1133,7 +1231,22 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.11}",
-            "default": "{palette.yellow.11}"
+            "default": "{palette.yellow.11}",
+            "virtuozzo": "{palette.yellow.11}"
+          }
+        }
+      },
+      "onStatusStrong": {
+        "primary": {
+          "$extensions": {
+            "com.figma.scopes": ["SHAPE_FILL"],
+            "com.figma.variableId": "VariableID:4169:6903"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         }
       },
@@ -1146,7 +1259,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.13}",
-            "default": "{palette.blue.13}"
+            "default": "{palette.blue.13}",
+            "virtuozzo": "{palette.blue.13}"
           }
         },
         "destructive": {
@@ -1157,7 +1271,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.7}",
-            "default": "{palette.red.7}"
+            "default": "{palette.red.7}",
+            "virtuozzo": "{palette.red.7}"
           }
         },
         "disabled": {
@@ -1168,7 +1283,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.5}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.grayscale.5}"
           }
         },
         "neutral": {
@@ -1179,7 +1295,20 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.4}",
-            "default": "{palette.grayscale.4}"
+            "default": "{palette.grayscale.4}",
+            "virtuozzo": "{palette.grayscale.4}"
+          }
+        },
+        "neutral-dark": {
+          "$extensions": {
+            "com.figma.scopes": ["SHAPE_FILL"],
+            "com.figma.variableId": "VariableID:6540:20828"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.10}",
+            "default": "{palette.grayscale.10}",
+            "virtuozzo": "{palette.grayscale.10}"
           }
         },
         "primary": {
@@ -1190,7 +1319,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.10}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{palette.grayscale.10}"
           }
         }
       }
@@ -1205,7 +1335,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
-            "default": "{palette.electricblue.4}"
+            "default": "{palette.electricblue.4}",
+            "virtuozzo": "{palette.electricblue.4}"
           }
         },
         "elementLink-hover": {
@@ -1216,7 +1347,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
-            "default": "{palette.electricblue.4}"
+            "default": "{palette.electricblue.4}",
+            "virtuozzo": "{palette.electricblue.4}"
           }
         },
         "elementLink-idle": {
@@ -1227,7 +1359,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.7}",
-            "default": "{palette.electricblue.7}"
+            "default": "{palette.electricblue.7}",
+            "virtuozzo": "{palette.electricblue.7}"
           }
         },
         "elementPrimary": {
@@ -1238,7 +1371,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.dark.inverse-100}",
-            "default": "{palette.transparent.dark.inverse-100}"
+            "default": "{palette.transparent.dark.inverse-100}",
+            "virtuozzo": "{palette.transparent.dark.inverse-100}"
           }
         },
         "screenLink-active": {
@@ -1249,7 +1383,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
-            "default": "{palette.electricblue.4}"
+            "default": "{palette.electricblue.4}",
+            "virtuozzo": "{palette.electricblue.4}"
           }
         },
         "screenLink-hover": {
@@ -1260,7 +1395,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
-            "default": "{palette.electricblue.4}"
+            "default": "{palette.electricblue.4}",
+            "virtuozzo": "{palette.electricblue.4}"
           }
         },
         "screenLink-idle": {
@@ -1271,7 +1407,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
-            "default": "{palette.electricblue.4}"
+            "default": "{palette.electricblue.4}",
+            "virtuozzo": "{palette.electricblue.4}"
           }
         },
         "screenPrimary": {
@@ -1282,7 +1419,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "screenSecondary": {
@@ -1293,7 +1431,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
-            "default": "{palette.transparent.white.fixed-60}"
+            "default": "{palette.transparent.white.fixed-60}",
+            "virtuozzo": "{palette.transparent.white.fixed-60}"
           }
         }
       },
@@ -1306,18 +1445,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-30}",
-            "default": "{palette.transparent.white.fixed-30}"
-          }
-        },
-        "link": {
-          "$extensions": {
-            "com.figma.scopes": ["TEXT_FILL"],
-            "com.figma.variableId": "VariableID:139:169"
-          },
-          "platforms": ["PD"],
-          "values": {
-            "deep_sky_itkontoret": "{palette.blue.7}",
-            "default": "{palette.blue.7}"
+            "default": "{palette.transparent.white.fixed-30}",
+            "virtuozzo": "{palette.transparent.white.fixed-30}"
           }
         },
         "link-disabled": {
@@ -1328,7 +1457,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-30}",
-            "default": "{palette.transparent.white.fixed-30}"
+            "default": "{palette.transparent.white.fixed-30}",
+            "virtuozzo": "{palette.transparent.white.fixed-30}"
           }
         },
         "link-hover": {
@@ -1339,7 +1469,20 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.5}",
-            "default": "{palette.blue.5}"
+            "default": "{palette.blue.5}",
+            "virtuozzo": "{palette.blue.5}"
+          }
+        },
+        "link-idle": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:169"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.blue.7}",
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{palette.blue.7}"
           }
         },
         "link-pressed": {
@@ -1350,7 +1493,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.3}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.blue.3}"
           }
         },
         "primary": {
@@ -1361,7 +1505,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "secondary": {
@@ -1372,7 +1517,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
-            "default": "{palette.transparent.white.fixed-60}"
+            "default": "{palette.transparent.white.fixed-60}",
+            "virtuozzo": "{palette.transparent.white.fixed-60}"
           }
         }
       },
@@ -1384,8 +1530,9 @@
           },
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "deep_sky_itkontoret": "{palette.transparent.white.inverse-100}",
+            "default": "{palette.transparent.white.inverse-100}",
+            "virtuozzo": "{palette.transparent.white.inverse-100}"
           }
         },
         "secondary": {
@@ -1396,7 +1543,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
-            "default": "{palette.transparent.white.fixed-60}"
+            "default": "{palette.transparent.white.fixed-60}",
+            "virtuozzo": "{palette.transparent.white.fixed-60}"
           }
         }
       },
@@ -1409,7 +1557,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.11}",
-            "default": "{palette.violet.11}"
+            "default": "{palette.violet.11}",
+            "virtuozzo": "{palette.violet.11}"
           }
         },
         "critical": {
@@ -1420,7 +1569,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.11}",
-            "default": "{palette.orange.11}"
+            "default": "{palette.orange.11}",
+            "virtuozzo": "{palette.orange.11}"
           }
         },
         "danger": {
@@ -1431,7 +1581,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.11}",
-            "default": "{palette.red.11}"
+            "default": "{palette.red.11}",
+            "virtuozzo": "{palette.red.11}"
           }
         },
         "info": {
@@ -1442,18 +1593,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.11}",
-            "default": "{palette.electricblue.11}"
-          }
-        },
-        "link": {
-          "$extensions": {
-            "com.figma.scopes": ["TEXT_FILL"],
-            "com.figma.variableId": "VariableID:149:4"
-          },
-          "platforms": ["PD"],
-          "values": {
-            "deep_sky_itkontoret": "{palette.electricblue.11}",
-            "default": "{palette.electricblue.11}"
+            "default": "{palette.electricblue.11}",
+            "virtuozzo": "{palette.electricblue.11}"
           }
         },
         "link-disabled": {
@@ -1464,7 +1605,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.5}",
-            "default": "{palette.electricblue.5}"
+            "default": "{palette.electricblue.5}",
+            "virtuozzo": "{palette.electricblue.5}"
           }
         },
         "link-hover": {
@@ -1475,7 +1617,20 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.13}",
-            "default": "{palette.electricblue.13}"
+            "default": "{palette.electricblue.13}",
+            "virtuozzo": "{palette.electricblue.13}"
+          }
+        },
+        "link-idle": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:149:4"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.electricblue.11}",
+            "default": "{palette.electricblue.11}",
+            "virtuozzo": "{palette.electricblue.11}"
           }
         },
         "link-pressed": {
@@ -1486,7 +1641,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.14}",
-            "default": "{palette.electricblue.14}"
+            "default": "{palette.electricblue.14}",
+            "virtuozzo": "{palette.electricblue.14}"
           }
         },
         "neutral": {
@@ -1497,7 +1653,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.11}",
-            "default": "{palette.grayscale.11}"
+            "default": "{palette.grayscale.11}",
+            "virtuozzo": "{palette.grayscale.11}"
           }
         },
         "primary": {
@@ -1508,7 +1665,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.14}",
-            "default": "{palette.grayscale.14}"
+            "default": "{palette.grayscale.14}",
+            "virtuozzo": "{palette.grayscale.14}"
           }
         },
         "secondary": {
@@ -1519,7 +1677,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.11}",
-            "default": "{palette.grayscale.11}"
+            "default": "{palette.grayscale.11}",
+            "virtuozzo": "{palette.grayscale.11}"
           }
         },
         "success": {
@@ -1530,7 +1689,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.11}",
-            "default": "{palette.green.11}"
+            "default": "{palette.green.11}",
+            "virtuozzo": "{palette.green.11}"
           }
         },
         "warning": {
@@ -1541,7 +1701,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.11}",
-            "default": "{palette.yellow.11}"
+            "default": "{palette.yellow.11}",
+            "virtuozzo": "{palette.yellow.11}"
           }
         }
       },
@@ -1554,7 +1715,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "critical": {
@@ -1565,7 +1727,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "danger": {
@@ -1576,7 +1739,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "info": {
@@ -1587,7 +1751,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "link": {
@@ -1598,7 +1763,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.11}",
-            "default": "{palette.electricblue.11}"
+            "default": "{palette.electricblue.11}",
+            "virtuozzo": "{palette.electricblue.11}"
           }
         },
         "neutral": {
@@ -1609,7 +1775,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "primary": {
@@ -1620,7 +1787,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.0}",
-            "default": "{palette.grayscale.0}"
+            "default": "{palette.grayscale.0}",
+            "virtuozzo": "{palette.grayscale.0}"
           }
         },
         "secondary": {
@@ -1631,7 +1799,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.2}",
-            "default": "{palette.grayscale.2}"
+            "default": "{palette.grayscale.2}",
+            "virtuozzo": "{palette.grayscale.2}"
           }
         },
         "success": {
@@ -1642,7 +1811,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         },
         "warning": {
@@ -1653,7 +1823,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
+            "default": "{palette.transparent.white.fixed-100}",
+            "virtuozzo": "{palette.transparent.white.fixed-100}"
           }
         }
       },
@@ -1666,7 +1837,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.7}",
-            "default": "{palette.red.7}"
+            "default": "{palette.red.7}",
+            "virtuozzo": "{palette.red.7}"
           }
         },
         "disabled": {
@@ -1676,25 +1848,9 @@
           },
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": {
-              "colorSpace": "hsl",
-              "components": [205.71, 14.58, 18.82]
-            },
-            "default": "{palette.grayscale.5}"
-          }
-        },
-        "link": {
-          "$extensions": {
-            "com.figma.scopes": ["TEXT_FILL"],
-            "com.figma.variableId": "VariableID:139:155"
-          },
-          "platforms": ["PD"],
-          "values": {
-            "deep_sky_itkontoret": {
-              "colorSpace": "hsl",
-              "components": [208.8, 15.53, 31.57]
-            },
-            "default": "{palette.blue.7}"
+            "deep_sky_itkontoret": "{palette.grayscale.5}",
+            "default": "{palette.grayscale.5}",
+            "virtuozzo": "{palette.grayscale.5}"
           }
         },
         "link-disabled": {
@@ -1705,7 +1861,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.3}",
-            "default": "{palette.blue.3}"
+            "default": "{palette.blue.3}",
+            "virtuozzo": "{palette.grayscale.3}"
           }
         },
         "link-hover": {
@@ -1716,7 +1873,20 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.11}",
-            "default": "{palette.blue.8}"
+            "default": "{palette.blue.8}",
+            "virtuozzo": "{palette.grayscale.11}"
+          }
+        },
+        "link-idle": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:155"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.10}",
+            "default": "{palette.blue.7}",
+            "virtuozzo": "{palette.grayscale.10}"
           }
         },
         "link-pressed": {
@@ -1727,7 +1897,8 @@
           "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.12}",
-            "default": "{palette.blue.11}"
+            "default": "{palette.blue.11}",
+            "virtuozzo": "{palette.grayscale.12}"
           }
         },
         "primary": {
@@ -1737,11 +1908,9 @@
           },
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": {
-              "colorSpace": "hsl",
-              "components": [208.8, 15.53, 31.57]
-            },
-            "default": "{palette.grayscale.14}"
+            "deep_sky_itkontoret": "{palette.grayscale.14}",
+            "default": "{palette.grayscale.14}",
+            "virtuozzo": "{palette.grayscale.14}"
           }
         },
         "secondary": {
@@ -1751,11 +1920,9 @@
           },
           "platforms": ["PD"],
           "values": {
-            "deep_sky_itkontoret": {
-              "colorSpace": "hsl",
-              "components": [207, 15.63, 25.1]
-            },
-            "default": "{palette.grayscale.7}"
+            "deep_sky_itkontoret": "{palette.grayscale.7}",
+            "default": "{palette.grayscale.7}",
+            "virtuozzo": "{palette.grayscale.7}"
           }
         }
       }
@@ -1789,6 +1956,22 @@
             }
           ],
           "default": [
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [234.11, 56.57, 38.82]
+              },
+              "position": 0.2
+            },
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [303.09, 69.78, 27.25]
+              },
+              "position": 1
+            }
+          ],
+          "virtuozzo": [
             {
               "color": {
                 "colorSpace": "hsl",
@@ -1845,6 +2028,22 @@
               },
               "position": 1
             }
+          ],
+          "virtuozzo": [
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [234.38, 100, 93.73]
+              },
+              "position": 0.2
+            },
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [303.24, 100, 92.75]
+              },
+              "position": 1
+            }
           ]
         }
       },
@@ -1887,6 +2086,22 @@
               },
               "position": 1
             }
+          ],
+          "virtuozzo": [
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [233.75, 58.54, 48.24]
+              },
+              "position": 0.2
+            },
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [303.22, 69.3, 42.16]
+              },
+              "position": 1
+            }
           ]
         }
       },
@@ -1915,6 +2130,22 @@
             }
           ],
           "default": [
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [233.93, 73.04, 54.9]
+              },
+              "position": 0.2
+            },
+            {
+              "color": {
+                "colorSpace": "hsl",
+                "components": [303.19, 97.18, 58.24]
+              },
+              "position": 1
+            }
+          ],
+          "virtuozzo": [
             {
               "color": {
                 "colorSpace": "hsl",
@@ -2064,6 +2295,19 @@
       "display": {
         "$extensions": {
           "com.figma.styleId": "S:8d14a110f7057b3371d8296edadbf8436e4bbde9,"
+        },
+        "$value": {
+          "fontFamily": "{font.font-family.default}",
+          "fontSize": "{font.font-size.32}",
+          "fontWeight": "{font.font-weight.regular}",
+          "letterSpacing": "{font.letter-spacing.0}",
+          "lineHeight": "{font.line-height.40}"
+        },
+        "platforms": ["PD"]
+      },
+      "display-numeric": {
+        "$extensions": {
+          "com.figma.styleId": "S:3a1abe681039f062b989ad383b761ae7c964035b,"
         },
         "$value": {
           "fontFamily": "{font.font-family.default}",

--- a/packages/design-tokens/tiers/semantics.json
+++ b/packages/design-tokens/tiers/semantics.json
@@ -17,14 +17,10 @@
         "element": {
           "primary": {
             "$extensions": {
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:202:38"
             },
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.transparent.white.inverse-95}",
               "default": "{palette.transparent.white.inverse-95}"
@@ -32,14 +28,10 @@
           },
           "secondary": {
             "$extensions": {
-              "com.figma.scopes": [
-                "FRAME_FILL"
-              ],
+              "com.figma.scopes": ["FRAME_FILL"],
               "com.figma.variableId": "VariableID:4370:2956"
             },
-            "platforms": [
-              "PD"
-            ],
+            "platforms": ["PD"],
             "values": {
               "deep_sky_itkontoret": "{palette.transparent.blue.inverse-95}",
               "default": "{palette.transparent.blue.inverse-95}"
@@ -48,14 +40,10 @@
         },
         "screen": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1433"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.dark.fixed-90}",
             "default": "{palette.transparent.dark.fixed-90}"
@@ -65,14 +53,10 @@
       "brand": {
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1428"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.SidebarPrimary.idle}",
             "default": "{palette.blue.13}"
@@ -80,14 +64,10 @@
         },
         "primary-active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:143:3"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.SidebarPrimary.active}",
             "default": "{palette.blue.7}"
@@ -95,14 +75,10 @@
         },
         "primary-disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:383:39"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.SidebarPrimary.disabled}",
             "default": "{palette.blue.5}"
@@ -110,14 +86,10 @@
         },
         "primary-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:143:2"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.SidebarPrimary.hover}",
             "default": "{palette.blue.12}"
@@ -125,14 +97,10 @@
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1429"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.ButtonPrimary.idle}",
             "default": "{palette.blue.7}"
@@ -140,14 +108,10 @@
         },
         "secondary-active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:265:59"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.ButtonPrimary.active}",
             "default": "{palette.blue.9}"
@@ -155,14 +119,10 @@
         },
         "secondary-disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:227:24"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.ButtonPrimary.disabled}",
             "default": "{palette.blue.3}"
@@ -170,14 +130,10 @@
         },
         "secondary-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:265:58"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{branding.deep_sky_itkontoret.ButtonPrimary.hover}",
             "default": "{palette.blue.8}"
@@ -187,14 +143,10 @@
       "inverse": {
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:3665:6953"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.dark.inverse-100}",
             "default": "{palette.transparent.dark.inverse-100}"
@@ -204,14 +156,10 @@
       "status": {
         "ai": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2277:406"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.1}",
             "default": "{palette.violet.1}"
@@ -219,14 +167,10 @@
         },
         "ai-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2277:407"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.2}",
             "default": "{palette.violet.2}"
@@ -234,14 +178,10 @@
         },
         "ai-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:2277:408"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.3}",
             "default": "{palette.violet.3}"
@@ -249,14 +189,10 @@
         },
         "critical": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:14"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.1}",
             "default": "{palette.orange.1}"
@@ -264,14 +200,10 @@
         },
         "critical-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:15"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.2}",
             "default": "{palette.orange.2}"
@@ -279,14 +211,10 @@
         },
         "critical-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:16"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.3}",
             "default": "{palette.orange.3}"
@@ -294,14 +222,10 @@
         },
         "danger": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:16"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.1}",
             "default": "{palette.red.1}"
@@ -309,14 +233,10 @@
         },
         "danger-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:17"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.2}",
             "default": "{palette.red.2}"
@@ -324,14 +244,10 @@
         },
         "danger-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:18"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.3}",
             "default": "{palette.red.3}"
@@ -339,14 +255,10 @@
         },
         "info": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:8"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.1}",
             "default": "{palette.electricblue.1}"
@@ -354,14 +266,10 @@
         },
         "info-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:9"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.2}",
             "default": "{palette.electricblue.2}"
@@ -369,14 +277,10 @@
         },
         "info-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:10"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.3}",
             "default": "{palette.electricblue.3}"
@@ -384,14 +288,10 @@
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263457"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.base}",
             "default": "{palette.base}"
@@ -399,14 +299,10 @@
         },
         "neutral-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263458"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.1}",
             "default": "{palette.grayscale.1}"
@@ -414,14 +310,10 @@
         },
         "neutral-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263459"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.2}",
             "default": "{palette.grayscale.2}"
@@ -429,14 +321,10 @@
         },
         "off": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:1205:160"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.3}",
             "default": "{palette.blue.3}"
@@ -444,14 +332,10 @@
         },
         "on": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:1205:161"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.6}",
             "default": "{palette.green.6}"
@@ -459,14 +343,10 @@
         },
         "success": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:10"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.1}",
             "default": "{palette.green.1}"
@@ -474,14 +354,10 @@
         },
         "success-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:11"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.2}",
             "default": "{palette.green.2}"
@@ -489,14 +365,10 @@
         },
         "success-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:12"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.3}",
             "default": "{palette.green.3}"
@@ -504,14 +376,10 @@
         },
         "warning": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:147:12"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.1}",
             "default": "{palette.yellow.1}"
@@ -519,14 +387,10 @@
         },
         "warning-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:13"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.2}",
             "default": "{palette.yellow.2}"
@@ -534,14 +398,10 @@
         },
         "warning-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:149:14"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.3}",
             "default": "{palette.yellow.3}"
@@ -551,14 +411,10 @@
       "statusStrong": {
         "critical": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263451"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.7}",
             "default": "{palette.orange.7}"
@@ -566,14 +422,10 @@
         },
         "critical-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263452"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.8}",
             "default": "{palette.orange.8}"
@@ -581,14 +433,10 @@
         },
         "critical-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263453"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.9}",
             "default": "{palette.orange.9}"
@@ -596,14 +444,10 @@
         },
         "danger": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263454"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.7}",
             "default": "{palette.red.7}"
@@ -611,14 +455,10 @@
         },
         "danger-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263455"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.9}",
             "default": "{palette.red.9}"
@@ -626,14 +466,10 @@
         },
         "danger-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263456"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.10}",
             "default": "{palette.red.10}"
@@ -641,14 +477,10 @@
         },
         "info": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263442"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.7}",
             "default": "{palette.blue.7}"
@@ -656,14 +488,10 @@
         },
         "info-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263443"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.8}",
             "default": "{palette.blue.8}"
@@ -671,14 +499,10 @@
         },
         "info-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263444"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.9}",
             "default": "{palette.blue.9}"
@@ -686,14 +510,10 @@
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263460"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.7}",
             "default": "{palette.grayscale.7}"
@@ -701,14 +521,10 @@
         },
         "neutral-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263461"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.8}",
             "default": "{palette.grayscale.8}"
@@ -716,14 +532,10 @@
         },
         "neutral-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:911:263462"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.9}",
             "default": "{palette.grayscale.9}"
@@ -731,14 +543,10 @@
         },
         "success": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263445"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.7}",
             "default": "{palette.green.7}"
@@ -746,14 +554,10 @@
         },
         "success-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263446"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.8}",
             "default": "{palette.green.8}"
@@ -761,14 +565,10 @@
         },
         "success-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263447"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.9}",
             "default": "{palette.green.9}"
@@ -776,14 +576,10 @@
         },
         "warning": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263448"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.7}",
             "default": "{palette.yellow.7}"
@@ -791,14 +587,10 @@
         },
         "warning-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263449"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.8}",
             "default": "{palette.yellow.8}"
@@ -806,14 +598,10 @@
         },
         "warning-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:910:263450"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.9}",
             "default": "{palette.yellow.9}"
@@ -823,14 +611,10 @@
       "surface": {
         "active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:141:276"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.2}",
             "default": "{palette.blue.2}"
@@ -838,14 +622,10 @@
         },
         "hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:141:275"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.1}",
             "default": "{palette.blue.1}"
@@ -853,14 +633,10 @@
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1426"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.base}",
             "default": "{palette.base}"
@@ -868,14 +644,10 @@
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "FRAME_FILL"
-            ],
+            "com.figma.scopes": ["FRAME_FILL"],
             "com.figma.variableId": "VariableID:50:1427"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.0}",
             "default": "{palette.blue.0}"
@@ -884,15 +656,10 @@
       },
       "transparent": {
         "$extensions": {
-          "com.figma.scopes": [
-            "FRAME_FILL",
-            "SHAPE_FILL"
-          ],
+          "com.figma.scopes": ["FRAME_FILL", "SHAPE_FILL"],
           "com.figma.variableId": "VariableID:2500:145417"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.transparent.clear}",
           "default": "{palette.transparent.clear}"
@@ -903,14 +670,10 @@
       "onBrand": {
         "border": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:52:1377"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-10}",
             "default": "{palette.transparent.white.fixed-10}"
@@ -918,14 +681,10 @@
         },
         "border-active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:139:5"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.0}",
             "default": "{palette.grayscale.0}"
@@ -933,14 +692,10 @@
         },
         "divider": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:52:1378"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-10}",
             "default": "{palette.transparent.white.fixed-10}"
@@ -950,14 +705,10 @@
       "onStatus": {
         "ai": {
           "$extensions": {
-            "com.figma.scopes": [
-              "ALL_SCOPES"
-            ],
+            "com.figma.scopes": ["ALL_SCOPES"],
             "com.figma.variableId": "VariableID:4313:50249"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.4}",
             "default": "{palette.violet.4}"
@@ -969,9 +720,7 @@
             "com.figma.variableId": "VariableID:2277:437"
           },
           "$type": "gradient",
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{gradients.ai.idle}",
             "default": "{gradients.ai.idle}"
@@ -979,14 +728,10 @@
         },
         "critical": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:41"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.4}",
             "default": "{palette.orange.4}"
@@ -994,14 +739,10 @@
         },
         "criticalStrong": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2005"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.8}",
             "default": "{palette.orange.8}"
@@ -1009,14 +750,10 @@
         },
         "danger": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:42"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.4}",
             "default": "{palette.red.4}"
@@ -1024,14 +761,10 @@
         },
         "dangerStrong": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2004"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.8}",
             "default": "{palette.red.8}"
@@ -1039,14 +772,10 @@
         },
         "info": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:38"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
             "default": "{palette.electricblue.4}"
@@ -1054,14 +783,10 @@
         },
         "infoStrong": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2008"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.8}",
             "default": "{palette.electricblue.8}"
@@ -1069,14 +794,10 @@
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:911:263463"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.4}",
             "default": "{palette.grayscale.4}"
@@ -1084,14 +805,10 @@
         },
         "neutralStrong": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:912:268723"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.8}",
             "default": "{palette.grayscale.8}"
@@ -1099,14 +816,10 @@
         },
         "success": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:39"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.4}",
             "default": "{palette.green.4}"
@@ -1114,14 +827,10 @@
         },
         "successStrong": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2007"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.8}",
             "default": "{palette.green.8}"
@@ -1129,14 +838,10 @@
         },
         "warning": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:147:40"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.4}",
             "default": "{palette.yellow.4}"
@@ -1144,14 +849,10 @@
         },
         "warningStrong": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:797:2006"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.8}",
             "default": "{palette.yellow.8}"
@@ -1161,14 +862,10 @@
       "onSurface": {
         "border": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:50:1437"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.3}",
             "default": "{palette.blue.3}"
@@ -1176,14 +873,10 @@
         },
         "border-active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:138:187"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.7}",
             "default": "{palette.blue.7}"
@@ -1191,14 +884,10 @@
         },
         "border-error": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:1234:100"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.7}",
             "default": "{palette.red.7}"
@@ -1206,14 +895,10 @@
         },
         "divider": {
           "$extensions": {
-            "com.figma.scopes": [
-              "STROKE_COLOR"
-            ],
+            "com.figma.scopes": ["STROKE_COLOR"],
             "com.figma.variableId": "VariableID:50:1438"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.3}",
             "default": "{palette.blue.3}"
@@ -1222,14 +907,10 @@
       },
       "transparent": {
         "$extensions": {
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:2500:145418"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.transparent.clear}",
           "default": "{palette.transparent.clear}"
@@ -1239,14 +920,10 @@
     "focus": {
       "brand": {
         "$extensions": {
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:1838:1394"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.blue.4}",
           "default": "{palette.blue.4}"
@@ -1254,14 +931,10 @@
       },
       "error": {
         "$extensions": {
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:1828:1379"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.red.4}",
           "default": "{palette.red.4}"
@@ -1269,14 +942,10 @@
       },
       "primary": {
         "$extensions": {
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:1828:1378"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.blue.4}",
           "default": "{palette.blue.4}"
@@ -1284,14 +953,10 @@
       },
       "secondary": {
         "$extensions": {
-          "com.figma.scopes": [
-            "STROKE_COLOR"
-          ],
+          "com.figma.scopes": ["STROKE_COLOR"],
           "com.figma.variableId": "VariableID:1838:1393"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": "{palette.blue.4}",
           "default": "{palette.blue.4}"
@@ -1302,14 +967,10 @@
       "onBackdrop": {
         "elementPrimary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:3931:8751"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.7}",
             "default": "{palette.blue.7}"
@@ -1317,14 +978,10 @@
         },
         "screenPrimary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:143:179"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
             "default": "{palette.transparent.white.fixed-100}"
@@ -1334,14 +991,10 @@
       "onBrand": {
         "disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:179:195"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-10}",
             "default": "{palette.transparent.white.fixed-10}"
@@ -1349,14 +1002,10 @@
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:52:2202"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
             "default": "{palette.transparent.white.fixed-100}"
@@ -1364,14 +1013,10 @@
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:179:196"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
             "default": "{palette.transparent.white.fixed-60}"
@@ -1381,14 +1026,10 @@
       "onInverse": {
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:305:125"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
             "default": "{palette.transparent.white.fixed-100}"
@@ -1398,14 +1039,10 @@
       "onStatus": {
         "ai": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:1936:2682"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.11}",
             "default": "{palette.violet.11}"
@@ -1413,14 +1050,10 @@
         },
         "critical": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1732"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.11}",
             "default": "{palette.orange.11}"
@@ -1428,14 +1061,10 @@
         },
         "danger": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1731"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.11}",
             "default": "{palette.red.11}"
@@ -1443,14 +1072,10 @@
         },
         "disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:151:43"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.3}",
             "default": "{palette.blue.3}"
@@ -1458,14 +1083,10 @@
         },
         "info": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1735"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.11}",
             "default": "{palette.electricblue.11}"
@@ -1473,14 +1094,10 @@
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:911:263464"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.11}",
             "default": "{palette.grayscale.11}"
@@ -1488,14 +1105,10 @@
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:149:7"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.11}",
             "default": "{palette.electricblue.11}"
@@ -1503,14 +1116,10 @@
         },
         "success": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1734"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.11}",
             "default": "{palette.green.11}"
@@ -1518,14 +1127,10 @@
         },
         "warning": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:796:1733"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.11}",
             "default": "{palette.yellow.11}"
@@ -1535,14 +1140,10 @@
       "onSurface": {
         "brand": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:2463:54749"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.13}",
             "default": "{palette.blue.13}"
@@ -1550,14 +1151,10 @@
         },
         "destructive": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:143:8"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.7}",
             "default": "{palette.red.7}"
@@ -1565,14 +1162,10 @@
         },
         "disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:56:1581"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.5}",
             "default": "{palette.blue.3}"
@@ -1580,14 +1173,10 @@
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:1024:122"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.4}",
             "default": "{palette.grayscale.4}"
@@ -1595,14 +1184,10 @@
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "SHAPE_FILL"
-            ],
+            "com.figma.scopes": ["SHAPE_FILL"],
             "com.figma.variableId": "VariableID:50:1436"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.10}",
             "default": "{palette.blue.7}"
@@ -1612,61 +1197,12 @@
     },
     "text": {
       "onBackdrop": {
-        "elementPrimary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:3931:7751"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.transparent.dark.inverse-100}",
-            "default": "{palette.transparent.dark.inverse-100}"
-          }
-        },
-        "screenPrimary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:3931:7747"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
-          }
-        },
-        "screenSecondary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:3931:7754"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
-            "default": "{palette.transparent.white.fixed-60}"
-          }
-        },
         "elementLink-active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3939:3396"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
             "default": "{palette.electricblue.4}"
@@ -1674,14 +1210,10 @@
         },
         "elementLink-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3939:3395"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
             "default": "{palette.electricblue.4}"
@@ -1689,29 +1221,32 @@
         },
         "elementLink-idle": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3939:3394"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.7}",
             "default": "{palette.electricblue.7}"
           }
         },
+        "elementPrimary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:3931:7751"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.transparent.dark.inverse-100}",
+            "default": "{palette.transparent.dark.inverse-100}"
+          }
+        },
         "screenLink-active": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:8760"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
             "default": "{palette.electricblue.4}"
@@ -1719,14 +1254,10 @@
         },
         "screenLink-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:8759"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
             "default": "{palette.electricblue.4}"
@@ -1734,31 +1265,45 @@
         },
         "screenLink-idle": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:8758"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.4}",
             "default": "{palette.electricblue.4}"
+          }
+        },
+        "screenPrimary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:3931:7747"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
+            "default": "{palette.transparent.white.fixed-100}"
+          }
+        },
+        "screenSecondary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:3931:7754"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
+            "default": "{palette.transparent.white.fixed-60}"
           }
         }
       },
       "onBrand": {
         "disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:52:1358"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-30}",
             "default": "{palette.transparent.white.fixed-30}"
@@ -1766,14 +1311,10 @@
         },
         "link": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:169"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.7}",
             "default": "{palette.blue.7}"
@@ -1781,14 +1322,10 @@
         },
         "link-disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:172"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-30}",
             "default": "{palette.transparent.white.fixed-30}"
@@ -1796,14 +1333,10 @@
         },
         "link-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:170"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.5}",
             "default": "{palette.blue.5}"
@@ -1811,14 +1344,10 @@
         },
         "link-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:139:171"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.blue.3}",
             "default": "{palette.blue.3}"
@@ -1826,14 +1355,10 @@
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:52:1353"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
             "default": "{palette.transparent.white.fixed-100}"
@@ -1841,14 +1366,34 @@
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:52:1354"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
+            "default": "{palette.transparent.white.fixed-60}"
+          }
+        }
+      },
+      "onInverse": {
+        "primary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:305:127"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
+            "default": "{palette.transparent.white.fixed-100}"
+          }
+        },
+        "secondary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:4363:6331"
+          },
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
             "default": "{palette.transparent.white.fixed-60}"
@@ -1858,14 +1403,10 @@
       "onStatus": {
         "ai": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:912:266569"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.violet.11}",
             "default": "{palette.violet.11}"
@@ -1873,14 +1414,10 @@
         },
         "critical": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:201:20"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.orange.11}",
             "default": "{palette.orange.11}"
@@ -1888,14 +1425,10 @@
         },
         "danger": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:201:19"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.red.11}",
             "default": "{palette.red.11}"
@@ -1903,14 +1436,10 @@
         },
         "info": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:201:17"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.11}",
             "default": "{palette.electricblue.11}"
@@ -1918,14 +1447,10 @@
         },
         "link": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:149:4"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.11}",
             "default": "{palette.electricblue.11}"
@@ -1933,14 +1458,10 @@
         },
         "link-disabled": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:149:8"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.5}",
             "default": "{palette.electricblue.5}"
@@ -1948,14 +1469,10 @@
         },
         "link-hover": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:149:5"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.13}",
             "default": "{palette.electricblue.13}"
@@ -1963,14 +1480,10 @@
         },
         "link-pressed": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:149:6"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.14}",
             "default": "{palette.electricblue.14}"
@@ -1978,14 +1491,10 @@
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:911:263465"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.11}",
             "default": "{palette.grayscale.11}"
@@ -1993,14 +1502,10 @@
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:149:2"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.14}",
             "default": "{palette.grayscale.14}"
@@ -2008,14 +1513,10 @@
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:149:3"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.11}",
             "default": "{palette.grayscale.11}"
@@ -2023,14 +1524,10 @@
         },
         "success": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:201:21"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.green.11}",
             "default": "{palette.green.11}"
@@ -2038,213 +1535,23 @@
         },
         "warning": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:201:18"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.yellow.11}",
             "default": "{palette.yellow.11}"
           }
         }
       },
-      "onSurface": {
-        "destructive": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:139:150"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.red.7}",
-            "default": "{palette.red.7}"
-          }
-        },
-        "disabled": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:52:1357"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": {
-              "colorSpace": "hsl",
-              "components": [
-                205.71,
-                14.58,
-                18.82
-              ]
-            },
-            "default": "{palette.grayscale.5}"
-          }
-        },
-        "link": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:139:155"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": {
-              "colorSpace": "hsl",
-              "components": [
-                208.8,
-                15.53,
-                31.57
-              ]
-            },
-            "default": "{palette.blue.7}"
-          }
-        },
-        "link-disabled": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:139:160"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.grayscale.3}",
-            "default": "{palette.blue.3}"
-          }
-        },
-        "link-hover": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:139:156"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.grayscale.11}",
-            "default": "{palette.blue.8}"
-          }
-        },
-        "link-pressed": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:139:159"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.grayscale.12}",
-            "default": "{palette.blue.11}"
-          }
-        },
-        "primary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:50:1425"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": {
-              "colorSpace": "hsl",
-              "components": [
-                208.8,
-                15.53,
-                31.57
-              ]
-            },
-            "default": "{palette.grayscale.14}"
-          }
-        },
-        "secondary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:50:1434"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": {
-              "colorSpace": "hsl",
-              "components": [
-                207,
-                15.63,
-                25.1
-              ]
-            },
-            "default": "{palette.grayscale.7}"
-          }
-        }
-      },
-      "onInverse": {
-        "primary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:305:127"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
-            "default": "{palette.transparent.white.fixed-100}"
-          }
-        },
-        "secondary": {
-          "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
-            "com.figma.variableId": "VariableID:4363:6331"
-          },
-          "platforms": [
-            "PD"
-          ],
-          "values": {
-            "deep_sky_itkontoret": "{palette.transparent.white.fixed-60}",
-            "default": "{palette.transparent.white.fixed-60}"
-          }
-        }
-      },
       "onStatusStrong": {
         "ai": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12115"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
             "default": "{palette.transparent.white.fixed-100}"
@@ -2252,14 +1559,10 @@
         },
         "critical": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12112"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
             "default": "{palette.transparent.white.fixed-100}"
@@ -2267,14 +1570,10 @@
         },
         "danger": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12113"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
             "default": "{palette.transparent.white.fixed-100}"
@@ -2282,14 +1581,10 @@
         },
         "info": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12109"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
             "default": "{palette.transparent.white.fixed-100}"
@@ -2297,14 +1592,10 @@
         },
         "link": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12116"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.electricblue.11}",
             "default": "{palette.electricblue.11}"
@@ -2312,14 +1603,10 @@
         },
         "neutral": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12114"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
             "default": "{palette.transparent.white.fixed-100}"
@@ -2327,14 +1614,10 @@
         },
         "primary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12107"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.0}",
             "default": "{palette.grayscale.0}"
@@ -2342,14 +1625,10 @@
         },
         "secondary": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12108"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.grayscale.2}",
             "default": "{palette.grayscale.2}"
@@ -2357,14 +1636,10 @@
         },
         "success": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12110"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
             "default": "{palette.transparent.white.fixed-100}"
@@ -2372,17 +1647,115 @@
         },
         "warning": {
           "$extensions": {
-            "com.figma.scopes": [
-              "TEXT_FILL"
-            ],
+            "com.figma.scopes": ["TEXT_FILL"],
             "com.figma.variableId": "VariableID:3931:12111"
           },
-          "platforms": [
-            "PD"
-          ],
+          "platforms": ["PD"],
           "values": {
             "deep_sky_itkontoret": "{palette.transparent.white.fixed-100}",
             "default": "{palette.transparent.white.fixed-100}"
+          }
+        }
+      },
+      "onSurface": {
+        "destructive": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:150"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.red.7}",
+            "default": "{palette.red.7}"
+          }
+        },
+        "disabled": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:52:1357"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": {
+              "colorSpace": "hsl",
+              "components": [205.71, 14.58, 18.82]
+            },
+            "default": "{palette.grayscale.5}"
+          }
+        },
+        "link": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:155"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": {
+              "colorSpace": "hsl",
+              "components": [208.8, 15.53, 31.57]
+            },
+            "default": "{palette.blue.7}"
+          }
+        },
+        "link-disabled": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:160"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.3}",
+            "default": "{palette.blue.3}"
+          }
+        },
+        "link-hover": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:156"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.11}",
+            "default": "{palette.blue.8}"
+          }
+        },
+        "link-pressed": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:139:159"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": "{palette.grayscale.12}",
+            "default": "{palette.blue.11}"
+          }
+        },
+        "primary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:50:1425"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": {
+              "colorSpace": "hsl",
+              "components": [208.8, 15.53, 31.57]
+            },
+            "default": "{palette.grayscale.14}"
+          }
+        },
+        "secondary": {
+          "$extensions": {
+            "com.figma.scopes": ["TEXT_FILL"],
+            "com.figma.variableId": "VariableID:50:1434"
+          },
+          "platforms": ["PD"],
+          "values": {
+            "deep_sky_itkontoret": {
+              "colorSpace": "hsl",
+              "components": [207, 15.63, 25.1]
+            },
+            "default": "{palette.grayscale.7}"
           }
         }
       }
@@ -2397,30 +1770,20 @@
           "com.figma.scopes": [],
           "com.figma.variableId": "VariableID:2277:28"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": [
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  234.11,
-                  56.57,
-                  38.82
-                ]
+                "components": [234.11, 56.57, 38.82]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.09,
-                  69.78,
-                  27.25
-                ]
+                "components": [303.09, 69.78, 27.25]
               },
               "position": 1
             }
@@ -2429,22 +1792,14 @@
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  234.11,
-                  56.57,
-                  38.82
-                ]
+                "components": [234.11, 56.57, 38.82]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.09,
-                  69.78,
-                  27.25
-                ]
+                "components": [303.09, 69.78, 27.25]
               },
               "position": 1
             }
@@ -2457,30 +1812,20 @@
           "com.figma.scopes": [],
           "com.figma.variableId": "VariableID:2277:29"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": [
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  234.38,
-                  100,
-                  93.73
-                ]
+                "components": [234.38, 100, 93.73]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.24,
-                  100,
-                  92.75
-                ]
+                "components": [303.24, 100, 92.75]
               },
               "position": 1
             }
@@ -2489,22 +1834,14 @@
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  234.38,
-                  100,
-                  93.73
-                ]
+                "components": [234.38, 100, 93.73]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.24,
-                  100,
-                  92.75
-                ]
+                "components": [303.24, 100, 92.75]
               },
               "position": 1
             }
@@ -2517,30 +1854,20 @@
           "com.figma.scopes": [],
           "com.figma.variableId": "VariableID:2277:27"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": [
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  233.75,
-                  58.54,
-                  48.24
-                ]
+                "components": [233.75, 58.54, 48.24]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.22,
-                  69.3,
-                  42.16
-                ]
+                "components": [303.22, 69.3, 42.16]
               },
               "position": 1
             }
@@ -2549,22 +1876,14 @@
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  233.75,
-                  58.54,
-                  48.24
-                ]
+                "components": [233.75, 58.54, 48.24]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.22,
-                  69.3,
-                  42.16
-                ]
+                "components": [303.22, 69.3, 42.16]
               },
               "position": 1
             }
@@ -2577,30 +1896,20 @@
           "com.figma.scopes": [],
           "com.figma.variableId": "VariableID:2277:21"
         },
-        "platforms": [
-          "PD"
-        ],
+        "platforms": ["PD"],
         "values": {
           "deep_sky_itkontoret": [
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  233.93,
-                  73.04,
-                  54.9
-                ]
+                "components": [233.93, 73.04, 54.9]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.19,
-                  97.18,
-                  58.24
-                ]
+                "components": [303.19, 97.18, 58.24]
               },
               "position": 1
             }
@@ -2609,22 +1918,14 @@
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  233.93,
-                  73.04,
-                  54.9
-                ]
+                "components": [233.93, 73.04, 54.9]
               },
               "position": 0.2
             },
             {
               "color": {
                 "colorSpace": "hsl",
-                "components": [
-                  303.19,
-                  97.18,
-                  58.24
-                ]
+                "components": [303.19, 97.18, 58.24]
               },
               "position": 1
             }
@@ -2647,9 +1948,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "default": {
         "$extensions": {
@@ -2662,9 +1961,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "form-label": {
         "$extensions": {
@@ -2677,9 +1974,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "heading": {
         "$extensions": {
@@ -2693,9 +1988,7 @@
           "letterSpacing": "{font.letter-spacing.0-3}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "strong": {
         "$extensions": {
@@ -2708,9 +2001,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       }
     },
     "caption": {
@@ -2725,9 +2016,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "default": {
         "$extensions": {
@@ -2740,9 +2029,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "strong": {
         "$extensions": {
@@ -2755,9 +2042,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       }
     },
     "fineprint": {
@@ -2772,9 +2057,7 @@
           "letterSpacing": "{font.letter-spacing.1}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       }
     },
     "headings": {
@@ -2789,9 +2072,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.40}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "lead": {
         "$extensions": {
@@ -2804,9 +2085,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "title": {
         "$extensions": {
@@ -2819,9 +2098,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.32}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "title-accent": {
         "$extensions": {
@@ -2834,9 +2111,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.32}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       }
     },
     "link": {
@@ -2851,9 +2126,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "default-underline": {
         "$extensions": {
@@ -2867,9 +2140,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "strong": {
         "$extensions": {
@@ -2882,9 +2153,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "strong-underline": {
         "$extensions": {
@@ -2898,9 +2167,7 @@
           "letterSpacing": "{font.letter-spacing.0}",
           "lineHeight": "{font.line-height.24}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       }
     },
     "note": {
@@ -2915,9 +2182,7 @@
           "letterSpacing": "{font.letter-spacing.1}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       },
       "heading": {
         "$extensions": {
@@ -2931,9 +2196,7 @@
           "letterSpacing": "{font.letter-spacing.1}",
           "lineHeight": "{font.line-height.16}"
         },
-        "platforms": [
-          "PD"
-        ]
+        "platforms": ["PD"]
       }
     }
   }


### PR DESCRIPTION
Syncs design tokens from Figma (`shadcn-uikit`) into the committed tiers. Broken into reviewable commits by tier and change type.

## Commits
1. `chore` — normalize token file formatting (isolates the serializer's whole-file reformat so the rest are clean)
2. `feat` — add primitive tokens and palette updates (10 new + 2 mode changes)
3. `feat` — sync semantic color tokens (6 added, 3 deleted, 159 mode changes)
4. `feat` — remove deprecated Link/Table/Resizable/clearIcon tokens (31 deletions)
5. `feat` — add new component tokens (211 new)
6. `feat` — populate virtuozzo brand mode for components (766 fills)
7. `feat` — update default/deep_sky_itkontoret component mode values (98 + scopes/ext) + changeset

## Validation
- `design-tokens` schema `validate`: all three tiers valid ✅
- `tokens-pd` build (`style-dictionary build pd-css pd-tailwind`): exit 0 ✅ (`tokens-pd` regenerates cleanly; intentionally **not** committed — owned by a downstream/release step)
- Verified the chunked apply is semantically identical to a single canonical apply across all tiers.

## Notes for reviewers
- **Figma typo fixed in-tree:** the sync introduced `{typography.headigns.display-numeric}` on two `InputOTP.placeholder.textStyle` tokens (broke the `tokens-pd` build). Patched to `headings` in commit 7. **This typo still exists in Figma** and will recur on the next sync unless corrected there.
- `tokens-pd` emits non-fatal warnings about unroutable `Table.Data.*` / `Table.Header.*` color tokens ("fix naming in Figma") — graceful skips, kept in CSS/tiers, another Figma-naming cleanup candidate.

Changeset: single `minor` bump for `@acronis-platform/design-tokens` and `@acronis-platform/tokens-pd` (tokens created and deleted).
