### PR TITLE
Feature/skills improvement

### DIFF
--- a/.claude/agents/developer-react/agent.md
+++ b/.claude/agents/developer-react/agent.md
@@ -54,6 +54,22 @@ This is a React-only monorepo (no Vue). Your code lives in:
   `@acronis-platform/design-tokens`, then rebuild `design-theme` — never fork
   values inside a component.
 
+## Localization & RTL — `packages/ui-react`
+
+Full rule in
+[context/conventions.md](../../../packages/ui-react/context/conventions.md#localization--no-hardcoded-labels).
+Applies to **every** change that touches component source, including a
+one-line fix — not just new components:
+
+- Any text the component renders on its own (`aria-label` fallback,
+  `sr-only` copy, placeholder/empty-state/tooltip strings) must come from a
+  prop with the literal only as that prop's default — never inlined in JSX.
+  Consumer-supplied `children`/`label` props are fine as-is.
+- Use **logical** Tailwind utilities (`ms-`/`me-`, `ps-`/`pe-`, `start-`/
+  `end-`) for anything that should mirror under `dir="rtl"` — never
+  physical ones (`ml-`/`mr-`, `pl-`/`pr-`, `left-`/`right-`). A directional
+  icon that should flip needs an explicit `rtl:`/`ltr:` variant.
+
 ## File layout per component
 
 ```
@@ -72,6 +88,9 @@ src/components/ui/<component>/
    **light and dark** mode.
 3. A **Changeset** (`pnpm changeset` from repo root) for any published-package
    change. See [context/releasing.md](../../../context/releasing.md).
+4. No new hardcoded label and no new physical directional utility introduced
+   in `packages/ui-react` (see Localization & RTL above) — check this even
+   when the change is a small fix, not just on new components.
 
 ## Commands
 

--- a/.claude/agents/devil-advocate/agent.md
+++ b/.claude/agents/devil-advocate/agent.md
@@ -37,6 +37,18 @@ team lead routes the fix.
 - [ ] New color names bridged via `@theme inline`, not forked from
       `design-theme`; no theme values hand-authored in a component.
 
+**Localization / RTL:**
+
+- [ ] No component-rendered text (`aria-label` fallback, `sr-only` copy,
+      placeholder/empty-state/tooltip strings) hardcoded as a literal instead
+      of a prop default. Consumer-supplied `children`/`label` don't count.
+- [ ] No physical directional utility (`ml-`/`mr-`, `pl-`/`pr-`,
+      `left-`/`right-`) introduced where a logical one applies; directional
+      icons that should mirror under `dir="rtl"` carry an explicit
+      `rtl:`/`ltr:` variant.
+- [ ] Flagged on small follow-up fixes too, not only on the initial build —
+      a regression here is a regression regardless of change size.
+
 **TypeScript:**
 
 - [ ] No `any`. Props typed (extending the HTML attr type or the primitive's

--- a/.claude/agents/qa/agent.md
+++ b/.claude/agents/qa/agent.md
@@ -54,6 +54,19 @@ Report each as **PASS** / **FAIL** (new error = FAIL, pre-existing = WARNING).
 - [ ] Any new color name is bridged in `src/styles/index.css` `@theme inline`,
       not forked from `design-theme`.
 
+**Localization / RTL** (see `packages/ui-react/context/conventions.md`):
+
+- [ ] No text the component renders on its own (`aria-label` fallback,
+      `sr-only` copy, placeholder/empty-state/tooltip strings) is inlined as a
+      literal — it comes from a prop, literal only as that prop's default.
+      Consumer-supplied `children`/`label` values don't count.
+- [ ] No physical directional Tailwind utility (`ml-`/`mr-`, `pl-`/`pr-`,
+      `left-`/`right-`) where a logical one (`ms-`/`me-`, `ps-`/`pe-`,
+      `start-`/`end-`) applies; directional icons that should flip under
+      `dir="rtl"` have an explicit `rtl:`/`ltr:` variant.
+- [ ] Check this on **every** change to component source, including a small
+      follow-up fix — not just on new components.
+
 **Tests & stories:**
 
 - [ ] Vitest + RTL test exists under `__tests__/`, asserts the public contract.

--- a/.claude/skills/component-readiness/SKILL.md
+++ b/.claude/skills/component-readiness/SKILL.md
@@ -4,14 +4,16 @@ description: >
   Read-only pre-flight gate that audits ui-react components for token drift and
   spec/test completeness BEFORE running /figma-component. Per component it checks
   that every --ui-* reference resolves in tokens-pd, that each referenced token
-  tier is imported in styles/index.css, that the ui-spec 7-file set is present and
+  tier is imported in styles/index.css, that no Radix/asChild import crept into
+  ui-react (Base UI only), that the ui-spec 7-file set is present and
   conformance passes, that tests exist, and that the Figma link is intact
-  (index.yaml node + a COMPLETE Code Connect). A deep mode adds Figma design
-  parity: structural (variants/states), value-level (each design variable's value
-  == the referenced --ui-* token's resolved value), and an advisory screenshot
-  pixel-diff — via the Figma MCP + bundled scripts. Reports a
-  READY / DRIFT / INCOMPLETE matrix; never edits files. Invoke with
-  /component-readiness [ComponentName | all].
+  (index.yaml node + a COMPLETE Code Connect) — plus advisory heuristics for
+  hardcoded labels, physical directional (RTL-risk) utilities, and a missing or
+  stale apps/docs page. A deep mode adds Figma design parity: structural
+  (variants/states), value-level (each design variable's value == the referenced
+  --ui-* token's resolved value), and an advisory screenshot pixel-diff — via the
+  Figma MCP + bundled scripts. Reports a READY / DRIFT / INCOMPLETE matrix; never
+  edits files. Invoke with /component-readiness [ComponentName | all].
 argument-hint: '[ComponentName | all]'
 ---
 
@@ -61,6 +63,7 @@ mirrors `/figma-component` Phase 2.
 | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
 | **TOKENS**  | Every `--ui-*` referenced in the component's code (`.tsx`/`.ts`: `var(--ui-*)` bindings, test/story class assertions) **and** in its `ui-spec` YAML (`tokens.yaml`, `anatomy.yaml`) resolves to a token defined in `packages/tokens-pd/css/**`.                                                             | **Yes** → DRIFT                |
 | **IMPORTS** | Every component **tier** whose tokens it references (e.g. `--ui-radio-*` → `Radio`) is `@import`-ed in `packages/ui-react/src/styles/index.css`. Component tiers are **opt-in**; a missing import means the tokens are undefined at runtime even though they exist in `tokens-pd`.                          | **Yes** → DRIFT                |
+| **IMPL**    | No `@radix-ui` import or `asChild` prop in the component's own `.tsx` — `ui-react` is Base UI only (`useRender`/`mergeProps`), never Radix/`asChild`/`Slot`. This is the one objective slice of "implementation correctness" a grep can decide; see the agent step below for the rest.                      | **Yes** → DRIFT                |
 | **SPEC**    | The `ui-spec` 7-file set is present (`index.yaml`, `anatomy.yaml`, `api.yaml`, `tokens.yaml`, `behavior.md`, `accessibility.md`, `README.md`).                                                                                                                                                              | No → INCOMPLETE                |
 | **TESTS**   | `__tests__/<name>.test.tsx` exists.                                                                                                                                                                                                                                                                         | No → INCOMPLETE                |
 | **FIGMA**   | **Linkage parity:** `index.yaml` has a `figma.node` **and** a `<name>.figma.tsx` marked `COMPLETE` whose `figma.codeConnect` path resolves. Values: `LINKED` / `DRAFT` (Code Connect unfinished) / `PARTIAL` (one side missing/broken) / `NONE`. The script surfaces both node IDs for the live diff below. | No → INCOMPLETE (NONE/PARTIAL) |
@@ -72,6 +75,32 @@ mirrors `/figma-component` Phase 2.
 **Non-blocking advisory:** stale `--ui-*` token names mentioned in spec **prose**
 (`behavior.md` etc.) that no longer resolve are reported but do **not** fail the
 gate (prose is documentation, not a live binding) — clean them during an update.
+
+**Non-blocking advisory — Localization / RTL:** two more heuristic greps run
+per component (see `packages/ui-react/context/conventions.md` for the actual
+rule) and print a note, never fail the gate — they're pattern matches, not
+semantic analysis, so judge each hit:
+
+- **Hardcoded label** — a literal string sits in `aria-label`/`placeholder`/
+  `title` or bare JSX text in the component's own `.tsx` where a prop default
+  belongs. Real hit: `pagination.tsx`'s `sr-only` "More pages" span has no
+  override. False-positive shape: a `.figma.tsx`/`.stories.tsx`/`.test.tsx`
+  file (excluded already) or example/demo text.
+- **Physical directional utility** — `ml-`/`mr-`/`pl-`/`pr-`/`left-`/`right-`
+  where a logical one (`ms-`/`me-`/`ps-`/`pe-`/`start-`/`end-`) should mirror
+  under `dir="rtl"`. Real hit: `calendar.tsx`'s `pl-2 pr-1`. False-positive
+  shape: symmetric centering (`left-1/2 -translate-x-1/2`) or a named `side`
+  variant (`sheet.tsx`'s `side="left"`) that's intentionally anchored to a
+  physical edge regardless of direction — use judgment, don't blanket-convert.
+
+**Non-blocking advisory — Docs:** `apps/docs/content/docs/components/<name>.mdx`
+existence and a prop-mention check (only runs when the component declares its
+own `Props` interface — nothing to check for a component that's purely
+`React.ComponentProps<'tag'>`). Never blocking, because not every component has
+a docs page by design — only `/legacy-component` writes one (Phase 5);
+`/figma-component` doesn't touch `apps/docs` at all. A missing page or an
+unmentioned prop is a genuine signal on a component you know went through
+`/legacy-component` or has a docs page already; it's expected noise otherwise.
 
 ---
 
@@ -174,13 +203,46 @@ diff PNG. Crop the Storybook capture to just the component for the cleanest resu
 
 ---
 
+## Implementation conformance & spec/docs content accuracy (agent step)
+
+The static checks above prove **files exist** and **references resolve** — they
+can't judge whether the content is actually right. That needs reading, the same
+way the Figma-parity section above requires reading the design instead of
+grepping it. Walk this checklist by hand for each component you're auditing
+(reuses the `qa`/`devil-advocate` repo-specific checklists — don't re-derive it):
+
+**Implementation conformance** — read the component against
+[`.claude/agents/qa/agent.md`](../../agents/qa/agent.md)'s "Component-level
+checks" (or [`devil-advocate/agent.md`](../../agents/devil-advocate/agent.md)'s
+mirror): right primitive for the interaction (Base UI `useRender`/`mergeProps`
+for polymorphism, not a hand-rolled pattern), `forwardRef` where a ref is
+actually accepted (not everywhere — e.g. a markup-only component like
+`pagination.tsx` legitimately has none), `cva` for variants merged with `cn()`,
+prop interface extending the right HTML/Base-UI type. The `IMPL` column only
+proves the one binary rule (no Radix/`asChild`); everything else here is a
+judgment call.
+
+**Spec content accuracy** — read `behavior.md`/`accessibility.md` against the
+component's actual code and tests: does the prose still describe what it does,
+or did a later fix change behavior the spec never caught up to? `ui-spec test`
+(the dynamic check above) only proves `cva` keys and `api.yaml` enums agree
+structurally — it can't read prose.
+
+**Docs content accuracy** — if `apps/docs/content/docs/components/<name>.mdx`
+exists, read its Usage/Examples/API Reference against the current component:
+does an example still compile against the real prop names, does the API
+Reference describe current defaults? The static `DOCS` advisory only checks a
+prop is _mentioned somewhere_, not that the description is still correct.
+
+---
+
 ## Verdict → gate decision
 
-| Verdict        | Meaning                                                                           | Action before `/figma-component`                                                                                                               |
-| -------------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| **READY**      | No token drift; spec + tests present.                                             | Proceed.                                                                                                                                       |
-| **DRIFT**      | A `--ui-*` ref doesn't resolve, or a tier isn't imported. **Will render broken.** | **Fix first.** Rewire dead token names to the current `tokens-pd` tier; add the missing `@import` to `styles/index.css`. Then re-run the gate. |
-| **INCOMPLETE** | Renders fine, but the spec or tests are missing.                                  | Safe to build; close the gap in the same change (`/figma-component` Phases 3–4 produce these).                                                 |
+| Verdict        | Meaning                                                                                                                                    | Action before `/figma-component`                                                                                                                                                     |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **READY**      | No token drift; spec + tests present.                                                                                                      | Proceed.                                                                                                                                                                             |
+| **DRIFT**      | A `--ui-*` ref doesn't resolve, a tier isn't imported, or Radix/`asChild` was introduced. **Will render broken, or violates a hard rule.** | **Fix first.** Rewire dead token names to the current `tokens-pd` tier; add the missing `@import` to `styles/index.css`; replace Radix/`asChild` with Base UI. Then re-run the gate. |
+| **INCOMPLETE** | Renders fine, but the spec or tests are missing.                                                                                           | Safe to build; close the gap in the same change (`/figma-component` Phases 3–4 produce these).                                                                                       |
 
 For a **`--update`** run of `/figma-component`, a `READY` verdict on the target
 component means you're refreshing a sound baseline; a `DRIFT` verdict means the

--- a/.claude/skills/component-readiness/scripts/audit.sh
+++ b/.claude/skills/component-readiness/scripts/audit.sh
@@ -18,10 +18,33 @@
 # Columns:
 #   TOKENS    every --ui-* ref (.tsx + tests + stories + spec) resolves in tokens-pd
 #   IMPORTS   every referenced component tier is @import-ed in ui-react styles/index.css
+#   IMPL      no @radix-ui import / asChild prop in the component's own .tsx — ui-react
+#             is Base UI only, this is a hard repo rule, not a style preference
 #   SPEC      ui-spec 7-file set present
 #   TESTS     __tests__/<name>.test.tsx present
 #   CODECONN  <name>.figma.tsx present + marked COMPLETE
-#   VERDICT   READY | DRIFT (token/import failure) | INCOMPLETE (spec/tests/CC gap)
+#   VERDICT   READY | DRIFT (token/import/impl failure) | INCOMPLETE (spec/tests/CC gap)
+#
+# Three more checks run per component but are printed as non-blocking advisory
+# notes, not columns (they're heuristic greps, prone to false positives —
+# same treatment as the stale-prose-token note below):
+#   I18N hint   a literal string sits where a prop default belongs (aria-label/
+#               placeholder/title attrs, or bare JSX text) in the component's
+#               own .tsx (excludes .stories./.test./.figma.)
+#   RTL hint    a physical directional Tailwind utility (ml-/mr-/pl-/pr-/
+#               left-/right-) where a logical one (ms-/me-/ps-/pe-/start-/end-)
+#               should be used instead
+#   DOCS hint   apps/docs/content/docs/components/<name>.mdx is missing, or a
+#               prop declared in the component's own Props interface isn't
+#               mentioned anywhere in it (both are heuristic — not every
+#               component gets a docs page via /figma-component, only
+#               /legacy-component writes one; judge each hit)
+#
+# What this script does NOT check (needs reading, not grepping — see SKILL.md
+# §Implementation conformance / §Spec & docs content accuracy, an agent step):
+# whether the right Base UI primitive/composition pattern was chosen, whether
+# spec prose (behavior.md/accessibility.md) still describes actual behavior,
+# whether docs prose is accurate (only presence/prop-mention is checked here).
 #
 # The dynamic checks (vitest run, typecheck, lint, `ui-spec test` conformance) are
 # slower and run by the caller per SKILL.md — this script does the fast static pass.
@@ -66,8 +89,8 @@ defined="$(mktemp)"
 grep -rho -- '--ui-[a-z0-9-]*' "$TOKENS" | sort -u > "$defined"
 
 fail=0
-printf '%-22s %-7s %-8s %-8s %-6s %-8s %s\n' COMPONENT TOKENS IMPORTS SPEC TESTS FIGMA VERDICT
-printf '%-22s %-7s %-8s %-8s %-6s %-8s %s\n' "----------------------" "------" "-------" "-------" "-----" "-------" "-------"
+printf '%-22s %-7s %-8s %-6s %-8s %-6s %-8s %s\n' COMPONENT TOKENS IMPORTS IMPL SPEC TESTS FIGMA VERDICT
+printf '%-22s %-7s %-8s %-6s %-8s %-6s %-8s %s\n' "----------------------" "------" "-------" "-----" "-------" "-----" "-------" "-------"
 
 for c in $comps; do
   if [ ! -d "$UI/$c" ]; then
@@ -104,6 +127,11 @@ for c in $comps; do
   done < "$refs"
   miss_imp="$(printf '%s' "$miss_imp" | tr ' ' '\n' | sort -u | tr '\n' ' ' | sed 's/^ *//;s/ *$//')"
   if [ -z "$miss_imp" ]; then imp=PASS; else imp=FAIL; fi
+
+  # ---- IMPL: hard ui-react rule — no Radix, no asChild (component's own .tsx only) ----
+  impl_hits="$(grep -lE '@radix-ui|asChild' "$UI/$c"/*.tsx 2>/dev/null \
+               | grep -vE '\.(stories|test|figma)\.tsx$')"
+  if [ -z "$impl_hits" ]; then impl=PASS; else impl=FAIL; fi
 
   # ---- SPEC: 7-file set present ----
   spec_missing=""
@@ -147,8 +175,39 @@ for c in $comps; do
     fig=LINKED
   fi
 
+  # ---- I18N / RTL: non-blocking advisory heuristics (component's own .tsx only) ----
+  i18n_hits=""
+  rtl_hits=""
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    h="$(grep -nE '(aria-label|placeholder|title)=["'"'"'][A-Za-z][A-Za-z ]{2,}["'"'"']|>[A-Z][a-zA-Z]+( [a-zA-Z]+){1,4}<' "$f" 2>/dev/null)"
+    [ -n "$h" ] && i18n_hits="$i18n_hits$f:$(printf '\n%s' "$h" | sed 's/^/    /')"
+    r="$(grep -nE '(^|[[:space:]"'"'"'])(ml|mr|pl|pr)-[0-9\[]|(^|[[:space:]"'"'"'])(left|right)-[0-9\[]' "$f" 2>/dev/null)"
+    [ -n "$r" ] && rtl_hits="$rtl_hits$f:$(printf '\n%s' "$r" | sed 's/^/    /')"
+  done < <(find "$UI/$c" -maxdepth 1 -name '*.tsx' ! -name '*.stories.tsx' ! -name '*.test.tsx' ! -name '*.figma.tsx' 2>/dev/null)
+
+  # ---- DOCS: advisory only — not every component gets a docs page via
+  # /figma-component (only /legacy-component writes one), so a missing page is
+  # never blocking. Prop-mention check only runs when the component declares
+  # its own Props interface (skips React.ComponentProps<'tag'>-only components,
+  # which have nothing custom to document).
+  mdx="apps/docs/content/docs/components/$c.mdx"
+  main_tsx="$UI/$c/$c.tsx"
+  docs_missing_props=""
+  if [ -f "$main_tsx" ]; then
+    own_props="$(sed -nE '/interface [A-Za-z0-9_]*Props/,/^}/p' "$main_tsx" 2>/dev/null \
+                 | grep -oE '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*\??:' \
+                 | sed -E 's/^[[:space:]]*//; s/\??:$//' | sort -u)"
+    if [ -f "$mdx" ] && [ -n "$own_props" ]; then
+      while IFS= read -r p; do
+        [ -z "$p" ] && continue
+        grep -qF "$p" "$mdx" || docs_missing_props="$docs_missing_props $p"
+      done <<< "$own_props"
+    fi
+  fi
+
   # ---- VERDICT ----
-  if [ "$tok" = FAIL ] || [ "$imp" = FAIL ]; then
+  if [ "$tok" = FAIL ] || [ "$imp" = FAIL ] || [ "$impl" = FAIL ]; then
     verdict="DRIFT"; fail=1
   elif [ "$spec" != PASS ] || [ "$tst" != PASS ] || [ "$fig" = NONE ] || [ "$fig" = PARTIAL ]; then
     verdict="INCOMPLETE"
@@ -156,9 +215,10 @@ for c in $comps; do
     verdict="READY"
   fi
 
-  printf '%-22s %-7s %-8s %-8s %-6s %-8s %s\n' "$c" "$tok" "$imp" "$spec" "$tst" "$fig" "$verdict"
+  printf '%-22s %-7s %-8s %-6s %-8s %-6s %-8s %s\n' "$c" "$tok" "$imp" "$impl" "$spec" "$tst" "$fig" "$verdict"
   [ -n "$dangling" ]      && echo "    ↳ dangling tokens: $(printf '%s' "$dangling" | tr '\n' ' ')"
   [ -n "$miss_imp" ]      && echo "    ↳ missing tier imports (add to $STYLES): $miss_imp"
+  [ "$impl" = FAIL ]      && echo "    ↳ Radix/asChild found (ui-react is Base UI only): $(printf '%s' "$impl_hits" | tr '\n' ' ')"
   [ "$spec" = PARTIAL ]   && echo "    ↳ missing spec files:$spec_missing"
   [ "$spec" = NONE ]      && echo "    ↳ no ui-spec dir ($SPEC/$c)"
   [ "$tst" = NONE ]       && echo "    ↳ no unit test ($UI/$c/__tests__/$c.test.tsx)"
@@ -167,6 +227,10 @@ for c in $comps; do
   [ "$fig" = DRAFT ]      && echo "    ↳ Code Connect not COMPLETE ($ff)"
   [ -n "$fig_node" ]      && echo "    ↳ figma parity: spec node $fig_node, code-connect node ${cc_node:-none} — run live diff (SKILL §Figma design parity)"
   [ -n "$prose_stale" ]   && echo "    ↳ (non-blocking) stale token names in spec prose: $(printf '%s' "$prose_stale" | tr '\n' ' ')"
+  [ -n "$i18n_hits" ]     && echo "    ↳ (advisory) possible hardcoded label — confirm it's a prop default, not inlined:$i18n_hits"
+  [ -n "$rtl_hits" ]      && echo "    ↳ (advisory) physical directional utility — confirm dir=\"rtl\" still renders correctly, prefer logical (ms-/me-/ps-/pe-/start-/end-):$rtl_hits"
+  [ ! -f "$mdx" ]         && echo "    ↳ (advisory) no docs page ($mdx) — expected only if this went through /legacy-component"
+  [ -n "$docs_missing_props" ] && echo "    ↳ (advisory) props not mentioned in docs ($mdx):$docs_missing_props"
   rm -f "$refs"
 done
 
@@ -174,7 +238,7 @@ rm -f "$defined"
 
 echo
 if [ "$fail" -ne 0 ]; then
-  echo "RESULT: DRIFT present — resolve dangling tokens / missing imports before /figma-component."
+  echo "RESULT: DRIFT present — resolve dangling tokens / missing imports / Radix-asChild before /figma-component."
 else
   echo "RESULT: no token drift. Review INCOMPLETE rows; run the dynamic checks (SKILL.md §Dynamic checks)."
 fi

--- a/.claude/skills/figma-component/SKILL.md
+++ b/.claude/skills/figma-component/SKILL.md
@@ -251,6 +251,17 @@ Conventions (mirror Button):
 mergeProps<'tag'>({…}, props) })`.
 - Export everything from `index.ts`, then add a line to
   `packages/ui-react/src/index.ts` (keep it alphabetical).
+- **Localization**: any text the component renders on its own (`aria-label`
+  fallback, `sr-only` copy, placeholder/empty-state/tooltip strings that the
+  design shows as static labels) must be a prop with that string only as its
+  default — never inlined in JSX. `children`/other consumer-supplied content
+  is fine as-is. See `context/conventions.md#localization--no-hardcoded-labels`.
+- **RTL**: use logical Tailwind utilities (`ms-`/`me-`, `ps-`/`pe-`,
+  `start-`/`end-`), never physical ones (`ml-`/`mr-`, `pl-`/`pr-`,
+  `left-`/`right-`), unless the design genuinely anchors to a physical edge
+  regardless of direction (e.g. a `side="left"` variant). Directional icons
+  that should flip need an explicit `rtl:`/`ltr:` variant. See
+  `context/conventions.md#rtl--bidirectional-layout`.
 
 For a **composable** component, export the full set of parts (see breadcrumb:
 `Breadcrumb`, `BreadcrumbList`, `BreadcrumbItem`, `BreadcrumbLink`,
@@ -418,6 +429,10 @@ the committed baselines still pass, and commit no PNGs.
 
 - [ ] `src/components/ui/<name>/<name>.tsx` — Base UI + `--ui-*` tokens, no hex.
 - [ ] `index.ts` + export line in `src/index.ts`.
+- [ ] No component-rendered text hardcoded — self-generated labels are prop
+      defaults, not inlined literals.
+- [ ] No physical directional utility where a logical one applies; directional
+      icons that should mirror under `dir="rtl"` have an explicit variant.
 - [ ] `__tests__/<name>.test.tsx` — render, variants/states, a11y roles, ref,
       `render`-prop composition.
 - [ ] `__stories__/<name>.stories.tsx` (hand) + `<name>.generated.stories.tsx`.

--- a/.claude/skills/legacy-component/SKILL.md
+++ b/.claude/skills/legacy-component/SKILL.md
@@ -284,6 +284,17 @@ when using `cva`; `cva` for `variant`/`size` merged with `cn()`; polymorphism vi
 Export everything from `index.ts`, then add an alphabetical line to
 `src/index.ts`. For a composable component, export the full set of parts.
 
+**Localization / RTL** — porting from legacy is exactly where a hardcoded
+label or a physical directional utility (`ml-`/`mr-`, `pl-`/`pr-`,
+`left-`/`right-`) tends to carry over verbatim; don't port it as-is. Expose
+any self-rendered text (`aria-label` fallback, `sr-only` copy, placeholder/
+empty-state strings) as a prop with the legacy string only as its default,
+and translate physical spacing/position utilities to logical ones
+(`ms-`/`me-`, `ps-`/`pe-`, `start-`/`end-`) unless the design genuinely
+anchors to a physical edge. See
+`context/conventions.md#localization--no-hardcoded-labels` and
+`#rtl--bidirectional-layout`.
+
 **Figma Code Connect — deferred.** Because there's no "ready for dev" node yet,
 the `.figma.tsx` carries the **`NEEDS_FIGMA_URL`** status marker (props are
 mapped correctly from the legacy contract; the node URL is a placeholder). Write
@@ -513,6 +524,10 @@ the `/figma-component` Phase 5 notes for the single-mode variants and the
       (component tier if it exists, else semantic/primitive), **no `--av-*`, no hex**.
 - [ ] `index.ts` + alphabetical export line in `src/index.ts`.
 - [ ] If an existing `--ui-<name>-*` tier is used: `@import` added to `src/styles/index.css`.
+- [ ] No hardcoded label carried over from legacy — self-rendered text is a
+      prop default, not an inlined literal.
+- [ ] No physical directional utility carried over from legacy where a
+      logical one applies.
 - [ ] `__tests__/<name>.test.tsx` — render, variants/states, a11y roles, ref,
       `render`-prop composition (intent ported from the legacy tests).
 - [ ] `__stories__/<name>.stories.tsx` (hand) + `<name>.generated.stories.tsx`.

--- a/.claude/skills/pre-push-check/SKILL.md
+++ b/.claude/skills/pre-push-check/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: pre-push-check
+description: >
+  Manual, local pre-push gate for packages/ui-react and packages/ui-spec
+  changes of any size — a one-line fix or a multi-file feature. Auto-discovers
+  which components changed versus a base ref (default origin/main), covering
+  both committed commits and uncommitted working-tree edits, so nothing needs
+  naming by hand. Reuses component-readiness's audit.sh per touched component
+  (TOKENS/IMPORTS/IMPL/SPEC/TESTS/FIGMA plus hardcoded-label, physical-RTL, and
+  docs-page advisories), then runs the dynamic checks (vitest scoped to
+  touched components, typecheck, lint, ui-spec test) and a changeset-presence
+  check — all in one command. Also documents the agent-judgment steps a script
+  can't do (implementation conformance, spec/docs content accuracy) and when
+  to reach for /figma-component --update instead (design-relevant changes).
+  Read-only — never edits files, never runs git push itself. Invoke with
+  /pre-push-check [base-ref].
+argument-hint: '[base-ref]'
+---
+
+# Skill: /pre-push-check
+
+A **manual, local, read-only gate** you run yourself before `git push` — not a
+hook, not automatic. It exists because the mandatory checklist enforced by
+`/figma-component`/`/legacy-component` on a component's _first_ build tends to
+get silently skipped on _follow-up_ fixes, since those don't necessarily go
+through the same skill again. This is the single command to re-assert it,
+sized for a small or medium change — not a full build recipe.
+
+Read the workspace contracts first — they override anything here on conflict:
+
+- [packages/ui-react/AGENTS.md](../../../packages/ui-react/AGENTS.md) +
+  [context/conventions.md](../../../packages/ui-react/context/conventions.md)
+- [.claude/skills/component-readiness/SKILL.md](../component-readiness/SKILL.md)
+  (reused directly for the per-component static audit — don't reinvent it)
+
+---
+
+## When this is the right tool — and when it isn't
+
+**Use this** for a design-irrelevant change: a logic fix, an a11y attribute
+tweak, an i18n/RTL fix, a perf change, a type fix, a refactor. None of that
+needs a Figma re-read.
+
+**Use `/figma-component <Name> <url> --update` instead** (or `/legacy-component
+--update`) when the change is design-relevant: a new/changed variant, a prop
+that maps to a Figma property, a visual restyle. That forces the full recipe
+to re-run — re-read the Figma node, re-check token mapping, re-verify
+tests/stories/VR/spec/changeset — which is the only way to catch _design
+drift_ (Figma changed and code didn't, or vice versa). This gate cannot see
+that; it only checks what's already in the code.
+
+Rule of thumb: **if you'd have to open the Figma file to explain the change,
+use `--update`; if you wouldn't, use this gate.**
+
+---
+
+## Invocation
+
+```
+/pre-push-check [base-ref]
+```
+
+`base-ref` defaults to `origin/main` (falling back to local `main`). Pass an
+explicit ref to compare against something else (e.g. a stacked branch).
+
+---
+
+## Steps
+
+1. **Run the script**:
+
+   ```bash
+   bash .claude/skills/pre-push-check/scripts/pre-push-audit.sh
+   ```
+
+   It diffs `base-ref` against `HEAD` **and** the working tree (so uncommitted
+   edits are covered too — this runs before you've even committed, let alone
+   pushed), derives the touched components automatically, and prints:
+   - `CHANGED` — every file that differs from `base-ref`.
+   - `COMPONENT_AUDIT` — `component-readiness`'s `audit.sh` output per touched
+     component: `TOKENS`/`IMPORTS`/`IMPL`/`SPEC`/`TESTS`/`FIGMA` plus the
+     hardcoded-label, physical-directional-utility, and docs-page advisories.
+   - `DYNAMIC` — `vitest` scoped to the touched components, then `typecheck`,
+     `lint`, and (if `packages/ui-spec` changed) `ui-spec test`.
+   - `CHANGESET` — `PRESENT`/`MISSING` for a `packages/ui-react` change.
+
+   If it short-circuits with `RESULT: PUSH-READY — no packages/ui-react or
+packages/ui-spec changes`, stop here — nothing else in this skill applies.
+
+2. **Fix anything the script flags** — a `DRIFT` row (dangling token, missing
+   import, Radix/`asChild`), a failing dynamic check, or a missing changeset —
+   then re-run. Treat `INCOMPLETE` rows and advisory notes (i18n/RTL/docs) as
+   judgment calls, not automatic fails; see `component-readiness`'s SKILL.md
+   for the false-positive shapes for each.
+
+3. **Walk the agent-judgment steps** — a script can't read for you. Do this by
+   hand for each touched component, reusing
+   [`component-readiness`'s "Implementation conformance & spec/docs content
+   accuracy"](../component-readiness/SKILL.md#implementation-conformance--specdocs-content-accuracy-agent-step)
+   section directly rather than re-deriving a checklist here:
+   - **Implementation conformance** — right primitive/composition, `forwardRef`
+     where actually warranted, `cva`/`cn()` usage.
+   - **Spec content accuracy** — does `behavior.md`/`accessibility.md` still
+     describe what the component actually does after this change.
+   - **Docs content accuracy** — if a docs page exists, do its examples still
+     compile against the real prop names.
+
+4. **Decide**: if the script's `RESULT` is `FIX-FIRST`, don't push yet. If it's
+   clear and step 3 raised nothing, you're done — push.
+
+---
+
+## Discipline
+
+- **Read-only.** Never edits files, never stages, never commits, never pushes.
+  Fixes are applied by hand or via `/figma-component`/`/legacy-component`.
+- **Not a substitute for `--update` on a design-relevant change** — see above.
+  Running this gate on a change that actually needed a Figma re-sync will
+  report clean while the design and code silently diverge.
+- **Covers uncommitted changes.** Unlike `review-ui-react` (which needs an
+  open PR) this reads the working tree directly — run it as early as "did I
+  just break something," not only right before `git push`.

--- a/.claude/skills/pre-push-check/scripts/pre-push-audit.sh
+++ b/.claude/skills/pre-push-check/scripts/pre-push-audit.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# Pre-push gate for local ui-react/ui-spec changes.
+#
+# Unlike component-readiness (a per-named-component pre-BUILD gate) or
+# review-ui-react (a PR-scoped review via gh), this runs locally against
+# whatever differs from a base ref — committed commits on the branch AND
+# uncommitted working-tree changes — so it works before a PR exists, on a
+# small fix or a big one. It auto-discovers touched components; you never
+# name them.
+#
+# Usage:
+#   bash .claude/skills/pre-push-check/scripts/pre-push-audit.sh [base-ref]
+#
+# base-ref defaults to origin/main, falling back to main.
+#
+# Sections printed:
+#   CHANGED           files that differ from base-ref (committed + working tree)
+#   COMPONENT_AUDIT   per touched component: component-readiness's audit.sh
+#                     (TOKENS/IMPORTS/IMPL/SPEC/TESTS/FIGMA + i18n/RTL/docs advisories)
+#   DYNAMIC           vitest (scoped to touched components) / typecheck / lint /
+#                     ui-spec test
+#   CHANGESET         presence check for a published-package change
+#
+# What this does NOT check — same gap as component-readiness, and worse here
+# since there's no Figma node in scope at all: implementation conformance,
+# spec/docs content accuracy, and Figma design parity are agent judgment
+# steps, never scriptable. See SKILL.md. If the change is design-relevant
+# (a new/changed variant or prop with a Figma counterpart), this script is
+# the wrong tool — use `/figma-component <Name> <url> --update` instead.
+
+set -uo pipefail
+
+ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT" || exit 1
+
+BASE="${1:-}"
+if [ -z "$BASE" ]; then
+  if git rev-parse --verify --quiet origin/main >/dev/null; then
+    BASE=origin/main
+  elif git rev-parse --verify --quiet main >/dev/null; then
+    BASE=main
+  else
+    echo "ERROR: no base ref found (tried origin/main, main) — pass one explicitly." >&2
+    exit 2
+  fi
+fi
+if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
+  echo "ERROR: base ref '$BASE' does not exist." >&2
+  exit 2
+fi
+
+echo "=== CHANGED (vs $BASE) ==="
+committed="$(git diff --name-only --diff-filter=ACMR "$BASE"...HEAD 2>/dev/null)"
+uncommitted="$(git status --porcelain=v1 --untracked-files=all 2>/dev/null | cut -c4- | sed -E 's/.* -> //')"
+all_changed="$(printf '%s\n%s\n' "$committed" "$uncommitted" | grep -v '^$' | sort -u)"
+
+if [ -z "$all_changed" ]; then
+  echo "(nothing changed vs $BASE)"
+  echo
+  echo "RESULT: PUSH-READY — no changes to check."
+  exit 0
+fi
+printf '%s\n' "$all_changed" | sed 's/^/  /'
+
+ui_react_changed="$(printf '%s\n' "$all_changed" | grep -E '^packages/ui-react/' || true)"
+ui_spec_changed="$(printf '%s\n' "$all_changed" | grep -E '^packages/ui-spec/' || true)"
+
+if [ -z "$ui_react_changed" ] && [ -z "$ui_spec_changed" ]; then
+  echo
+  echo "RESULT: PUSH-READY — no packages/ui-react or packages/ui-spec changes; nothing for this gate to check."
+  exit 0
+fi
+
+# ---- derive touched components (no naming them yourself) ----
+components="$(printf '%s\n%s\n' "$ui_react_changed" "$ui_spec_changed" \
+  | grep -oE '(packages/ui-react/src/components/ui|packages/ui-spec/components)/[^/]+' \
+  | sed -E 's#.*/##' | sort -u)"
+
+echo
+echo "=== COMPONENT_AUDIT ==="
+fail_static=0
+if [ -z "$components" ]; then
+  echo "(no component-scoped files touched)"
+else
+  for c in $components; do
+    [ -d "packages/ui-react/src/components/ui/$c" ] || continue
+    bash .claude/skills/component-readiness/scripts/audit.sh "$c" || fail_static=1
+    echo
+  done
+fi
+
+echo "=== DYNAMIC ==="
+dyn_fail=0
+if [ -n "$components" ]; then
+  test_paths=""
+  for c in $components; do
+    [ -d "packages/ui-react/src/components/ui/$c" ] && test_paths="$test_paths src/components/ui/$c"
+  done
+  if [ -n "$test_paths" ]; then
+    echo "--- vitest (scoped: $test_paths) ---"
+    # shellcheck disable=SC2086
+    pnpm --filter @acronis-platform/ui-react exec vitest run $test_paths || dyn_fail=1
+  fi
+fi
+if [ -n "$ui_react_changed" ]; then
+  echo "--- typecheck ---"
+  pnpm --filter @acronis-platform/ui-react typecheck || dyn_fail=1
+  echo "--- lint ---"
+  pnpm --filter @acronis-platform/ui-react lint || dyn_fail=1
+fi
+if [ -n "$ui_spec_changed" ]; then
+  echo "--- ui-spec test ---"
+  pnpm --filter @acronis-platform/ui-spec test || dyn_fail=1
+fi
+
+echo
+echo "=== CHANGESET ==="
+if [ -n "$ui_react_changed" ]; then
+  if printf '%s\n' "$all_changed" | grep -qE '^\.changeset/.*\.md$'; then
+    echo "CHANGESET: PRESENT"
+  else
+    echo "CHANGESET: MISSING (packages/ui-react is published — run: pnpm changeset)"
+  fi
+else
+  echo "CHANGESET: n/a (no packages/ui-react change)"
+fi
+
+echo
+if [ "$fail_static" -ne 0 ] || [ "$dyn_fail" -ne 0 ]; then
+  echo "RESULT: FIX-FIRST — see DRIFT rows and/or failing dynamic checks above."
+  exit 1
+else
+  echo "RESULT: static + dynamic checks clear. Before pushing, still walk the"
+  echo "        agent-judgment steps in SKILL.md (implementation conformance,"
+  echo "        spec/docs content accuracy) — this script can't read for you."
+  exit 0
+fi

--- a/.claude/skills/review-ui-react/SKILL.md
+++ b/.claude/skills/review-ui-react/SKILL.md
@@ -9,8 +9,10 @@ description: >
   that feed its styling/icons, its other declared dependencies, and
   consumer apps that render it: impact review; everything else: listed
   only), statically verifies --ui-* token resolution and repo conventions
-  (no --av-*, no hardcoded colors, tier imports present, changeset present)
-  against the PR's HEAD commit — not just main — using only local
+  (no --av-*, no hardcoded colors, tier imports present, changeset present,
+  plus advisory greps for hardcoded labels and physical directional
+  utilities that risk breaking RTL) against the PR's HEAD commit — not just
+  main — using only local
   tokens-pd/design-tokens data (no Figma value queries), checks whether a
   source change requires a regeneration command that wasn't run in the same
   PR (design-tokens → tokens-pd, icons-svg → icons-sprite, a component change
@@ -144,6 +146,14 @@ contains and exit — don't run devil-advocate on nothing.
      devil-advocate in step 8.
    - `ICONS_SVG_NEXT_CHANGED` and `VR_BASELINE_HEURISTIC` are advisory only —
      read them, decide whether they're worth a finding, don't auto-escalate.
+   - `HARDCODED_LABELS_ADVISORY` / `RTL_PHYSICAL_UTILITY_ADVISORY` are heuristic
+     greps over added lines in changed component source (see
+     `packages/ui-react/context/conventions.md`), also advisory only. A hit is
+     only a real finding if the string truly has no way for the consumer to
+     override it, or the physical utility truly needs to mirror under
+     `dir="rtl"` — a `side="left"` variant or symmetric centering
+     (`left-1/2 -translate-x-1/2`) is a legitimate false positive; check the
+     surrounding code before reporting it as Important/Critical.
    - For any component under `packages/ui-react/src/components/ui/<X>/` that
      changed, reuse the existing gate instead of re-deriving it — pass
      `refs/pr/<num>` as the optional second argument so it audits the
@@ -318,6 +328,8 @@ generated-artifact-pipeline dependencies, and its direct consumers
 | Hardcoded hex/hsl/oklch on added lines                                            | PASS/FAIL (list)            |
 | Tier `@import` present in styles/index.css                                        | PASS/FAIL (list)            |
 | Changeset present (published package)                                             | PASS/FAIL                   |
+| Hardcoded label introduced (advisory — confirm it's a prop default)               | none / flagged (list)       |
+| Physical directional utility introduced (advisory — RTL risk)                     | none / flagged (list)       |
 | Visual snapshot PNGs changed                                                      | N/A / flagged               |
 | `tokens-pd` regenerated after `design-tokens` change                              | PASS/FAIL/N/A               |
 | `icons-sprite` regenerated after `icons-svg` change                               | PASS/FAIL/N/A               |

--- a/.claude/skills/review-ui-react/scripts/pr-audit.sh
+++ b/.claude/skills/review-ui-react/scripts/pr-audit.sh
@@ -196,6 +196,30 @@ if [ -s "$TIER_A_FILE" ]; then
     echo "SNAPSHOT_PNGS_CHANGED (confirm Docker/Linux origin):"
     printf '%s\n' "$snap" | sed 's/^/  /'
   fi
+
+  # Advisory only (heuristic greps, not semantic analysis) — restricted to a
+  # component's own source (excludes .stories./.test./.figma., where example
+  # text and dir-comparison fixtures are expected). See
+  # packages/ui-react/context/conventions.md for the actual rule.
+  comp_src="$(grep -E '^packages/ui-react/src/components/ui/[^/]+/[^/]+\.tsx$' "$TIER_A_FILE" \
+              | grep -vE '\.(stories|test|figma)\.tsx$')"
+  hc_label=""; rtl_phys=""
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    added_f="$(git diff "origin/main...$PR_REF" -- "$f" 2>/dev/null | grep -E '^\+' | grep -v '^\+\+\+')"
+    h="$(printf '%s\n' "$added_f" | grep -noE '(aria-label|placeholder|title)=["'"'"'][A-Za-z][A-Za-z ]{2,}["'"'"']|>[A-Z][a-zA-Z]+( [a-zA-Z]+){1,4}<')"
+    [ -n "$h" ] && hc_label="$hc_label$f: $(printf '%s' "$h" | tr '\n' ';')"$'\n'
+    r="$(printf '%s\n' "$added_f" | grep -noE '(^|[[:space:]"'"'"'])(ml|mr|pl|pr)-[0-9\[]|(^|[[:space:]"'"'"'])(left|right)-[0-9\[]')"
+    [ -n "$r" ] && rtl_phys="$rtl_phys$f: $(printf '%s' "$r" | tr '\n' ';')"$'\n'
+  done <<< "$comp_src"
+  if [ -z "$hc_label" ]; then echo "HARDCODED_LABELS_ADVISORY: none"; else
+    echo "HARDCODED_LABELS_ADVISORY (confirm it's a prop default, not inlined):"
+    printf '%s' "$hc_label" | sed 's/^/  /'
+  fi
+  if [ -z "$rtl_phys" ]; then echo "RTL_PHYSICAL_UTILITY_ADVISORY: none"; else
+    echo "RTL_PHYSICAL_UTILITY_ADVISORY (confirm dir=\"rtl\" still renders correctly; prefer ms-/me-/ps-/pe-/start-/end-):"
+    printf '%s' "$rtl_phys" | sed 's/^/  /'
+  fi
 else
   echo "n/a (no tier A files)"
 fi

--- a/packages/ui-react/context/conventions.md
+++ b/packages/ui-react/context/conventions.md
@@ -69,6 +69,47 @@ the token is**, not by habit:
 - Lean on Base UI primitives for keyboard nav, focus management, and ARIA.
 - A11y is checked in Storybook via `@storybook/addon-a11y`.
 
+## Localization — no hardcoded labels
+
+There is no i18n library in this repo (no `react-intl`/`i18next`). Consumers
+localize by controlling the text they pass in — `children`, a `label` prop,
+an `aria-label` prop, a render prop. A component is only "hardcoded" when
+**the component itself** bakes in a string the consumer has no way to
+override:
+
+- Every piece of user-facing text the component renders on its own —
+  `aria-label`/`aria-labelledby` fallback text, `sr-only` helper text,
+  placeholder copy, empty-state/error copy, a tooltip string — must come from
+  a prop, with the literal only ever used as that prop's **default value**
+  (`ariaLabel = 'More pages'`), never inlined directly in the JSX output.
+- Consumer-supplied content (`<Button>Submit</Button>`, a `children` render
+  prop, a `label` prop's value) is **not** a violation — the consumer already
+  controls it and can localize at their layer.
+- Static demo/story/Figma-fixture text (`.stories.tsx`, `.figma.tsx`) is
+  exempt — it's example data, not shipped UI.
+- Applies **to every change that touches component source**, not just new
+  components — a one-line fix that introduces a literal string is the same
+  violation as shipping it on day one.
+
+## RTL / bidirectional layout
+
+Every component must render correctly under `dir="rtl"` (Base UI/the app
+shell sets `dir` on an ancestor; components don't set it themselves).
+
+- **Use logical Tailwind utilities** (`ms-`/`me-`, `ps-`/`pe-`, `start-`/
+  `end-`) for anything that should mirror in RTL — never physical ones
+  (`ml-`/`mr-`, `pl-`/`pr-`, `left-`/`right-`). See `switch.tsx`,
+  `breadcrumb.tsx`, `sidebar-secondary.tsx`, `avatar.tsx`, `input-text.tsx`
+  for the existing pattern.
+- **Directional icons/artwork that should flip** (e.g. a "next"/"back"
+  chevron) need an explicit `rtl:`/`ltr:` Tailwind variant (e.g.
+  `rtl:rotate-180`) — logical positioning alone doesn't mirror the artwork
+  itself. Icons that are direction-**agnostic** (e.g. a checkmark, an
+  external-link glyph) must not be flipped.
+- Applies **to every change that touches component source**, not just new
+  components — a follow-up fix that reintroduces a physical `ml-`/`pr-`/
+  `left-` utility is a regression even if the original component was correct.
+
 ## Theming source of truth
 
 `@acronis-platform/design-tokens` (upstream source package; raw Design Tokens


### PR DESCRIPTION
### Type of change

- [ ] Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality like performance)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Refactoring (old API is revised and supported)
- [x] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

This PR improves the Claude Code agents/skills used for developing and
reviewing `packages/ui-react` components, in two parts:

**1. Localization and RTL compliance checks.** Nothing in the repo previously
enforced that ui-react components avoid hardcoded, non-localizable labels or
that they render correctly under `dir="rtl"`. This adds:

- The actual rule in `packages/ui-react/context/conventions.md`: any text a
  component renders on its own (`aria-label` fallback, `sr-only` copy,
  placeholder/empty-state strings) must be a prop with the literal only as
  that prop's default, never inlined; and logical Tailwind utilities
  (`ms-`/`me-`/`ps-`/`pe-`/`start-`/`end-`) must be used instead of physical
  ones (`ml-`/`mr-`/`pl-`/`pr-`/`left-`/`right-`) wherever the layout should
  mirror under RTL.
- Matching checklist items in the `developer-react`, `qa`, and
  `devil-advocate` agent definitions.
- Heuristic static detection in `component-readiness`'s `audit.sh` (which
  already caught a real hardcoded label in `pagination.tsx` and a physical
  spacing utility in `calendar.tsx` during testing) and in
  `review-ui-react`'s `pr-audit.sh`.
- Authoring guidance in the `figma-component` and `legacy-component` skills.

**2. A `component-readiness` extension and a new `/pre-push-check` skill.**
`component-readiness` gained a blocking check for stray Radix/`asChild` usage
in `ui-react` (Base UI only), an advisory check for missing/out-of-sync
`apps/docs` pages, and a documented agent-judgment section for the parts a
script can't verify (implementation conformance, spec/docs content accuracy).

A new `/pre-push-check` skill was added as a manual, local, read-only gate:
it auto-discovers which `ui-react`/`ui-spec` components changed (committed
and uncommitted) versus a base ref, then runs the `component-readiness`
audit plus scoped `vitest`/`typecheck`/`lint`/`ui-spec test` and a changeset
check — one command to run before pushing a small or medium fix, without
needing to re-run the full `figma-component`/`legacy-component` build recipe.

An earlier version of this used a `PostToolUse` hook to auto-inject the
checklist after every component edit; it was removed in favor of this
manual, on-demand skill to avoid slowing down iteration.

## Related issue

- Related # (none — internal tooling improvement)

### 📸 Screenshots (if appropriate)

N/A — no UI change.

### Checklist

- [ ] I have linked an **issue** or **discussion**;
- [x] I have updated the **documentation** accordingly;
- [ ] I have added or updated **tests** to cover my changes;
- [x] I have performed a **self-review** of my code;
- [x] My code follows the style **guidelines** of this project;
- [x] My changes generate no new **warnings**.
