### PR TITLE
chore(tokens-pd): regenerate Tailwind presets for ButtonGroup, Chat, …

### DIFF
--- a/packages/tokens-pd/tailwind/deep_sky_itkontoret/components/ButtonGroup.js
+++ b/packages/tokens-pd/tailwind/deep_sky_itkontoret/components/ButtonGroup.js
@@ -14,7 +14,8 @@ export default {
         "button-group-global-value": "light-dark(rgb(24 25 27), rgb(244 245 245))"
       },
       "borderColor": {
-        "button-group-global-container-border-color": "light-dark(rgb(215 217 219), rgb(61 63 67))"
+        "button-group-global-container-border-color": "light-dark(rgb(215 217 219), rgb(61 63 67))",
+        "button-group-global-separator": "light-dark(rgb(215 217 219), rgb(61 63 67))"
       },
       "fontFamily": {
         "button-group-global-value-text-style": "Inter, system-ui, sans-serif"

--- a/packages/tokens-pd/tailwind/deep_sky_itkontoret/components/Chat.js
+++ b/packages/tokens-pd/tailwind/deep_sky_itkontoret/components/Chat.js
@@ -9,6 +9,7 @@ export default {
         "chat-container": "light-dark(rgb(255 255 255), rgb(31 32 34))"
       },
       "textColor": {
+        "chat-menu-item-hint": "light-dark(rgb(109 114 120), rgb(109 114 120))",
         "chat-menu-item-label": "light-dark(rgb(24 25 27), rgb(244 245 245))"
       },
       "borderColor": {

--- a/packages/tokens-pd/tailwind/deep_sky_itkontoret/components/Dialog.js
+++ b/packages/tokens-pd/tailwind/deep_sky_itkontoret/components/Dialog.js
@@ -6,7 +6,11 @@ export default {
   theme: {
     extend: {
       "backgroundColor": {
-        "dialog-container": "light-dark(rgb(244 245 245), rgb(24 25 27))"
+        "dialog-container": "light-dark(rgb(244 245 245), rgb(24 25 27))",
+        "dialog-header": "light-dark(rgb(255 255 255), rgb(31 32 34))"
+      },
+      "textColor": {
+        "dialog-header-title": "light-dark(rgb(24 25 27), rgb(244 245 245))"
       },
       "borderColor": {
         "dialog-header-border-color": "light-dark(rgb(215 217 219), rgb(61 63 67))"

--- a/packages/tokens-pd/tailwind/default/components/ButtonGroup.js
+++ b/packages/tokens-pd/tailwind/default/components/ButtonGroup.js
@@ -14,7 +14,8 @@ export default {
         "button-group-global-value": "light-dark(rgb(24 25 27), rgb(244 245 245))"
       },
       "borderColor": {
-        "button-group-global-container-border-color": "light-dark(rgb(214 228 245), rgb(48 50 54))"
+        "button-group-global-container-border-color": "light-dark(rgb(214 228 245), rgb(48 50 54))",
+        "button-group-global-separator": "light-dark(rgb(214 228 245), rgb(48 50 54))"
       },
       "fontFamily": {
         "button-group-global-value-text-style": "Inter, system-ui, sans-serif"

--- a/packages/tokens-pd/tailwind/default/components/Chat.js
+++ b/packages/tokens-pd/tailwind/default/components/Chat.js
@@ -9,6 +9,7 @@ export default {
         "chat-container": "light-dark(rgb(255 255 255), rgb(31 32 34))"
       },
       "textColor": {
+        "chat-menu-item-hint": "light-dark(rgb(109 114 120), rgb(109 114 120))",
         "chat-menu-item-label": "light-dark(rgb(24 25 27), rgb(244 245 245))"
       },
       "borderColor": {

--- a/packages/tokens-pd/tailwind/default/components/Dialog.js
+++ b/packages/tokens-pd/tailwind/default/components/Dialog.js
@@ -6,7 +6,11 @@ export default {
   theme: {
     extend: {
       "backgroundColor": {
-        "dialog-container": "light-dark(rgb(248 250 252), rgb(24 25 27))"
+        "dialog-container": "light-dark(rgb(248 250 252), rgb(24 25 27))",
+        "dialog-header": "light-dark(rgb(255 255 255), rgb(31 32 34))"
+      },
+      "textColor": {
+        "dialog-header-title": "light-dark(rgb(24 25 27), rgb(244 245 245))"
       },
       "borderColor": {
         "dialog-header-border-color": "light-dark(rgb(214 228 245), rgb(48 50 54))"

--- a/packages/tokens-pd/tailwind/virtuozzo/components/ButtonGroup.js
+++ b/packages/tokens-pd/tailwind/virtuozzo/components/ButtonGroup.js
@@ -14,7 +14,8 @@ export default {
         "button-group-global-value": "light-dark(rgb(24 25 27), rgb(244 245 245))"
       },
       "borderColor": {
-        "button-group-global-container-border-color": "light-dark(rgb(215 217 219), rgb(61 63 67))"
+        "button-group-global-container-border-color": "light-dark(rgb(215 217 219), rgb(61 63 67))",
+        "button-group-global-separator": "light-dark(rgb(215 217 219), rgb(61 63 67))"
       },
       "fontFamily": {
         "button-group-global-value-text-style": "Inter, system-ui, sans-serif"

--- a/packages/tokens-pd/tailwind/virtuozzo/components/Chat.js
+++ b/packages/tokens-pd/tailwind/virtuozzo/components/Chat.js
@@ -9,6 +9,7 @@ export default {
         "chat-container": "light-dark(rgb(255 255 255), rgb(31 32 34))"
       },
       "textColor": {
+        "chat-menu-item-hint": "light-dark(rgb(109 114 120), rgb(109 114 120))",
         "chat-menu-item-label": "light-dark(rgb(24 25 27), rgb(244 245 245))"
       },
       "borderColor": {

--- a/packages/tokens-pd/tailwind/virtuozzo/components/Dialog.js
+++ b/packages/tokens-pd/tailwind/virtuozzo/components/Dialog.js
@@ -6,7 +6,11 @@ export default {
   theme: {
     extend: {
       "backgroundColor": {
-        "dialog-container": "light-dark(rgb(244 245 245), rgb(24 25 27))"
+        "dialog-container": "light-dark(rgb(244 245 245), rgb(24 25 27))",
+        "dialog-header": "light-dark(rgb(255 255 255), rgb(31 32 34))"
+      },
+      "textColor": {
+        "dialog-header-title": "light-dark(rgb(24 25 27), rgb(244 245 245))"
       },
       "borderColor": {
         "dialog-header-border-color": "light-dark(rgb(215 217 219), rgb(61 63 67))"


### PR DESCRIPTION
<!---️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### Type of change

- [ ] Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality like performance)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Refactoring (old API is revised and supported)
- [x] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

`main`'s CI (Test - CI) is currently failing on the "Verify generated tokens-pd is committed" step. `#579` regenerated `packages/tokens-pd` after `#577` added new component design tokens, but that regeneration only picked up the CSS output — the Tailwind preset `.js` files for `ButtonGroup`, `Chat`, and `Dialog` were left stale across all three brands (`default`, `deep_sky_itkontoret`, `virtuozzo`):

- `ButtonGroup`: missing `button-group-global-separator` (borderColor)
- `Chat`: missing `chat-menu-item-hint` (textColor)
- `Dialog`: missing `dialog-header` (backgroundColor) and `dialog-header-title` (textColor)

This PR re-runs the `tokens-pd` build (`pnpm --filter @acronis-platform/style-dictionary build pd-css pd-tailwind`) so the Tailwind presets match the already-correct CSS output and the design-tokens source, closing the drift CI was catching.

Verified locally: `git diff --exit-code -- packages/tokens-pd` is now clean, and `pnpm -r build`, `pnpm -r typecheck`, `pnpm -r test`, and the ui-react visual regression suite (Docker) all pass.

## Related issue

- Fixes # (issue)
- Closes # (issue)
- Related # (issue)

### 📸 Screenshots (if appropriate)

N/A — generated Tailwind preset data only, no visual/behavioral change (values already matched the shipped CSS).

### Checklist

- [ ] I have linked an **issue** or **discussion**;
- [x] I have updated the **documentation** accordingly;
- [ ] I have added or updated **tests** to cover my changes;
- [x] I have performed a **self-review** of my code;
- [x] My code follows the style **guidelines** of this project;
- [x] My changes generate no new **warnings**.
