### PR TITLE
ci(release): trigger release workflow manually instead of on every pu…

### DIFF
--- a/.changeset/input-select-figma-connect-search-fix.md
+++ b/.changeset/input-select-figma-connect-search-fix.md
@@ -1,0 +1,5 @@
+---
+'@acronis-platform/ui-react': patch
+---
+
+Fix `InputSelect`'s Figma Code Connect mapping rendering the search field's placeholder example even when the design's `hasSearch` boolean is `false`. `hasSearch` (and the data variant's `hasRecent`) now resolve directly to the example element via `figma.boolean`'s true/false map instead of a truthy render gate on the raw boolean.

--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -5,14 +5,17 @@
 # per deployment, so each deploy replaces the whole site. A separate per-app
 # deploy workflow would clobber the others.
 #
-# Trigger: GitHub Release published. \`release.yml\` is configured with
-# \`createGithubReleases: true\`, so a successful Changesets publish
-# emits the release event we listen to here — meaning the Pages site
-# only updates when a real version of the UI library ships, not on
-# every push to main.
+# Trigger: every push to main, plus GitHub Release published (kept so a
+# release always re-deploys even if a prior push-triggered deploy failed)
+# and manual workflow_dispatch. Push-triggered runs are best-effort: build
+# and deploy failures are logged but do not fail the job, so a broken Pages
+# deploy never blocks or shows as a failing check on the commit.
 name: Demo & Storybook - Deploy to Pages
 
 on:
+  push:
+    branches: [main]
+
   release:
     types: [published]
 
@@ -25,16 +28,18 @@ permissions:
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# One deployment at a time. Push-triggered runs cancel a stale in-progress
+# push build (only the latest commit's site matters); release/manual runs
+# should still be allowed to finish, so cancellation only applies to pushes.
 concurrency:
   group: pages
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ github.event_name == 'push' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -105,15 +110,28 @@ jobs:
         with:
           path: apps/demo/dist
 
+      - name: Log build failure
+        if: failure() && github.event_name == 'push'
+        run: 'echo "### :warning: Pages build failed for this push — see the failed step above. Deploy was skipped; the site was not updated." >> "$GITHUB_STEP_SUMMARY"'
+
   # Deployment job
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    # NOTE: needs.build.result reports 'success' even when a step failed,
+    # because build's own continue-on-error masks the failure from this
+    # gate — so on push this job always attempts to run. If the artifact
+    # upload didn't happen, deploy-pages fails fast and is logged below.
     needs: build
+    continue-on-error: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     name: Deploy
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      - name: Log deploy failure
+        if: failure() && github.event_name == 'push'
+        run: 'echo "### :warning: Pages deploy failed for this push — see the failed step above." >> "$GITHUB_STEP_SUMMARY"'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # Release flow driven by changesets.
 #
-# On every push to main, this workflow does ONE of:
+# Triggered manually (workflow_dispatch). Run it to do ONE of:
 #   1. If unpublished changesets exist (.changeset/*.md), it opens
 #      (or updates) a "Version Packages" PR that bumps versions in
 #      package.json files and rewrites CHANGELOG.md.
@@ -24,8 +24,7 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/packages/ui-react/src/components/ui/input-select/input-select.figma.tsx
+++ b/packages/ui-react/src/components/ui/input-select/input-select.figma.tsx
@@ -69,12 +69,15 @@ figma.connect(
   {
     variant: { variant: 'data' },
     props: {
-      hasSearch: figma.boolean('hasSearch'),
+      hasSearch: figma.boolean('hasSearch', {
+        true: <InputSelectSearch placeholder="Search…" />,
+        false: undefined,
+      }),
       sectionList: figma.children('sectionList'),
     },
     example: ({ hasSearch, sectionList }) => (
       <InputSelectContent>
-        {hasSearch && <InputSelectSearch placeholder="Search…" />}
+        {hasSearch}
         <InputSelectSection>{sectionList}</InputSelectSection>
       </InputSelectContent>
     ),
@@ -87,11 +90,14 @@ figma.connect(
   {
     variant: { variant: 'loading' },
     props: {
-      hasSearch: figma.boolean('hasSearch'),
+      hasSearch: figma.boolean('hasSearch', {
+        true: <InputSelectSearch placeholder="Search…" />,
+        false: undefined,
+      }),
     },
     example: ({ hasSearch }) => (
       <InputSelectContent>
-        {hasSearch && <InputSelectSearch placeholder="Search…" />}
+        {hasSearch}
         <InputSelectStatus variant="loading">Data is loading…</InputSelectStatus>
       </InputSelectContent>
     ),
@@ -104,11 +110,14 @@ figma.connect(
   {
     variant: { variant: 'empty' },
     props: {
-      hasSearch: figma.boolean('hasSearch'),
+      hasSearch: figma.boolean('hasSearch', {
+        true: <InputSelectSearch placeholder="Search…" />,
+        false: undefined,
+      }),
     },
     example: ({ hasSearch }) => (
       <InputSelectContent>
-        {hasSearch && <InputSelectSearch placeholder="Search…" />}
+        {hasSearch}
         <InputSelectStatus variant="empty">No data found</InputSelectStatus>
       </InputSelectContent>
     ),
@@ -121,11 +130,14 @@ figma.connect(
   {
     variant: { variant: 'error' },
     props: {
-      hasSearch: figma.boolean('hasSearch'),
+      hasSearch: figma.boolean('hasSearch', {
+        true: <InputSelectSearch placeholder="Search…" />,
+        false: undefined,
+      }),
     },
     example: ({ hasSearch }) => (
       <InputSelectContent>
-        {hasSearch && <InputSelectSearch placeholder="Search…" />}
+        {hasSearch}
         <InputSelectStatus variant="error" action={<a href="#">Try again</a>}>
           Something went wrong
         </InputSelectStatus>
@@ -142,19 +154,21 @@ figma.connect(
   {
     variant: { variant: 'data' },
     props: {
-      hasRecent: figma.boolean('hasRecent'),
-      listRecent: figma.children('listRecent'),
-      listBrowse: figma.children('listBrowse'),
-    },
-    example: ({ hasRecent, listRecent, listBrowse }) => (
-      <InputSelectContent>
-        <InputSelectSearch placeholder="Search…" />
-        {hasRecent && (
+      hasRecent: figma.boolean('hasRecent', {
+        true: (
           <InputSelectSection>
             <InputSelectSectionLabel>Recent</InputSelectSectionLabel>
-            {listRecent}
+            {figma.children('listRecent')}
           </InputSelectSection>
-        )}
+        ),
+        false: undefined,
+      }),
+      listBrowse: figma.children('listBrowse'),
+    },
+    example: ({ hasRecent, listBrowse }) => (
+      <InputSelectContent>
+        <InputSelectSearch placeholder="Search…" />
+        {hasRecent}
         <InputSelectSection>
           <InputSelectSectionLabel>Browse</InputSelectSectionLabel>
           {listBrowse}


### PR DESCRIPTION
ci(release): decouple Pages deploy from the release workflow trigger

The "Create release PR" step (changesets/action) was failing on every push to main with a 401 from the GitHub API, because xxxxx is stale/invalid. Since releases are already run manually via "xxxxxx", switch the trigger to workflow_dispatch so it stops running (and failing) on every merge.

<!---️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality like performance)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Refactoring (old API is revised and supported)
- [x] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

This PR bundles three related pipeline fixes:
