### PR TITLE
fix(ui-react): MenuButton hover cursor + cascade chevron centering

### DIFF
--- a/.changeset/button-menu-cursor-pointer.md
+++ b/.changeset/button-menu-cursor-pointer.md
@@ -1,0 +1,5 @@
+---
+'@acronis-platform/ui-react': patch
+---
+
+Fix `ButtonMenu` missing a pointer cursor on hover. `cursor-pointer` now lives on the shared base class (matching `Button`), so the trigger shows `cursor: pointer` when hovered and reverts to the default cursor while disabled via `disabled:pointer-events-none`.

--- a/.changeset/dropdown-menu-cascade-chevron-center.md
+++ b/.changeset/dropdown-menu-cascade-chevron-center.md
@@ -1,0 +1,5 @@
+---
+'@acronis-platform/ui-react': patch
+---
+
+Fix the cascade (submenu) chevron in `DropdownMenuSubTrigger` sitting too high. The menu item row is `items-start`, so the 16px chevron pinned to the top of the label's 24px line box; it now uses `self-center` to align vertically against the label.

--- a/packages/ui-react/src/components/ui/button-menu/__tests__/button-menu.test.tsx
+++ b/packages/ui-react/src/components/ui/button-menu/__tests__/button-menu.test.tsx
@@ -22,6 +22,13 @@ describe('ButtonMenu', () => {
     );
   });
 
+  it('shows a pointer cursor on hover', () => {
+    render(<ButtonMenu>Actions</ButtonMenu>);
+    expect(screen.getByRole('button', { name: 'Actions' })).toHaveClass(
+      'cursor-pointer'
+    );
+  });
+
   it('applies the secondary variant token classes', () => {
     render(<ButtonMenu variant="secondary">Actions</ButtonMenu>);
     expect(screen.getByRole('button', { name: 'Actions' })).toHaveClass(

--- a/packages/ui-react/src/components/ui/button-menu/button-menu.tsx
+++ b/packages/ui-react/src/components/ui/button-menu/button-menu.tsx
@@ -26,7 +26,7 @@ import { cn } from '@/lib/utils';
 // Figma focus state is a 3px `--ui-focus-primary` ring flush to the button edge
 // (no offset) — `ring-[3px]`, no `ring-offset`.
 const buttonMenuVariants = cva(
-  'inline-flex h-[var(--ui-button-menu-global-container-height)] min-w-[var(--ui-button-menu-global-container-width-min)] items-center justify-center gap-[var(--ui-button-menu-global-container-gap)] whitespace-nowrap rounded-[var(--ui-button-menu-global-container-border-radius)] border border-transparent px-[var(--ui-button-menu-global-container-padding-x)] text-sm font-semibold leading-6 transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[var(--ui-focus-primary)] disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:size-[var(--ui-button-menu-global-icon-size)] [&_svg]:shrink-0',
+  'inline-flex h-[var(--ui-button-menu-global-container-height)] min-w-[var(--ui-button-menu-global-container-width-min)] cursor-pointer items-center justify-center gap-[var(--ui-button-menu-global-container-gap)] whitespace-nowrap rounded-[var(--ui-button-menu-global-container-border-radius)] border border-transparent px-[var(--ui-button-menu-global-container-padding-x)] text-sm font-semibold leading-6 transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[var(--ui-focus-primary)] disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:size-[var(--ui-button-menu-global-icon-size)] [&_svg]:shrink-0',
   {
     variants: {
       variant: {

--- a/packages/ui-react/src/components/ui/dropdown-menu/__tests__/dropdown-menu.test.tsx
+++ b/packages/ui-react/src/components/ui/dropdown-menu/__tests__/dropdown-menu.test.tsx
@@ -9,6 +9,9 @@ import {
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '../dropdown-menu';
 
@@ -101,6 +104,28 @@ describe('DropdownMenu', () => {
     expect(groups[0]).toHaveClass(
       'py-[var(--ui-button-menu-dropdown-section-container-padding-y)]'
     );
+  });
+
+  it('centers the sub-trigger cascade chevron against the label', () => {
+    render(
+      <DropdownMenu defaultOpen>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuGroup>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>Share</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                <DropdownMenuItem>Copy link</DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+    const chevron = screen
+      .getByRole('menuitem', { name: /Share/ })
+      .querySelector('svg');
+    expect(chevron).toHaveClass('self-center', 'ms-auto');
   });
 
   it('forwards the ref to the popup', () => {

--- a/packages/ui-react/src/components/ui/dropdown-menu/dropdown-menu.tsx
+++ b/packages/ui-react/src/components/ui/dropdown-menu/dropdown-menu.tsx
@@ -138,7 +138,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
     {...props}
   >
     {children}
-    <ChevronRightIcon className="ms-auto text-[var(--ui-button-menu-dropdown-extras-cascade-icon-color)] rtl:rotate-180" />
+    <ChevronRightIcon className="ms-auto self-center text-[var(--ui-button-menu-dropdown-extras-cascade-icon-color)] rtl:rotate-180" />
   </MenuPrimitive.SubmenuTrigger>
 ));
 DropdownMenuSubTrigger.displayName = 'DropdownMenuSubTrigger';


### PR DESCRIPTION
## What

Two small `ui-react` fixes:

1. **`ButtonMenu` — pointer cursor on hover** (PLTFRM-92686). The trigger was showing `cursor: default` on hover. Added `cursor-pointer` to the shared base class (matching `Button`); `disabled:pointer-events-none` already keeps the disabled cursor default.
2. **`DropdownMenu` — cascade submenu chevron centering.** The menu item row is `items-start`, so the 16px cascade `>` chevron in `DropdownMenuSubTrigger` pinned to the top of the label's 24px line box and read as off-center. Added `self-center` to align it vertically against the label.

## Testing

- Added unit tests for both (`cursor-pointer` on `ButtonMenu`; `self-center`/`ms-auto` on the sub-trigger chevron).
- `vitest`, `typecheck`, `lint` pass locally.
- Changeset added for each fix (patch).

## Visual regression

The chevron change shifts pixels in the `WithSubmenu` (and `all-states`) stories — local Docker baseline regen didn't pick it up cleanly, so relying on the CI visual-regression job to regenerate/validate against the canonical Linux renderer. The `ButtonMenu` cursor change is not captured in screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)