### PR TITLE
fix(review-ui-react): make PR audit stateless and fork-safe

### DIFF
--- a/.claude/skills/component-readiness/scripts/audit.sh
+++ b/.claude/skills/component-readiness/scripts/audit.sh
@@ -58,13 +58,20 @@ SCRIPT_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel
 REF="${2:-}"
 WORKTREE=""
 if [ -n "$REF" ]; then
+  # Defensive: a prior run killed mid-audit (not a normal exit) skips the EXIT
+  # trap below and leaves its worktree registered under .git/worktrees even
+  # after its tmpdir is gone. Prune that stale metadata BEFORE adding a new
+  # one so it can never be mistaken for live state or block this run.
+  git -C "$SCRIPT_ROOT" worktree prune --expire=now >/dev/null 2>&1 || true
   WORKTREE="$(mktemp -d)"
   if ! git -C "$SCRIPT_ROOT" worktree add --detach --quiet "$WORKTREE" "$REF" >/dev/null 2>&1; then
     echo "ERROR: could not create a worktree for ref '$REF'" >&2
     rm -rf "$WORKTREE"
     exit 1
   fi
-  trap 'git -C "$SCRIPT_ROOT" worktree remove --force "$WORKTREE" >/dev/null 2>&1; rm -rf "$WORKTREE" 2>/dev/null' EXIT
+  # EXIT covers normal/early exits; INT/TERM covers a killed run so a fresh
+  # worktree from THIS run doesn't itself become tomorrow's orphan.
+  trap 'git -C "$SCRIPT_ROOT" worktree remove --force "$WORKTREE" >/dev/null 2>&1; rm -rf "$WORKTREE" 2>/dev/null' EXIT INT TERM
   ROOT="$WORKTREE"
 else
   ROOT="$SCRIPT_ROOT"

--- a/.claude/skills/component-readiness/scripts/audit.sh
+++ b/.claude/skills/component-readiness/scripts/audit.sh
@@ -69,9 +69,11 @@ if [ -n "$REF" ]; then
     rm -rf "$WORKTREE"
     exit 1
   fi
-  # EXIT covers normal/early exits; INT/TERM covers a killed run so a fresh
-  # worktree from THIS run doesn't itself become tomorrow's orphan.
-  trap 'git -C "$SCRIPT_ROOT" worktree remove --force "$WORKTREE" >/dev/null 2>&1; rm -rf "$WORKTREE" 2>/dev/null' EXIT INT TERM
+  # EXIT already covers SIGINT/SIGTERM (bash runs the EXIT trap for those too)
+  # as well as normal/early returns. A non-terminating INT/TERM handler would
+  # instead let the script resume after the worktree it just removed, auditing
+  # a deleted directory — so EXIT alone, without INT/TERM, is correct here.
+  trap 'git -C "$SCRIPT_ROOT" worktree remove --force "$WORKTREE" >/dev/null 2>&1; rm -rf "$WORKTREE" 2>/dev/null' EXIT
   ROOT="$WORKTREE"
 else
   ROOT="$SCRIPT_ROOT"

--- a/.claude/skills/review-ui-react/SKILL.md
+++ b/.claude/skills/review-ui-react/SKILL.md
@@ -98,6 +98,12 @@ ran before. Two layers enforce that:
 - **On disk / in git**: the script resets its own state before AND after
   every run (see step 2 and step 12) — no local ref, worktree, or temp file
   it creates is allowed to outlive or influence a later invocation.
+  `pr-audit.sh` also refuses to run at all if another invocation for the
+  same PR number is already in flight (`LOCK: FAIL`, see step 2) rather than
+  race it on the shared `refs/pr/<num>` ref. That lock only spans the
+  script's own runtime, though — don't start a second review of the same PR
+  number while an earlier one is still mid-flow (steps 3–12 not yet done),
+  since those steps read and finally delete that ref outside the script.
 - **In the conversation**: if this skill is invoked again for a PR number
   already discussed earlier in this session, treat it as a cold start
   anyway. Re-run `pr-audit.sh`, re-run `gh pr diff`, re-read `git show`
@@ -140,6 +146,10 @@ ran before. Two layers enforce that:
      resolved) and that they need to run this from a checkout where `origin`
      is the base repo — do not attempt to fetch from the other remote
      yourself as a workaround.
+   - If it prints `LOCK: FAIL`, another review of the same PR number is
+     already running (a concurrent invocation, not this run). Wait for it to
+     finish and re-run — do not delete the lock directory or retry
+     immediately; that's exactly the race this check exists to prevent.
    - If it prints `origin/main: FETCH FAILED`, this is a **hard abort** —
      every downstream check in this run diffs against `origin/main`, so a
      stale fetch there makes the whole run's output untrustworthy, not just
@@ -448,7 +458,15 @@ view`'s `headRefOid` and aborts on any mismatch, so a stale fetch can never
   as current — i.e. a fork checkout (`origin` = your fork, some other remote
   = the base repo). Every fetch in this skill targets `origin` by name; in a
   fork checkout that silently targets the wrong repository. There is no
-  workaround mode — point `origin` at the base repo and re-run.
+  workaround mode — point `origin` at the base repo and re-run. `origin`'s
+  owner/repo is parsed straight out of `git remote get-url origin` (not
+  resolved via a `gh` network call), so an SSH config host alias for
+  `github.com` doesn't trip a false `FORK_CHECK: FAIL`.
+- **One review of a given PR number at a time.** `pr-audit.sh` takes an
+  exclusive lock (`LOCK: FAIL` if held) before touching `refs/pr/<num>`,
+  since a second concurrent run would race the first on that shared ref's
+  delete/fetch. Don't start a second invocation for the same PR number until
+  the first has finished through step 12.
 - **No lingering local git state, once the whole review is done.**
   `pr-audit.sh` defensively deletes a leftover `refs/pr/<num>` from a prior
   run on entry (after AUTH/FORK_CHECK pass), but leaves the ref it fetches in

--- a/.claude/skills/review-ui-react/SKILL.md
+++ b/.claude/skills/review-ui-react/SKILL.md
@@ -140,6 +140,12 @@ ran before. Two layers enforce that:
      resolved) and that they need to run this from a checkout where `origin`
      is the base repo — do not attempt to fetch from the other remote
      yourself as a workaround.
+   - If it prints `origin/main: FETCH FAILED`, this is a **hard abort** —
+     every downstream check in this run diffs against `origin/main`, so a
+     stale fetch there makes the whole run's output untrustworthy, not just
+     one section. Report the git error the script printed to the developer
+     instead of retrying blind or falling back to whatever `origin/main` was
+     fetched last time.
    - If it fails to fetch `refs/pr/<num>`, or `FETCH_VERIFY` reports a
      mismatch, this is a **hard abort** — do not retry silently. Read the git
      error the script printed: only if it names a shallow clone should you
@@ -328,15 +334,16 @@ ran before. Two layers enforce that:
     one piece of this skill's output that's meant to persist — but each write
     replaces the last, it never accumulates.
 
-12. **Local git state cleanup is automatic — not a step you perform.** The
-    script deletes `refs/pr/<num>` itself, both defensively on entry (in case
-    a prior run was killed before cleaning up) and unconditionally on exit via
-    a trap (success, early abort, or `SHORT_CIRCUIT`) — see `pr-audit.sh`.
-    Do not add a manual `git update-ref -d` step here: the point of doing it
-    inside the script is that it happens whether or not the calling agent
-    remembers to, which is what makes a run stateless. The forced fetch
-    (`+pull/<num>/head:refs/pr/<num>`) is what keeps a single run correct;
-    the trap-based delete is what guarantees no ref survives _between_ runs.
+12. **Delete `refs/pr/<num>` now that nothing else needs it.** Steps 4 and 5
+    read this ref after `pr-audit.sh` has already returned, so the script
+    itself cannot safely delete it on exit — it defensively wipes a leftover
+    ref from a prior run on entry (see `pr-audit.sh`), but leaves the ref it
+    just fetched in place when it exits. Once the report is written (step 11)
+    and nothing in this skill needs the ref anymore, run
+    `git update-ref -d refs/pr/<num>` yourself as this step. The forced fetch
+    (`+pull/<num>/head:refs/pr/<num>`) is what keeps a single run correct even
+    if this delete is ever skipped; this step is what keeps no ref surviving
+    _between_ runs.
 
 13. **Print a short terminal summary** (verdict, top findings, report path)
     so the developer doesn't have to open the file for the headline.
@@ -427,27 +434,34 @@ that this PR doesn't touch `packages/ui-react` or anything that affects it.
   (`git fetch origin +pull/<num>/head:refs/pr/<num>`) so the ref always
   reflects the PR's real current head even after a rebase/amend/force-push —
   this works for fork PRs too, since GitHub mirrors them into the base
-  repo's `refs/pull/*` namespace. `main` freshness comes from
-  `git fetch origin main` only; the developer's checked-out branch (even if
-  it happens to be `main`) is never fast-forwarded or switched. A hard
-  `FETCH_VERIFY` check in the script cross-checks the fetched local SHA
-  against `gh pr view`'s `headRefOid` and aborts on any mismatch, so a stale
-  fetch can never silently drive the rest of the review.
+  repo's `refs/pull/*` namespace. `main` freshness comes from a forced
+  `git fetch origin +main:refs/remotes/origin/main`, which hard-aborts the
+  whole script on failure (every downstream check diffs against
+  `origin/main`, so a stale fetch there would make every result wrong, not
+  just one section); the developer's checked-out branch (even if it happens
+  to be `main`) is never fast-forwarded or switched. A hard `FETCH_VERIFY`
+  check in the script cross-checks the fetched local SHA against `gh pr
+view`'s `headRefOid` and aborts on any mismatch, so a stale fetch can never
+  silently drive the rest of the review.
 - **Base-repo checkouts only.** `pr-audit.sh` hard-aborts (`FORK_CHECK: FAIL`)
   before fetching anything if `origin` doesn't match the repo `gh` resolves
   as current — i.e. a fork checkout (`origin` = your fork, some other remote
   = the base repo). Every fetch in this skill targets `origin` by name; in a
   fork checkout that silently targets the wrong repository. There is no
   workaround mode — point `origin` at the base repo and re-run.
-- **No lingering local git state.** `pr-audit.sh` deletes `refs/pr/<num>`
-  defensively on entry and unconditionally on every exit path via a trap —
-  not as a step the calling agent has to remember. A killed/interrupted run
-  can't poison the next one, and a normal run never leaves the ref behind
-  either. `component-readiness/audit.sh`'s worktree (used in step 5) is the
-  same story: pruned defensively before creation, removed via an
-  `EXIT INT TERM` trap after. See "Statelessness contract" above — the
-  report file (always overwritten, never suffixed) is the only thing that
-  persists after a run.
+- **No lingering local git state, once the whole review is done.**
+  `pr-audit.sh` defensively deletes a leftover `refs/pr/<num>` from a prior
+  run on entry (after AUTH/FORK_CHECK pass), but leaves the ref it fetches in
+  place on exit — steps 4 and 5 still need it after the script returns. Step
+  12 of this skill deletes it explicitly once the report is written, so a
+  killed/interrupted run can't poison the next one and a completed run never
+  leaves the ref behind either. `component-readiness/audit.sh`'s worktree
+  (used in step 5) is the same story: pruned defensively before creation,
+  removed via an `EXIT` trap after (that trap intentionally does not add
+  `INT`/`TERM` — `EXIT` already fires for those signals, and a non-terminating
+  handler for them would let the script resume against a worktree it just
+  deleted). The report file (always overwritten, never suffixed) is the only
+  thing that persists after a run.
 - **Local-only token/style truth.** All `--ui-*` resolution and
   generated-artifact freshness checks read `packages/tokens-pd`,
   `packages/design-tokens`, `packages/icons-svg(-next)`, and

--- a/.claude/skills/review-ui-react/SKILL.md
+++ b/.claude/skills/review-ui-react/SKILL.md
@@ -89,6 +89,26 @@ contains and exit — don't run devil-advocate on nothing.
 
 ---
 
+## Statelessness contract
+
+This skill must behave identically on the first review of a PR and the
+tenth re-review of the same PR after it changed — it must never be aware it
+ran before. Two layers enforce that:
+
+- **On disk / in git**: the script resets its own state before AND after
+  every run (see step 2 and step 12) — no local ref, worktree, or temp file
+  it creates is allowed to outlive or influence a later invocation.
+- **In the conversation**: if this skill is invoked again for a PR number
+  already discussed earlier in this session, treat it as a cold start
+  anyway. Re-run `pr-audit.sh`, re-run `gh pr diff`, re-read `git show`
+  content — do not answer from an earlier turn's tool output, findings, or
+  report content still sitting in context. The PR may have gained commits,
+  lost commits, or been rebased since that earlier turn; the only source of
+  truth is what this run's fetch actually returns. If a finding from a
+  previous run of this skill on the same PR still applies, it will show up
+  again on its own because the underlying code is still there — it should
+  never be asserted from memory of the earlier run.
+
 ## Steps
 
 1. **Parse the argument** — a bare PR number, a full GitHub URL, or a number
@@ -107,6 +127,19 @@ contains and exit — don't run devil-advocate on nothing.
    anything else — most of the mechanical work is already done for you.
    - If it prints `AUTH: FAIL`, stop and tell the developer to run
      `gh auth login`, then retry.
+   - If it prints `FORK_CHECK: FAIL`, **stop — this is a hard, by-design
+     block, not a bug to work around.** It means the checkout's `origin`
+     remote doesn't match the repo `gh` resolves as the PR's home (a fork
+     checkout: `origin` = the developer's fork, some other remote = the base
+     repo). This skill only runs when `origin` IS the base repo, because
+     every fetch is hardcoded against `origin` — in a fork checkout that
+     would fetch PR refs from the wrong repository, at best failing outright
+     and at worst (if the fork happens to have its own same-numbered PR)
+     silently reviewing unrelated commits. Tell the developer exactly what
+     the script reported (which repo `origin` points at vs. which repo `gh`
+     resolved) and that they need to run this from a checkout where `origin`
+     is the base repo — do not attempt to fetch from the other remote
+     yourself as a workaround.
    - If it fails to fetch `refs/pr/<num>`, or `FETCH_VERIFY` reports a
      mismatch, this is a **hard abort** — do not retry silently. Read the git
      error the script printed: only if it names a shallow clone should you
@@ -287,26 +320,23 @@ contains and exit — don't run devil-advocate on nothing.
     Important → Nit.
 
 11. **Write the report** to the repo root as `uikit-pr-<number>-review.md`
-    (see structure below). If it already exists, ask: overwrite, or write a
-    `-<timestamp>` suffixed copy — never silently clobber.
+    (see structure below), **always overwriting** any existing file with that
+    name unconditionally — no ask, no `-<timestamp>` suffixed copy. A prior
+    run's report for the same PR number is stale by definition once the PR
+    has moved; keeping it around (under this name or a suffixed one) only
+    risks the developer reading old findings by mistake. The report is the
+    one piece of this skill's output that's meant to persist — but each write
+    replaces the last, it never accumulates.
 
-12. **Clean up local state** — now that the report file is fully written,
-    remove the local ref this run created so a fresh invocation always
-    starts clean and repeated reviews of the same PR don't accumulate
-    `refs/pr/*` clutter:
-
-    ```bash
-    git update-ref -d refs/pr/<num>
-    ```
-
-    This deletes only that one local ref (a no-op if it's already gone) and
-    must run **only after** step 11 has finished writing the report. It must
-    never touch the report file, the developer's working tree, or their
-    checked-out branch. This is a hygiene safety net, not the fix for stale
-    reviews — the forced fetch in the script (`+pull/<num>/head:refs/pr/<num>`)
-    is what actually keeps a single run correct; this step just guarantees a
-    leftover ref from an interrupted or earlier run can't confuse the next
-    one.
+12. **Local git state cleanup is automatic — not a step you perform.** The
+    script deletes `refs/pr/<num>` itself, both defensively on entry (in case
+    a prior run was killed before cleaning up) and unconditionally on exit via
+    a trap (success, early abort, or `SHORT_CIRCUIT`) — see `pr-audit.sh`.
+    Do not add a manual `git update-ref -d` step here: the point of doing it
+    inside the script is that it happens whether or not the calling agent
+    remembers to, which is what makes a run stateless. The forced fetch
+    (`+pull/<num>/head:refs/pr/<num>`) is what keeps a single run correct;
+    the trap-based delete is what guarantees no ref survives _between_ runs.
 
 13. **Print a short terminal summary** (verdict, top findings, report path)
     so the developer doesn't have to open the file for the headline.
@@ -403,10 +433,20 @@ that this PR doesn't touch `packages/ui-react` or anything that affects it.
   `FETCH_VERIFY` check in the script cross-checks the fetched local SHA
   against `gh pr view`'s `headRefOid` and aborts on any mismatch, so a stale
   fetch can never silently drive the rest of the review.
-- **No lingering local git state.** The one local ref this skill creates
-  (`refs/pr/<num>`) is deleted once the report is fully written (step 12) —
-  a fresh invocation, or a re-review of the same PR after it changes, never
-  starts from a leftover ref. The report file is the only thing that
+- **Base-repo checkouts only.** `pr-audit.sh` hard-aborts (`FORK_CHECK: FAIL`)
+  before fetching anything if `origin` doesn't match the repo `gh` resolves
+  as current — i.e. a fork checkout (`origin` = your fork, some other remote
+  = the base repo). Every fetch in this skill targets `origin` by name; in a
+  fork checkout that silently targets the wrong repository. There is no
+  workaround mode — point `origin` at the base repo and re-run.
+- **No lingering local git state.** `pr-audit.sh` deletes `refs/pr/<num>`
+  defensively on entry and unconditionally on every exit path via a trap —
+  not as a step the calling agent has to remember. A killed/interrupted run
+  can't poison the next one, and a normal run never leaves the ref behind
+  either. `component-readiness/audit.sh`'s worktree (used in step 5) is the
+  same story: pruned defensively before creation, removed via an
+  `EXIT INT TERM` trap after. See "Statelessness contract" above — the
+  report file (always overwritten, never suffixed) is the only thing that
   persists after a run.
 - **Local-only token/style truth.** All `--ui-*` resolution and
   generated-artifact freshness checks read `packages/tokens-pd`,

--- a/.claude/skills/review-ui-react/SKILL.md
+++ b/.claude/skills/review-ui-react/SKILL.md
@@ -95,9 +95,12 @@ This skill must behave identically on the first review of a PR and the
 tenth re-review of the same PR after it changed — it must never be aware it
 ran before. Two layers enforce that:
 
-- **On disk / in git**: the script resets its own state before AND after
-  every run (see step 2 and step 12) — no local ref, worktree, or temp file
-  it creates is allowed to outlive or influence a later invocation.
+- **On disk / in git**: no local ref, worktree, or temp file this skill
+  creates is allowed to outlive or influence a later invocation.
+  `pr-audit.sh` defensively wipes a leftover `refs/pr/<num>` from a prior
+  run on entry (step 2), but leaves the ref it fetches in place on exit,
+  since steps 4 and 5 still need to read it after the script returns; step
+  12 of this skill deletes it explicitly once the report is written.
   `pr-audit.sh` also refuses to run at all if another invocation for the
   same PR number is already in flight (`LOCK: FAIL`, see step 2) rather than
   race it on the shared `refs/pr/<num>` ref. That lock only spans the
@@ -458,10 +461,13 @@ view`'s `headRefOid` and aborts on any mismatch, so a stale fetch can never
   as current — i.e. a fork checkout (`origin` = your fork, some other remote
   = the base repo). Every fetch in this skill targets `origin` by name; in a
   fork checkout that silently targets the wrong repository. There is no
-  workaround mode — point `origin` at the base repo and re-run. `origin`'s
-  owner/repo is parsed straight out of `git remote get-url origin` (not
-  resolved via a `gh` network call), so an SSH config host alias for
-  `github.com` doesn't trip a false `FORK_CHECK: FAIL`.
+  workaround mode — point `origin` at the base repo and re-run. Note this
+  check itself first asks `gh repo view` to resolve the current repo, which
+  needs `origin`'s host to be one `gh` recognizes (github.com, or a
+  configured `GH_HOST`); an SSH config host alias for `origin` (e.g.
+  `git@github-work:owner/repo`) makes that resolution fail too, so it is
+  **not** a safe setup — every `gh` command in this skill would fail the
+  same way, not just this check.
 - **One review of a given PR number at a time.** `pr-audit.sh` takes an
   exclusive lock (`LOCK: FAIL` if held) before touching `refs/pr/<num>`,
   since a second concurrent run would race the first on that shared ref's

--- a/.claude/skills/review-ui-react/scripts/pr-audit.sh
+++ b/.claude/skills/review-ui-react/scripts/pr-audit.sh
@@ -36,6 +36,19 @@ STYLES=packages/ui-react/src/styles/index.css
 TIER_B_RE='^packages/design-tokens/|^tools/style-dictionary/|^packages/tokens-pd/|^packages/icons-svg/|^packages/icons-svg-next/|^packages/icons-sprite/'
 TIER_D_RE='^apps/docs/|^apps/demo/|^apps/demos/'
 
+# Statelessness contract: this script must behave identically whether this is
+# the first time <NUM> has ever been reviewed or the tenth time in a row.
+# Two guarantees enforce that:
+#   1. Wipe any leftover $PR_REF from a prior run (interrupted, killed, or
+#      simply never cleaned up) BEFORE doing anything else — never trust that
+#      a previous invocation left things tidy.
+#   2. Delete $PR_REF again on the way out, unconditionally, via a trap — so
+#      it happens on every exit path (success, early exit 1, or the
+#      SHORT_CIRCUIT return) instead of depending on the caller remembering a
+#      manual cleanup step. No local git state survives this script.
+git update-ref -d "$PR_REF" >/dev/null 2>&1 || true
+trap 'git update-ref -d "$PR_REF" >/dev/null 2>&1 || true' EXIT
+
 echo "=== PREFLIGHT ==="
 if ! gh auth status >/dev/null 2>&1; then
   echo "AUTH: FAIL — run: gh auth login"
@@ -46,9 +59,51 @@ echo "AUTH: OK"
 REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)"
 echo "REPO: ${REPO:-unknown}"
 
+# Fork guard — this skill's fetch/diff logic hardcodes the "origin" remote,
+# but every gh command below (pr view/diff/checks) resolves independently
+# against whatever repo `gh` considers current (it prefers an "upstream"
+# remote over "origin" when both exist, e.g. a fork checkout with origin =
+# your fork and upstream = the base repo). If those two disagree, `git fetch
+# origin +pull/<n>/head:...` fetches PR refs from the WRONG repository — at
+# best it fails outright (no such ref), at worst (if the fork happens to
+# have its own same-numbered PR) it fetches an unrelated PR's commits while
+# FETCH_VERIFY is the only thing standing between that and a silently wrong
+# review. Check this explicitly, up front, instead of relying on that as an
+# incidental safety net.
+ORIGIN_URL="$(git remote get-url origin 2>/dev/null)"
+if [ -z "$ORIGIN_URL" ]; then
+  echo "FORK_CHECK: FAIL — no 'origin' remote configured; this skill requires origin to be the base repo."
+  exit 1
+fi
+ORIGIN_REPO="$(gh repo view "$ORIGIN_URL" --json nameWithOwner -q .nameWithOwner 2>/dev/null)"
+if [ -z "$REPO" ] || [ -z "$ORIGIN_REPO" ]; then
+  echo "FORK_CHECK: FAIL — could not resolve the repo for 'origin' and/or gh's current repo; aborting rather than guessing."
+  exit 1
+elif [ "$ORIGIN_REPO" != "$REPO" ]; then
+  echo "FORK_CHECK: FAIL — 'origin' is $ORIGIN_REPO but gh resolves the base repo as $REPO."
+  echo "  This is a fork checkout (origin = your fork, a separate remote = the base repo)."
+  echo "  This skill assumes 'origin' IS the base repo it reviews PRs against — fetching PR refs"
+  echo "  from the wrong repo can silently review the wrong commits. Re-run this from a checkout"
+  echo "  where 'origin' points at $REPO (e.g. swap remotes, or reclone non-forked)."
+  exit 1
+fi
+echo "FORK_CHECK: OK — origin matches $REPO"
+
 echo
 echo "=== FETCH ==="
-git fetch origin main >/dev/null 2>&1 && echo "origin/main: updated" || echo "origin/main: FETCH FAILED"
+# Forced, same reasoning as the PR fetch below: origin/main may have been
+# rewritten (rare, but possible), and a non-force fetch would then either no-op
+# or fail while leaving the OLD local origin/main in place. Unlike before, a
+# failed main fetch is now a hard abort (exit 1) rather than a printed warning
+# the rest of the script silently ignores — every downstream diff/scope/token
+# check is computed against origin/main, so a stale main means every result
+# in this run is wrong, not just one section of it.
+if git fetch origin +main:refs/remotes/origin/main >/dev/null 2>&1; then
+  echo "origin/main: updated"
+else
+  echo "origin/main: FETCH FAILED — aborting rather than diffing against a stale local origin/main."
+  exit 1
+fi
 # The leading "+" forces the update even when the PR's history diverged from
 # what refs/pr/$NUM already points to locally (rebase/amend/force-push) — a
 # plain refspec only allows a fast-forward and would silently leave the old,

--- a/.claude/skills/review-ui-react/scripts/pr-audit.sh
+++ b/.claude/skills/review-ui-react/scripts/pr-audit.sh
@@ -74,15 +74,23 @@ if [ -z "$ORIGIN_URL" ]; then
   echo "FORK_CHECK: FAIL — no 'origin' remote configured; this skill requires origin to be the base repo."
   exit 1
 fi
-# Parse owner/repo out of the URL text instead of asking `gh repo view` to
-# resolve it over the network. `gh` treats the URL's host literally, so an
-# SSH config alias for github.com (e.g. origin = git@github-work:owner/repo,
-# common when juggling multiple GitHub identities) makes it try to connect
-# to a host literally named "github-work" and fail — which would otherwise
-# hard-abort every run for that developer even though origin is correct.
+# Parse owner/repo out of the URL text as a fallback source of truth, but
+# note this does NOT make an SSH config host alias for origin (e.g.
+# origin = git@github-work:owner/repo, common when juggling multiple GitHub
+# identities) safe end-to-end: `gh repo view` above resolves the "current
+# repo" by matching remote hosts against its own known-hosts list, and it
+# does not consult ~/.ssh/config to translate an alias back to github.com —
+# so with an aliased origin, REPO comes back empty and every gh command in
+# this skill (not just this check) would fail the same way. There is no
+# workaround here short of pointing origin at the literal host gh knows
+# (github.com, or a configured GH_HOST) — see the FAIL message below.
 ORIGIN_REPO="$(echo "$ORIGIN_URL" | sed -E 's#\.git$##' | sed -E 's#^.*[:/]([^/:]+/[^/:]+)$#\1#')"
 if [ -z "$REPO" ] || [ -z "$ORIGIN_REPO" ]; then
-  echo "FORK_CHECK: FAIL — could not resolve the repo for 'origin' ($ORIGIN_URL) and/or gh's current repo; aborting rather than guessing."
+  echo "FORK_CHECK: FAIL — could not resolve the repo for 'origin' ($ORIGIN_URL) and/or gh's current repo."
+  echo "  If 'origin' uses an SSH config host alias (e.g. git@github-work:owner/repo),"
+  echo "  gh cannot resolve it — every gh command in this skill needs 'origin' to use"
+  echo "  a host gh recognizes (github.com, or your configured GH_HOST). Point 'origin'"
+  echo "  at that literal host and re-run."
   exit 1
 elif [ "$(echo "$ORIGIN_REPO" | tr '[:upper:]' '[:lower:]')" != "$(echo "$REPO" | tr '[:upper:]' '[:lower:]')" ]; then
   echo "FORK_CHECK: FAIL — 'origin' is $ORIGIN_REPO but gh resolves the base repo as $REPO."

--- a/.claude/skills/review-ui-react/scripts/pr-audit.sh
+++ b/.claude/skills/review-ui-react/scripts/pr-audit.sh
@@ -37,17 +37,16 @@ TIER_B_RE='^packages/design-tokens/|^tools/style-dictionary/|^packages/tokens-pd
 TIER_D_RE='^apps/docs/|^apps/demo/|^apps/demos/'
 
 # Statelessness contract: this script must behave identically whether this is
-# the first time <NUM> has ever been reviewed or the tenth time in a row.
-# Two guarantees enforce that:
-#   1. Wipe any leftover $PR_REF from a prior run (interrupted, killed, or
-#      simply never cleaned up) BEFORE doing anything else — never trust that
-#      a previous invocation left things tidy.
-#   2. Delete $PR_REF again on the way out, unconditionally, via a trap — so
-#      it happens on every exit path (success, early exit 1, or the
-#      SHORT_CIRCUIT return) instead of depending on the caller remembering a
-#      manual cleanup step. No local git state survives this script.
-git update-ref -d "$PR_REF" >/dev/null 2>&1 || true
-trap 'git update-ref -d "$PR_REF" >/dev/null 2>&1 || true' EXIT
+# the first time <NUM> has ever been reviewed or the tenth time in a row. The
+# forced refspec used below (+pull/$NUM/head:$PR_REF) already guarantees that
+# on its own — it overwrites $PR_REF regardless of what it pointed to before.
+# We additionally wipe any leftover $PR_REF from a prior run (interrupted,
+# killed, or simply never cleaned up) once we know this run will actually
+# fetch — i.e. after AUTH/FORK_CHECK pass, not before — so a run that aborts
+# early never destroys a pre-existing ref for no benefit. $PR_REF is left in
+# place when this script exits: the calling skill's steps 4/5 read it after
+# the script returns, so it must survive until the whole review is done. The
+# skill deletes it as its own final step once nothing else needs it.
 
 echo "=== PREFLIGHT ==="
 if ! gh auth status >/dev/null 2>&1; then
@@ -88,6 +87,11 @@ elif [ "$ORIGIN_REPO" != "$REPO" ]; then
   exit 1
 fi
 echo "FORK_CHECK: OK — origin matches $REPO"
+
+# Now that we know this run will actually fetch, wipe any leftover $PR_REF
+# from a prior run (interrupted, killed, or simply never cleaned up) —
+# never trust that a previous invocation left things tidy.
+git update-ref -d "$PR_REF" >/dev/null 2>&1 || true
 
 echo
 echo "=== FETCH ==="

--- a/.claude/skills/review-ui-react/scripts/pr-audit.sh
+++ b/.claude/skills/review-ui-react/scripts/pr-audit.sh
@@ -74,11 +74,17 @@ if [ -z "$ORIGIN_URL" ]; then
   echo "FORK_CHECK: FAIL — no 'origin' remote configured; this skill requires origin to be the base repo."
   exit 1
 fi
-ORIGIN_REPO="$(gh repo view "$ORIGIN_URL" --json nameWithOwner -q .nameWithOwner 2>/dev/null)"
+# Parse owner/repo out of the URL text instead of asking `gh repo view` to
+# resolve it over the network. `gh` treats the URL's host literally, so an
+# SSH config alias for github.com (e.g. origin = git@github-work:owner/repo,
+# common when juggling multiple GitHub identities) makes it try to connect
+# to a host literally named "github-work" and fail — which would otherwise
+# hard-abort every run for that developer even though origin is correct.
+ORIGIN_REPO="$(echo "$ORIGIN_URL" | sed -E 's#\.git$##' | sed -E 's#^.*[:/]([^/:]+/[^/:]+)$#\1#')"
 if [ -z "$REPO" ] || [ -z "$ORIGIN_REPO" ]; then
-  echo "FORK_CHECK: FAIL — could not resolve the repo for 'origin' and/or gh's current repo; aborting rather than guessing."
+  echo "FORK_CHECK: FAIL — could not resolve the repo for 'origin' ($ORIGIN_URL) and/or gh's current repo; aborting rather than guessing."
   exit 1
-elif [ "$ORIGIN_REPO" != "$REPO" ]; then
+elif [ "$(echo "$ORIGIN_REPO" | tr '[:upper:]' '[:lower:]')" != "$(echo "$REPO" | tr '[:upper:]' '[:lower:]')" ]; then
   echo "FORK_CHECK: FAIL — 'origin' is $ORIGIN_REPO but gh resolves the base repo as $REPO."
   echo "  This is a fork checkout (origin = your fork, a separate remote = the base repo)."
   echo "  This skill assumes 'origin' IS the base repo it reviews PRs against — fetching PR refs"
@@ -87,6 +93,31 @@ elif [ "$ORIGIN_REPO" != "$REPO" ]; then
   exit 1
 fi
 echo "FORK_CHECK: OK — origin matches $REPO"
+
+# Concurrency guard — $PR_REF is a single ref name keyed only on the PR
+# number, and this script both deletes and (re)fetches it. Two overlapping
+# runs for the same PR number would race on that ref (one run's delete or
+# fetch landing mid-way through another run's fetch/verify/read), so refuse
+# to proceed if another run for this PR number is already in flight rather
+# than corrupt or invalidate it silently. A lock left behind by a run that
+# was killed (not a clean exit) is detected and reclaimed by checking
+# whether its owning pid is still alive.
+LOCK_DIR="$(git rev-parse --git-dir)/uikit-review-lock-$NUM"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  LOCK_PID="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+  if [ -n "$LOCK_PID" ] && kill -0 "$LOCK_PID" 2>/dev/null; then
+    echo "LOCK: FAIL — another review of PR $NUM is already running (pid $LOCK_PID). Wait for it to finish, then re-run."
+    exit 1
+  fi
+  rm -rf "$LOCK_DIR"
+  if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    echo "LOCK: FAIL — could not create the lock directory for PR $NUM."
+    exit 1
+  fi
+fi
+echo $$ >"$LOCK_DIR/pid"
+trap 'rm -rf "$LOCK_DIR"' EXIT
+echo "LOCK: OK"
 
 # Now that we know this run will actually fetch, wipe any leftover $PR_REF
 # from a prior run (interrupted, killed, or simply never cleaned up) —


### PR DESCRIPTION
Force+verify the origin/main fetch, delete refs/pr/<num> defensively on entry and via an exit trap so a killed run can't leak state, prune stale worktrees before reuse, always overwrite the review report instead of asking, and hard-abort with FORK_CHECK before any fetch when origin isn't the base repo gh resolves against.
