### PR TITLE
fix(toolbar): carry the disabled state to the overflow menu through React

### DIFF
--- a/.changeset/toolbar-disabled-portal-close.md
+++ b/.changeset/toolbar-disabled-portal-close.md
@@ -1,0 +1,13 @@
+---
+'@acronis-platform/ui-react': patch
+---
+
+fix(toolbar): carry the disabled state to the overflow menu through React
+
+`ToolbarActionList` learned that its ancestor `Toolbar` had become disabled by
+running a `MutationObserver` over the `<fieldset>`'s `disabled` attribute. That
+resolved a render late — the portalled overflow menu stayed interactive for a
+beat after the toolbar was disabled — and the resulting `setState` landed
+outside React's own scheduling, where it could be dropped entirely, leaving an
+open menu enabled indefinitely. The state now comes from the `Toolbar` via
+context and gates the menu's `open` prop, so it closes in the same commit.

--- a/packages/ui-react/src/components/ui/toolbar/__tests__/toolbar.test.tsx
+++ b/packages/ui-react/src/components/ui/toolbar/__tests__/toolbar.test.tsx
@@ -482,6 +482,47 @@ describe('ToolbarActionList', () => {
     });
   });
 
+  it('keeps the overflow menu closed after the Toolbar is re-enabled', async () => {
+    // The disabled state gates the menu's `open` prop, so the stored open
+    // state has to be cleared too — otherwise re-enabling the toolbar pops
+    // the menu back open on its own, with no user interaction.
+    mockGeometry({ itemWidth: 100, clientWidth: 250 });
+    const { rerender } = render(
+      <Toolbar>
+        <ToolbarActionList actions={THREE_ACTIONS} />
+      </Toolbar>
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    expect(
+      await screen.findByRole('menuitem', { name: 'Second action' })
+    ).toBeInTheDocument();
+
+    rerender(
+      <Toolbar disabled>
+        <ToolbarActionList actions={THREE_ACTIONS} />
+      </Toolbar>
+    );
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('menuitem', { name: 'Second action' })
+      ).not.toBeInTheDocument();
+    });
+
+    rerender(
+      <Toolbar>
+        <ToolbarActionList actions={THREE_ACTIONS} />
+      </Toolbar>
+    );
+
+    expect(
+      screen.queryByRole('menuitem', { name: 'Second action' })
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'More actions' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+  });
+
   it('re-measures correctly when actions shrinks, without stale phantom widths', () => {
     // Regression for a bug where the invisible clones' width refs (keyed by
     // array index) kept stale trailing entries once `actions` shrank, adding

--- a/packages/ui-react/src/components/ui/toolbar/toolbar.tsx
+++ b/packages/ui-react/src/components/ui/toolbar/toolbar.tsx
@@ -35,18 +35,32 @@ import {
 // balloons to fit every action before that measurement ever runs, so it
 // always measures "everything fits" and the row never collapses.
 
+// The fieldset cascade only reaches descendants, so anything a nested part
+// renders in a portal (see `ToolbarActionList`'s overflow menu) has to learn
+// the disabled state another way. This carries it in React, deliberately
+// rather than reading the fieldset's `disabled` attribute back out of the DOM:
+// an out-of-React side channel (a MutationObserver on the attribute) resolves
+// one render *after* the fact, so the portal renders enabled for a beat, and
+// its `setState` lands outside React's own scheduling — which under React 19's
+// act environment is intermittently never flushed at all, leaving the portal
+// enabled forever.
+const ToolbarDisabledContext = React.createContext(false);
+
 export type ToolbarProps = React.ComponentPropsWithoutRef<'fieldset'>;
 
 const Toolbar = React.forwardRef<HTMLFieldSetElement, ToolbarProps>(
-  ({ className, ...props }, ref) => (
-    <fieldset
-      ref={ref}
-      className={cn(
-        'm-0 flex min-w-0 items-center gap-4 border-0 p-0',
-        className
-      )}
-      {...props}
-    />
+  ({ className, disabled, ...props }, ref) => (
+    <ToolbarDisabledContext.Provider value={!!disabled}>
+      <fieldset
+        ref={ref}
+        className={cn(
+          'm-0 flex min-w-0 items-center gap-4 border-0 p-0',
+          className
+        )}
+        disabled={disabled}
+        {...props}
+      />
+    </ToolbarDisabledContext.Provider>
   )
 );
 Toolbar.displayName = 'Toolbar';
@@ -248,24 +262,19 @@ const ToolbarActionList = React.forwardRef<
     const [moreMenuOpen, setMoreMenuOpen] = React.useState(false);
     // The overflow menu renders in a portal, outside the ancestor
     // `<fieldset>`'s DOM subtree, so the native disabled-cascade (see
-    // `Toolbar` above) never reaches its items. Tracked separately here so a
-    // menu already open when the fieldset becomes disabled gets closed, and
-    // its items stay disabled even if forced open again (e.g. via a ref).
-    const [ancestorDisabled, setAncestorDisabled] = React.useState(false);
+    // `Toolbar` above) never reaches its items — they read the state off
+    // context instead, so a menu already open when the toolbar becomes
+    // disabled gets closed, and its items stay disabled even if forced open
+    // again (e.g. via a ref).
+    const ancestorDisabled = React.useContext(ToolbarDisabledContext);
 
-    React.useEffect(() => {
-      const fieldset = containerRef.current?.closest('fieldset');
-      if (!fieldset) return;
-      const sync = () => setAncestorDisabled(fieldset.disabled);
-      sync();
-      const observer = new MutationObserver(sync);
-      observer.observe(fieldset, {
-        attributes: true,
-        attributeFilter: ['disabled'],
-      });
-      return () => observer.disconnect();
-    }, []);
+    // Gating the `open` prop (rather than only resetting the state below)
+    // closes the menu in the very commit the toolbar becomes disabled — an
+    // effect would leave it open for one frame.
+    const menuOpen = moreMenuOpen && !ancestorDisabled;
 
+    // Still clear the stored state, or re-enabling the toolbar would pop the
+    // menu back open on its own.
     React.useEffect(() => {
       if (ancestorDisabled) setMoreMenuOpen(false);
     }, [ancestorDisabled]);
@@ -349,7 +358,7 @@ const ToolbarActionList = React.forwardRef<
         ))}
         {hiddenActions.length > 0 && (
           <DropdownMenu
-            open={moreMenuOpen}
+            open={menuOpen}
             onOpenChange={setMoreMenuOpen}
             disabled={ancestorDisabled}
           >

--- a/packages/ui-spec/components/toolbar/behavior.md
+++ b/packages/ui-spec/components/toolbar/behavior.md
@@ -40,6 +40,21 @@ ButtonMenu children (including inside a ToolbarActions child)
 **When** it renders
 **Then** every nested Button/ButtonMenu is enabled
 
+### Closes an open overflow menu when the Toolbar becomes disabled
+
+**Given** a ToolbarActionList whose overflow menu is open
+**When** the ancestor Toolbar's `disabled` becomes `true`
+**Then** the menu closes and its items are disabled — the menu renders in a
+portal, outside the `<fieldset>` subtree the native cascade reaches, so the
+disabled state is carried to it in the same render rather than observed off
+the DOM afterwards
+
+### Keeps the overflow menu closed once the Toolbar is re-enabled
+
+**Given** a Toolbar that was disabled while its overflow menu was open
+**When** `disabled` becomes `false` again
+**Then** the menu stays closed until the user opens it again
+
 ---
 
 ## Actions Area


### PR DESCRIPTION
### Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

### Description

`toolbar.test.tsx > closes the overflow menu and disables its items once the ancestor Toolbar becomes disabled while it is open` is flaky on `main`. It failed today on two unrelated branches — [#605](https://github.com/acronis/uikit/actions/runs/30553734321/job/90912399252) and `feat/ai-chat` ([run](https://github.com/acronis/uikit/actions/runs/30547802040)) — both at ~1150 ms, i.e. burning the full 1000 ms `waitFor` budget.

It is **not** CI slowness. Reproduced locally in ~1.3% of runs (3 hangs in ~235 iterations); the menu never closes at all, even given a 15 s `waitFor`.

**Root cause.** `ToolbarActionList` learned that its ancestor `Toolbar` had become disabled by running a `MutationObserver` over the `<fieldset>`'s `disabled` attribute. Instrumenting a hang showed `fieldset.disabled === true` and the observer firing, but `ancestorDisabled` stuck at `false` forever:

```
HANG: fieldset.disabled=true hasAttr=true trigger aria-expanded=true
      trigger disabled=false item data-disabled=false MY_OBSERVER_FIRED=1
```

The observer's `setAncestorDisabled` call lands outside React's own scheduling, and that update is intermittently never flushed. Two problems with reading the state back out of the DOM, then:

- it resolves one render late, so the portalled overflow menu stays interactive for a frame after the toolbar is disabled — a real (if brief) browser bug, not just a test artifact;
- the update can be lost entirely, leaving an open menu enabled indefinitely.

**Fix.** `Toolbar` publishes `disabled` on a context that `ToolbarActionList` consumes, and that gates the menu's `open` prop so it closes in the same commit. `closest('fieldset')` always resolved to the `Toolbar`'s own fieldset, so the observer never covered a case the context doesn't — it's removed rather than kept as a fallback.

Also added a regression test for re-enabling: the disabled state now gates `open`, so the stored open state has to be cleared too, or re-enabling the toolbar would pop the menu back open with no user interaction.

**No visual baselines move.** Rendered DOM is identical for every story — a context provider emits no element and `disabled` still lands on the fieldset — and no story renders an open overflow menu (there are no `play:` functions in the file), so the state this changes isn't captured by any baseline.

### Verification

| | |
|---|---|
| Repro probe, post-fix | 660 iterations, **0 hangs** (pre-fix rate ~1.3%) |
| `toolbar.test.tsx` | 36 passed |
| `ui-react` full suite | 106 files / 1156 tests |
| `ui-spec` | 892 tests |
| typecheck + lint | clean |

### Checklist

- [x] I have updated the **documentation** accordingly (two scenarios added to the toolbar spec's `behavior.md` — the Disabled section never documented the portal case);
- [x] I have added or updated **tests** to cover my changes;
- [x] I have performed a **self-review** of my code;
- [x] My code follows the style **guidelines** of this project;
- [x] My changes generate no new **warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
