### PR TITLE
test(sankey-chart): make tooltip range assertion locale-independent

### DIFF
--- a/packages/ui-react/src/components/ui/sankey-chart/__tests__/sankey-chart.test.tsx
+++ b/packages/ui-react/src/components/ui/sankey-chart/__tests__/sankey-chart.test.tsx
@@ -215,7 +215,10 @@ describe('SankeyChart default tooltip', () => {
     const { container } = render(
       <Tooltip active payload={[{ name: 'all - certified', value: [1000, 2000] }]} />
     );
-    expect(container.textContent).toContain('1,000 – 2,000');
+    // the tooltip localises each part, so derive the expectation from the same
+    // locale the test process runs under instead of hardcoding en-US grouping
+    const expected = `${(1000).toLocaleString()} – ${(2000).toLocaleString()}`;
+    expect(container.textContent).toContain(expected);
     expect(container.textContent).not.toContain('1000,2000');
   });
 


### PR DESCRIPTION
## What

The `SankeyChart` default-tooltip test `formats a range-tuple value instead of printing a comma-joined array` fails on any machine whose locale groups numbers differently from en-US. It passes in CI (en-US) and fails locally for at least one of us:

```
AssertionError: expected 'All tenants → Certified1000 – 2000' to contain '1,000 – 2,000'
```

## Why

`formatTooltipValue` in `sankey-chart.tsx` calls `toLocaleString()` with no explicit locale — deliberately, so numbers follow the user's locale (the shared `ChartTooltipContent` primitive does the same). The test, however, hardcoded en-US grouping.

Under `bg-BG` the value renders as `1000`, not `1 000`: CLDR gives `bg` a `minimumGroupingDigits` of 2, so four-digit numbers are not grouped at all.

```
LC_ALL=en_US → "1,000"      LC_ALL=bg_BG → "1000"
```

So this is a test bug, not a component bug — the runtime behaviour is the intended one and is unchanged here.

## Change

Derive the expected string from `toLocaleString()` instead of hardcoding it. The test still covers its actual intent — a range tuple renders as parts joined by `–`, rather than `Array.toString()`'s comma-join, which the `not.toContain('1000,2000')` assertion continues to guard.

## Verification

- `sankey-chart.test.tsx` → 19/19 under `bg_BG.UTF-8`, `en_US.UTF-8`, `de_DE.UTF-8` and `C`
- full `packages/ui-react` suite under `LC_ALL=bg_BG.UTF-8 TZ=Europe/Sofia` → **108 files / 1189 tests passing**, confirming this was the only locale-dependent assertion in the package

No changeset: test-only change, exempt under the CI changeset gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)