### PR TITLE
docs(shadow-dom): fix the Quick setup example and pin null-container behaviour

### DIFF
--- a/apps/docs/content/docs/shadow-dom.mdx
+++ b/apps/docs/content/docs/shadow-dom.mdx
@@ -3,8 +3,6 @@ title: Shadow DOM Integration
 description: How to render @acronis-platform/ui-react inside a shadow-DOM micro-frontend with fully styled portaled components and zero host style leakage.
 ---
 
-# Shadow DOM Integration
-
 When `@acronis-platform/ui-react` runs inside a **shadow-DOM micro-frontend**
 (MFE), portaled components — Popover, DropdownMenu, Tooltip, Dialog, Sheet,
 Select, Combobox, and Toaster — mount their popups into `document.body` by
@@ -16,24 +14,23 @@ inside the shadow root.
 
 ## Quick setup
 
+If your host already renders the app inside its shadow root, all you need is a
+container element to point the provider at:
+
 ```tsx
+import { useState } from 'react';
 import { PortalContainerProvider } from '@acronis-platform/ui-react';
 
-function ShadowMFE({ shadowRoot }: { shadowRoot: ShadowRoot }) {
-  // 1. Create a mount point inside the shadow root
-  const mountRef = useRef<HTMLDivElement>(null);
+function ShadowMFE() {
+  // Hold the mount element in state, not a ref: the provider reads `container`
+  // during render, and populating a ref doesn't trigger one. With a ref, the
+  // provider keeps the `null` it saw on the first render — and a `null`
+  // container renders no popup at all, so overlays silently never open.
+  const [mount, setMount] = useState<HTMLElement | null>(null);
 
-  // 2. Adopt ui-react's CSS onto the shadow root
-  useEffect(() => {
-    const sheet = new CSSStyleSheet();
-    sheet.replaceSync(uiReactCssText); // your bundled/fetched CSS
-    shadowRoot.adoptedStyleSheets = [sheet];
-  }, [shadowRoot]);
-
-  // 3. Wrap your app — all portals now render inside the shadow root
   return (
-    <div ref={mountRef}>
-      <PortalContainerProvider container={mountRef.current}>
+    <div ref={setMount}>
+      <PortalContainerProvider container={mount}>
         <App />
       </PortalContainerProvider>
     </div>
@@ -43,6 +40,16 @@ function ShadowMFE({ shadowRoot }: { shadowRoot: ShadowRoot }) {
 
 That's it. Every portaling component automatically picks up the container from
 context. No need to pass `portalContainer` to each component individually.
+
+Passing the state setter straight to `ref` is the shortest correct form — React
+calls it with the element on mount (and with `null` on unmount), so the provider
+re-renders exactly once with the real container.
+
+If your app also **creates** the shadow root, attach it and render into it with
+`createPortal` first — see
+[`ShadowDemo.tsx`](https://github.com/acronis/uikit/blob/main/apps/docs/src/components/ShadowDemo.tsx),
+which is what powers the live previews on these component pages — then adopt the
+stylesheet as shown in [Adopting styles](#adopting-styles).
 
 ## How it works
 
@@ -59,16 +66,16 @@ context. No need to pass `portalContainer` to each component individually.
 
 All portaling components respect `PortalContainerProvider`:
 
-| Component | Portal target |
-|-----------|---------------|
-| `PopoverContent` | Positioner + popup |
-| `DropdownMenuContent` | Positioner + popup |
-| `TooltipContent` | Positioner + popup |
-| `Dialog` | Backdrop + popup |
-| `SheetContent` | Backdrop + popup |
+| Component                              | Portal target      |
+| -------------------------------------- | ------------------ |
+| `PopoverContent`                       | Positioner + popup |
+| `DropdownMenuContent`                  | Positioner + popup |
+| `TooltipContent`                       | Positioner + popup |
+| `Dialog`                               | Backdrop + popup   |
+| `SheetContent`                         | Backdrop + popup   |
 | `SelectContent` / `InputSelectContent` | Positioner + popup |
-| `ComboboxContent` | Positioner + popup |
-| `Toaster` | Viewport + toasts |
+| `ComboboxContent`                      | Positioner + popup |
+| `Toaster`                              | Viewport + toasts  |
 
 ## Adopting styles
 

--- a/packages/ui-react/src/lib/__tests__/portal-container.test.tsx
+++ b/packages/ui-react/src/lib/__tests__/portal-container.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -38,7 +39,12 @@ import {
 describe('usePortalContainer', () => {
   function Spy() {
     const container = usePortalContainer();
-    const label = container === undefined ? 'undefined' : container === null ? 'null' : 'element';
+    const label =
+      container === undefined
+        ? 'undefined'
+        : container === null
+          ? 'null'
+          : 'element';
     return <span data-testid="spy">{label}</span>;
   }
 
@@ -57,13 +63,15 @@ describe('usePortalContainer', () => {
     expect(screen.getByTestId('spy').textContent).toBe('element');
   });
 
-  it('allows null container (portals go to document.body)', () => {
+  it('passes a null container through unchanged', () => {
     render(
       <PortalContainerProvider container={null}>
         <Spy />
       </PortalContainerProvider>
     );
-    // null is a valid value — Base UI treats null as document.body
+    // The hook is a plain pass-through: null reaches the component as null.
+    // What that does to an actual portal is asserted below — it is NOT a
+    // fallback to document.body.
     expect(screen.getByTestId('spy').textContent).toBe('null');
   });
 });
@@ -182,5 +190,58 @@ describe('PortalContainerProvider integration', () => {
     await screen.findByText('Tip text');
     expect(container.textContent).toContain('Tip text');
     document.body.removeChild(container);
+  });
+});
+
+// ── A null container is not a fallback ──────────────────────────────────────
+
+describe('null container', () => {
+  // A null container renders NO popup — it does not fall back to
+  // document.body. This is why the container must be held in state: a plain
+  // `useRef` leaves the provider with the `null` it saw on the first render,
+  // and the overlay then silently never opens. See the Shadow DOM guide.
+  it('renders no popup at all', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PortalContainerProvider container={null}>
+        <Popover>
+          <PopoverTrigger>Open</PopoverTrigger>
+          <PopoverContent>Popup content</PopoverContent>
+        </Popover>
+      </PortalContainerProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+
+    expect(screen.queryByText('Popup content')).toBeNull();
+    expect(document.body.textContent).not.toContain('Popup content');
+  });
+
+  it('renders the popup once the container arrives via state', async () => {
+    const user = userEvent.setup();
+
+    // The documented pattern: a callback ref that is the state setter, so the
+    // provider re-renders with the real element.
+    function App() {
+      const [mount, setMount] = useState<HTMLElement | null>(null);
+      return (
+        <div ref={setMount} data-testid="mount">
+          <PortalContainerProvider container={mount}>
+            <Popover>
+              <PopoverTrigger>Open</PopoverTrigger>
+              <PopoverContent>Popup content</PopoverContent>
+            </Popover>
+          </PortalContainerProvider>
+        </div>
+      );
+    }
+
+    render(<App />);
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+
+    expect(
+      screen.getByTestId('mount').contains(screen.getByText('Popup content'))
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## What

The Shadow DOM guide's **Quick setup** snippet handed out a container that is always `null`:

```tsx
const mountRef = useRef<HTMLDivElement>(null);
…
<PortalContainerProvider container={mountRef.current}>  // null
```

`PortalContainerProvider` reads `container` during render, and populating a ref doesn't trigger one — so the provider keeps the `null` it saw on the first pass. A `null` container renders **no popup at all**, so a Popover/Tooltip/Select
copied from this snippet silently never opens.

It recovers as soon as anything re-renders the parent, which is why this went unreported — but it does fail on the path the guide describes: mounted into a shadow root, first interaction being an overlay.

Verified against a real shadow root under `StrictMode`, opening a Popover as the first interaction:

| Snippet | Popup renders? |
| --- | --- |
| Guide as written | no — absent from the shadow root *and* `document.body` |
| Guide + the theme mirroring the same page recommends | no — `setDark(false)` when already `false` bails out, so no re-render |
| Callback ref into state (this PR) | yes, inside the shadow mount, no leak to `document.body` |

## Changes

**`apps/docs` — the guide**

- **Quick setup** now holds the mount element in state via a callback ref (`ref={setMount}`), the shortest correct form — React calls it with the element on mount, so the provider re-renders once with the real container. A comment records why a ref doesn't work, so it doesn't regress.
- Dropped the stylesheet-adoption step from the snippet — already covered by the **Adopting styles** section below, and it made the "quick" setup carry an unrelated concern.
- Added a pointer for apps that also *create* the shadow root (attach + render in with `createPortal`), linking `ShadowDemo.tsx` — the implementation that already powers the live previews on the component pages, and which had the correct pattern all along.
- Removed the body `# Shadow DOM Integration`, which duplicated the frontmatter `title` and rendered the heading twice.

**`packages/ui-react` — the test that hid this**

`portal-container.test.tsx` had:

```tsx
it('allows null container (portals go to document.body)', () => {
  …
  // null is a valid value — Base UI treats null as document.body
  expect(screen.getByTestId('spy').textContent).toBe('null');
});
```

The name and comment both assert a `document.body` fallback that doesn't exist, and the `expect` only checks the hook's return value — it never looks at where the portal lands, so the claim was never verified. This is what made the docs bug look benign.

- Renamed to `passes a null container through unchanged`, describing what it actually asserts, and corrected the comment.
- Added a `null container` block pinning the real behaviour: `renders no popup at all` (not even into `document.body`), and `renders the popup once the container arrives via state` — the pattern the guide now documents.

## Notes for review

- **Prettier** realigned the **Affected components** table in the MDX. The file wasn't prettier-clean on `main`, so `lint-staged` would have done this on any commit touching it — not a deliberate change.
- **No changeset.** `apps/docs` is private, and the ui-react change is test-only with no consumer-visible effect — consistent with existing `test(...)` commits in this repo, none of which carry one. Happy to add a patch changeset if you'd rather.
- **The pre-commit hook didn't run.** Committed from a `git worktree`, where `.husky/_` (generated by `pnpm install`) doesn't exist, so git found nothing at `core.hooksPath` and skipped it. `--no-verify` was **not** used. Ran the equivalents by hand: `eslint` clean, `prettier --check` clean, the MDX compiles, and `vitest run portal-container` passes 10/10.