### PR TITLE
docs: address the PR 620 review follow-ups

### DIFF
--- a/.changeset/remove-search-global.md
+++ b/.changeset/remove-search-global.md
@@ -1,5 +1,5 @@
 ---
-'@acronis-platform/ui-react': minor
+'@acronis-platform/ui-react': major
 ---
 
 Remove the `SearchGlobal` component — it is no longer part of the design system.

--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ function MyComponent() {
 The library covers layout (`AppShell`, `AppShellChat`, `AuthLayout`, `Card`,
 `CardFilter`, `Grid`, `Stack`, `Section`, `PageContent`, `PageHeader`,
 `Separator`, `ScrollArea`, `Resizable`, `Toolbar`), navigation (`Breadcrumb`,
-`Tabs`, `Pagination`, `SidebarPrimary`, `SidebarSecondary`, `SearchGlobal`,
-`Link`), forms (`InputText`, `InputSearch`, `InputTextArea`, `InputSelect`,
+`Tabs`, `Pagination`, `SidebarPrimary`, `SidebarSecondary`, `Link`), forms
+(`InputText`, `InputSearch`, `InputTextArea`, `InputSelect`,
 `InputDatePicker`, `InputPassword`, `InputOTP`, `Combobox`, `Select`,
 `Checkbox`, `Radio`, `Switch`, `Slider`, `NumberField`, `Calendar`,
 `DateRangePicker`, `Field`, `Form`, `Label`), buttons (`Button`, `ButtonIcon`,

--- a/apps/docs/content/docs/packages/tokens-pd.mdx
+++ b/apps/docs/content/docs/packages/tokens-pd.mdx
@@ -25,6 +25,11 @@ first.
 `@acronis-platform/ui-react` already pulls this in for you when you import its
 styles entry, so most apps never import it directly.
 
+Alongside colors, typography, and spacing, the semantic tier ships elevation as
+`--ui-shadow-{sm,md,lg}`. The light/dark pair sits **inside the shadow's color
+slot** — `0px 8px 16px 0px light-dark(…, …)` — because `light-dark()` is a color
+function and cannot wrap a whole shadow value.
+
 ## Per-component tiers
 
 Each component has its own CSS under `css/<Component>/default.css` (e.g.
@@ -38,10 +43,12 @@ component-scoped `--ui-*` tokens (such as `--ui-button-global-radius`) and are
 
 ## Brand overrides
 
-Non-default brands ship as **override-only** files. `css/deep_sky_itkontoret.css` contains
-a token only when its value differs from `default` or is new in that brand.
-Brand selection is import-order based — **last import wins** — not a class
-toggle:
+Besides `default`, the package ships `deep_sky_itkontoret`, `light-gray`,
+`telstra`, `virtuozzo`, and `yellow-1c` — each as an **override-only** file
+(`css/<brand>.css` for the semantic tier, `css/<Component>/<brand>.css` for a
+component tier). A brand file contains a token only when its value differs from
+`default` or is new in that brand. Brand selection is import-order based —
+**last import wins** — not a class toggle:
 
 ```css
 @import '@acronis-platform/tokens-pd/css/default.css';
@@ -86,19 +93,21 @@ export default {
 
 Color roles land in Tailwind's role-namespaced keys with the role word and the
 `ui-` prefix dropped — `bg-surface-primary`, `text-on-surface-primary`,
-`border-on-surface-border`, `ring-brand`. Because the values are baked, a preset
-is self-contained, but brand selection happens at build time.
+`border-on-surface-border`, `ring-brand`. Shadows land in `boxShadow`, so the
+preset's `shadow-sm`/`shadow-md`/`shadow-lg` carry the design-system elevation
+instead of Tailwind's defaults. Because the values are baked, a preset is
+self-contained, but brand selection happens at build time.
 
 ## The `--ui-*` naming convention
 
 Every CSS custom property is prefixed `ui` and the token path is flattened with
 hyphens. The `colors` tier root is dropped:
 
-| Token path                            | CSS variable                      |
-| ------------------------------------- | --------------------------------- |
-| `colors.background.surface.primary`   | `--ui-background-surface-primary` |
-| `colors.text.on-surface.primary`      | `--ui-text-on-surface-primary`    |
-| `button._global.radius`               | `--ui-button-global-radius`       |
+| Token path                          | CSS variable                      |
+| ----------------------------------- | --------------------------------- |
+| `colors.background.surface.primary` | `--ui-background-surface-primary` |
+| `colors.text.on-surface.primary`    | `--ui-text-on-surface-primary`    |
+| `button._global.radius`             | `--ui-button-global-radius`       |
 
 ## DTCG intermediate
 

--- a/packages/tokens-pd/README.md
+++ b/packages/tokens-pd/README.md
@@ -7,24 +7,26 @@ DTCG token data) by the
 
 The raw tokens are a Figma-exported, multi-dimensional DTCG variant that no app
 can use directly — primitives carry per-scheme (`light`/`dark`) values and
-semantic/component tokens carry per-brand (`default`/`deep_sky_itkontoret`) aliases back into
-the primitives. This package ships the resolved output. **The generated files are
-committed** (and published); do not edit them by hand — change the upstream tokens
-and rebuild.
+semantic/component tokens carry per-brand aliases back into the primitives. This
+package ships the resolved output. **The generated files are committed** (and
+published); do not edit them by hand — change the upstream tokens and rebuild.
+
+Brands: `default` plus `deep_sky_itkontoret`, `light-gray`, `telstra`,
+`virtuozzo`, `yellow-1c`.
 
 ## Layout
 
 Output is grouped into three top-level directories — `css/`, `tailwind/`, `dtcg/`:
 
-| Path                                         | Tier      | Contents                                                                                             |
-| -------------------------------------------- | --------- | ---------------------------------------------------------------------------------------------------- |
-| `css/default.css`                            | semantic  | Default brand — every semantic token (`--ui-*`), `.ui-typography-*`, `.ui-p-*`/`.ui-m-*`/`.ui-gap-*` |
-| `css/deep_sky_itkontoret.css`                | semantic  | Non-default brand — only the tokens that differ from `default`                                       |
-| `css/<component>/default.css`                | component | Default brand — that component's tokens (`button/`, `tooltip/`, …)                                   |
-| `css/<component>/deep_sky_itkontoret.css`    | component | Non-default brand — only the component tokens that differ                                            |
-| `tailwind/<brand>/tokens.js`                 | semantic  | Tailwind preset of the shared semantic vocabulary (**baked** values), incl. `gap-*` keys             |
-| `tailwind/<brand>/components/<component>.js` | component | One preset per component — opt-in, so its utilities aren't suggested globally                        |
-| `dtcg/*.json`                                | —         | The 100%-DTCG intermediate (per-mode), for generic DTCG tooling                                      |
+| Path                                         | Tier      | Contents                                                                                                                    |
+| -------------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `css/default.css`                            | semantic  | Default brand — every semantic token (`--ui-*`, incl. `--ui-shadow-*`), `.ui-typography-*`, `.ui-p-*`/`.ui-m-*`/`.ui-gap-*` |
+| `css/<brand>.css`                            | semantic  | Non-default brand — only the tokens that differ from `default`                                                              |
+| `css/<Component>/default.css`                | component | Default brand — that component's tokens (`Button/`, `Tooltip/`, …; dirs are PascalCase)                                     |
+| `css/<Component>/<brand>.css`                | component | Non-default brand — only the component tokens that differ                                                                   |
+| `tailwind/<brand>/tokens.js`                 | semantic  | Tailwind preset of the shared semantic vocabulary (**baked** values), incl. `gap-*` and `boxShadow` keys                    |
+| `tailwind/<brand>/components/<Component>.js` | component | One preset per component — opt-in, so its utilities aren't suggested globally                                               |
+| `dtcg/*.json`                                | —         | The 100%-DTCG intermediate (per-mode), for generic DTCG tooling                                                             |
 
 Names use the `--ui-*` convention (the `colors` tier segment is dropped, every
 token is prefixed with `ui`): `colors.background.surface.primary` →
@@ -40,8 +42,8 @@ token is prefixed with `ui`): `colors.background.surface.primary` →
 @import '@acronis-platform/tokens-pd/css/default.css';
 @import '@acronis-platform/tokens-pd/css/deep_sky_itkontoret.css';
 
-/* Component tier is opt-in, per component */
-@import '@acronis-platform/tokens-pd/css/button/default.css';
+/* Component tier is opt-in, per component (dirs are PascalCase) */
+@import '@acronis-platform/tokens-pd/css/Button/default.css';
 ```
 
 Light/dark is built in via `light-dark()` + `color-scheme`; switch with the
@@ -58,7 +60,7 @@ loaded — not globally:
 @import 'tailwindcss';
 /* presets: [
      require('@acronis-platform/tokens-pd/tailwind/default/tokens.js'),       // shared vocabulary
-     require('@acronis-platform/tokens-pd/tailwind/default/components/button.js'), // opt-in per component
+     require('@acronis-platform/tokens-pd/tailwind/default/components/Button.js'), // opt-in per component
    ] */
 @config '../tailwind.config.js';
 ```
@@ -76,12 +78,17 @@ package — it is a published home for the tool's token output.
 ## Scope
 
 - Colors (incl. `light-dark()` theming and gradients as `linear-gradient(...)`),
-  typography utility classes, spacing (margin/padding/gap), and component dimensions.
+  typography utility classes, spacing (margin/padding/gap), shadows, and component
+  dimensions.
+- Shadows ship as `--ui-shadow-{sm,md,lg}` custom properties plus a `boxShadow`
+  Tailwind namespace (`shadow-sm`/`shadow-md`/`shadow-lg`). The light/dark pair sits
+  **inside the shadow's color slot** (`0px 8px 16px 0px light-dark(…, …)`) because
+  `light-dark()` is a color function and cannot wrap a whole shadow value.
 - Spacing ships three ways, generated directly from the `units.gap` **primitive**
   scale by dedicated build code (not a semantic token — see the tool's
   `context/output.md`): `--ui-gap-*` custom properties, framework-agnostic
   `.ui-p-*`/`.ui-m-*`/`.ui-gap-*` utility classes (plus `.ui-mx-auto`), and `gap-*`
   Tailwind preset keys (e.g. `p-gap-8`, `gap-x-gap-16`) — not brand-dependent, so it
   carries no override-file entries.
-- Non-default brands are emitted as **override-only** files: a token appears in
-  `deep_sky_itkontoret.css` only when its value differs from `default` or is new in that brand.
+- Non-default brands are emitted as **override-only** files: a token appears in a
+  brand's file only when its value differs from `default` or is new in that brand.

--- a/tools/style-dictionary/AGENTS.md
+++ b/tools/style-dictionary/AGENTS.md
@@ -106,7 +106,8 @@ src/
                         is what stage 1 calls directly; `acronisDtcg` wraps it as an
                         SD preprocessor (kept for reuse, not currently registered).
     transforms/         color/hsl-to-rgb, gradient/css, dimension/px, scalar/css,
-                        typography/css-class, name/ui + the `acronis/css` transform group.
+                        shadow/css, typography/css-class, name/ui + the `acronis/css`
+                        transform group.
     filters/            semantic-only — drop the primitive roots from CSS output
                         (isEmittableToken is the plain predicate the builder reuses).
     formats/            css/light-dark — collectDecls + serializeCss render the CSS.


### PR DESCRIPTION
Follow-up to the review of #620 (already merged). Closes every finding that was
**not** marked "tracked" there — i.e. everything the reviewers flagged as ours to
fix before the release, plus the changeset bump type.

The three "tracked" findings (the emitter's default component allowlist, wiring
`--ui-shadow-*` into ui-react's `@theme` bridge, importing the six new component
tiers) are intentionally **not** here — they're dev-owned code work for a
separate PR.

### Changes

- **`.changeset/remove-search-global.md`: `minor` → `major`.** The changeset
  documents a `### BREAKING CHANGES` section for a removed export, which
  `context/releasing.md` files under `major`.
- **Root `README.md`:** dropped `SearchGlobal` from the navigation component
  list — the component and its export are gone.
- **`packages/tokens-pd/README.md` + `apps/docs/.../tokens-pd.mdx`:** both still
  listed only `default`/`deep_sky_itkontoret`, missing `virtuozzo` (stale since an
  earlier sync) plus the three brands #620 added (`light-gray`, `telstra`,
  `yellow-1c`), and neither mentioned `--ui-shadow-{sm,md,lg}` or the `boxShadow`
  Tailwind namespace. `README.md` ships inside the published package, so this
  would have gone to npm with the next release.
- **`tools/style-dictionary/AGENTS.md`:** added `shadow/css` to the transform
  inventory.

Also fixed while in the same published README: the component-tier examples used
lowercase dirs (`css/button/default.css`, `components/button.js`) but the
generated dirs are PascalCase (`css/Button/`, `components/Button.js`) — the
documented import resolves to nothing on a case-sensitive filesystem.

### Note for whoever runs `changeset version`

With the `major` bump, `changeset version` produces `ui-react@1.0.0`. Per this
repo's practice the version stays in `0.x` and is corrected by hand in the
"version packages" PR (same as `0.56.1`, which carries a `### Major Changes`
section). Don't publish a `1.0.0` by accident.

### Verification

- `prettier --check` clean on all five files.
- The MDX page compiles (`@mdx-js/mdx`).
- No changeset needed for this PR: CI's published-surface gate exempts
  `*/README.md`, and `tokens-pd` is already bumping this cycle, so the README fix
  rides along.
- Grepped the tree for leftover `SearchGlobal` / `search-global` references: only
  changesets and historical CHANGELOG entries remain, as expected.

