### PR TITLE
refactor(ui-react): drive Alert and Toast titles from their own token tier

### DIFF
--- a/.changeset/alert-toast-title-text-style.md
+++ b/.changeset/alert-toast-title-text-style.md
@@ -1,0 +1,12 @@
+---
+'@acronis-platform/ui-react': patch
+---
+
+Drive `Alert` and `Toast` titles from their own component token tier.
+
+Both titles borrowed the semantic `ui-typography-headings-lead` class because
+their tiers emitted one only for the description. The tiers now emit a title
+text style too, so each component reads its own — matching what the description
+already did, and letting a brand re-style just the Alert or Toast title. The two
+classes resolve identically today (Inter Regular 18 / 24), so nothing renders
+differently.

--- a/packages/ui-react/src/components/ui/alert/alert.tsx
+++ b/packages/ui-react/src/components/ui/alert/alert.tsx
@@ -37,12 +37,14 @@ import { ButtonIcon, type ButtonIconProps } from '../button-icon';
 // clip edge out to the border box lets the bleed survive while still rounding the
 // corners.
 //
-// Typography comes from the generated classes: `ui-typography-headings-lead` for
-// the title (Inter Regular 18 / 24) and the Alert tier's own emitted class for the
-// description (Inter Regular 14 / 24) — the same pair Toast uses, since the two are
-// the same card. Only the *colors* are separate token references. Every other value
-// is a `var(--ui-alert-*)` reference, so a brand override is honored without
-// touching this file.
+// Typography comes from the Alert tier's own emitted classes — the title (Inter
+// Regular 18 / 24) and the description (Inter Regular 14 / 24) — the same pair
+// Toast uses, since the two are the same card. The title previously borrowed the
+// semantic `ui-typography-headings-lead` because the tier emitted no title class;
+// it does now, and the two resolve identically today, so a brand that re-styles
+// only Alert's title is honored. Only the *colors* are separate token references.
+// Every other value is a `var(--ui-alert-*)` reference, so a brand override is
+// honored without touching this file.
 const alertVariants = cva(
   'relative flex w-full items-start overflow-clip [overflow-clip-margin:border-box] border-solid ' +
     'min-w-[var(--ui-alert-global-container-width-min)] ' +
@@ -191,7 +193,7 @@ const AlertTitle = React.forwardRef<
     ref={ref}
     data-slot="alert-title"
     className={cn(
-      'ui-typography-headings-lead mb-0 w-full text-[var(--ui-alert-global-content-text-container-title-color)]',
+      'ui-alert-global-content-text-container-title-text-style mb-0 w-full text-[var(--ui-alert-global-content-text-container-title-color)]',
       className
     )}
     {...props}

--- a/packages/ui-react/src/components/ui/toast/toast.tsx
+++ b/packages/ui-react/src/components/ui/toast/toast.tsx
@@ -52,11 +52,13 @@ import { Spinner } from '../spinner';
 // clip edge out to the border box lets the bleed survive while still rounding the
 // corners.
 //
-// Typography comes from the generated classes rather than hand-written utilities:
-// `ui-typography-headings-lead` is the title's Figma text style (Inter Regular
-// 18 / 24 — the same treatment Alert's title uses) and the Toast tier emits its
-// own class for the description (Inter Regular 14 / 24). Only the *colors* are
-// separate token references.
+// Typography comes from the Toast tier's own emitted classes rather than
+// hand-written utilities: one for the title (Inter Regular 18 / 24 — the same
+// treatment Alert's title uses) and one for the description (Inter Regular
+// 14 / 24). The title previously borrowed the semantic
+// `ui-typography-headings-lead` because the tier emitted no title class; it does
+// now, and the two resolve identically today. Only the *colors* are separate
+// token references.
 //
 // One deliberate deviation from the Figma: `container/widthMin` (384px) is applied
 // to the viewport, not to the card. A fixed-position stack with a 384px
@@ -272,7 +274,7 @@ function ToastList({ closeAriaLabel }: { closeAriaLabel: string }) {
               // `h5` overrides Base UI's `h2` default to match Alert — a toast
               // is not a page-level heading.
               render={<h5 />}
-              className="ui-typography-headings-lead mb-0 w-full text-[var(--ui-toast-global-content-text-container-title-color)]"
+              className="ui-toast-global-content-text-container-title-text-style mb-0 w-full text-[var(--ui-toast-global-content-text-container-title-color)]"
             />
             {item.description ? (
               <ToastPrimitive.Description

--- a/packages/ui-spec/components/toast/anatomy.yaml
+++ b/packages/ui-spec/components/toast/anatomy.yaml
@@ -62,7 +62,7 @@ parts:
     element: h5
     description: >-
       A short heading for the notification; also the card's accessible name. Typed
-      like Alert's title (Inter Medium 16 / 24) and rendered as an `h5` rather than
+      like Alert's title (Inter Regular 18 / 24) and rendered as an `h5` rather than
       Base UI's `h2` default — a toast is not a page-level heading.
   - id: toast-description
     element: div


### PR DESCRIPTION
Follow-up to the 2026-08-19 Figma sync (#666).

## What

`Alert` and `Toast` titles borrowed the semantic `ui-typography-headings-lead`
class because their token tiers emitted one only for the description:

```
alert.tsx  description → ui-alert-global-content-text-container-description-text-style  (tier)
alert.tsx  title       → ui-typography-headings-lead                                    (semantic)
```

#666 added `Alert._global.content.textContainer.title.textStyle` and the Toast
equivalent, so each component now reads its own tier class — matching what the
description already did, and following the workspace convention that
component-specific tokens are referenced directly.

The practical gain: a brand that re-styles only Alert's or Toast's title is now
honored without touching this code.

Also corrects `packages/ui-spec/components/toast/anatomy.yaml`, which described
the title as Inter Medium 16 / 24. It renders Inter Regular 18 / 24. Pre-existing
error, fixed here because it documents the part this branch repoints.

## Visual impact: none

Both classes resolve identically today — `Inter, system-ui, sans-serif`,
`18px / 400 / 24px / 0px`. Verified in Docker rather than assumed: the 26 Alert
and Toast visual-regression snapshots pass **unchanged** against the committed
baselines, in light and dark. No baselines regenerated.

## Verification

| Check | Result |
| --- | --- |
| `vitest` (ui-react) | 1972 pass / 120 files |
| `tsc --noEmit` | clean |
| `eslint src/` | clean |
| `ui-spec` test (schema + conformance) | 945 pass |
| VR Alert + Toast, light | 13 snapshots pass |
| VR Alert + Toast, dark | 13 snapshots pass |

## Not in scope

`Timeline` still asserts in four places that it has no `--ui-timeline-*` tier —
#666 shipped one. That is a larger change (a tier `@import`, the connector/gap
constants, and the load-bearing `GAP === MARKER / 2` comment) and gets its own PR.
