### PR TITLE
refactor(timeline): theme the connector and gap from the --ui-timeline-* tier

### DIFF
--- a/.changeset/timeline-token-tier.md
+++ b/.changeset/timeline-token-tier.md
@@ -1,0 +1,17 @@
+---
+'@acronis-platform/ui-react': patch
+---
+
+Theme `Timeline`'s connector and gap from the `--ui-timeline-*` tier.
+
+The component consumed the alias targets `--ui-border-on-surface-border` and
+`--ui-gap-16` because the Figma variables it references had no tier of their
+own. That tier now ships, so the connector, the elbow and the marker-to-card
+gap read `--ui-timeline-connector-color` and `--ui-timeline-gap` directly, and
+`src/styles/index.css` imports the tier.
+
+Figma binds `Timeline/gap` only to the horizontal marker-to-card gap and the
+indent step derived from it; the vertical rhythm between rows and the card
+header's spacing are unbound literals in the design and stay on `--ui-gap-16`.
+Every value resolves the same today, so nothing renders differently — but a
+brand override of the Timeline tokens is now honored.

--- a/apps/docs/content/docs/components/timeline.mdx
+++ b/apps/docs/content/docs/components/timeline.mdx
@@ -173,16 +173,16 @@ renders in the card below a divider (and is hidden while the row is collapsed).
 
 ## Theming
 
-The connector and elbow use `--ui-border-on-surface-border`; spacing and the
-indent step derive from `--ui-gap-16`, `--ui-gap-8`,
+The connector and elbow use `--ui-timeline-connector-color`; spacing and the
+indent step derive from `--ui-timeline-gap`, `--ui-gap-16`, `--ui-gap-8`,
 `--ui-avatar-global-avatar-size`, and
 `--ui-button-icon-global-container-height`. The marker, disclosure button, and
 card are themed by `Avatar`'s, `ButtonIcon`'s, and `Card`'s own token tiers.
 
-The Figma variables `components/Timeline/{connectorColor,gap}` are not yet "ready
-for dev" and have no `--ui-timeline-*` tier. Both are pure aliases in Figma,
-identical across all six brands, so the implementation consumes their alias
-targets directly.
+The Figma variables `components/Timeline/{connectorColor,gap}` ship as the
+`--ui-timeline-*` tier and are consumed directly. `Timeline/gap` covers the
+horizontal marker-to-card gap and the indent step derived from it; the vertical
+rhythm between rows is unbound in the design, so it stays on `--ui-gap-16`.
 
 ## API Reference
 

--- a/packages/ui-react/src/components/ui/timeline/timeline.tsx
+++ b/packages/ui-react/src/components/ui/timeline/timeline.tsx
@@ -46,19 +46,25 @@ import { Card } from '../card';
 // design primitives, not iconography, and CSS borders mirror correctly under
 // `dir="rtl"` where a baked-in asset cannot.
 //
-// The design references `components/Timeline/{connectorColor,gap}`, which are
-// not "ready for dev" and have no `--ui-timeline-*` tier. Both are pure aliases
-// in Figma — identical across all six brand modes — so this consumes the alias
-// targets directly: `--ui-border-on-surface-border` (connector) and
-// `--ui-gap-16` (gap). Re-point them at `--ui-timeline-*` once that tier ships.
+// The design references `components/Timeline/{connectorColor,gap}`, which now
+// ship as a `--ui-timeline-*` tier (imported in `src/styles/index.css`), so this
+// consumes them directly rather than the alias targets it used while the tier
+// was missing.
+//
+// Figma binds `Timeline/gap` to exactly one thing: the row's *horizontal* gap
+// between the marker column and the card (and, through it, the indent step).
+// The vertical rhythm between rows and the card header's own spacing are
+// unbound 16px literals in the design, so they stay on `--ui-gap-16` — do not
+// "tidy" them onto the Timeline token, or a future change to `Timeline/gap`
+// would silently retune the vertical layout the design never tied to it.
 
-const CONNECTOR_COLOR = 'var(--ui-border-on-surface-border)';
+const CONNECTOR_COLOR = 'var(--ui-timeline-connector-color)';
 // Load-bearing invariant: the elbow's vertical lands on the parent's connector
 // only while GAP === MARKER / 2 (16 === 32 / 2 today). The elbow is offset from the
 // child's indent while the connector is offset from the parent's marker centre, and
 // those two coincide at exactly that ratio. If either token moves, every elbow
 // detaches — re-derive the elbow's `insetInlineStart` rather than nudging it.
-const GAP = 'var(--ui-gap-16)';
+const GAP = 'var(--ui-timeline-gap)';
 /** The Avatar marker's own width — also the elbow's horizontal reach. */
 const MARKER = 'var(--ui-avatar-global-avatar-size)';
 /** Disclosure button + its gap, present only on a `tree` row with descendants. */
@@ -461,7 +467,7 @@ const TimelineItem = React.forwardRef<HTMLLIElement, TimelineItemProps>(
           } as React.CSSProperties
         }
         className={cn(
-          'relative flex items-start gap-[var(--ui-gap-16)]',
+          'relative flex items-start gap-[var(--ui-timeline-gap)]',
           'ps-[var(--timeline-indent)]',
           className
         )}

--- a/packages/ui-react/src/styles/index.css
+++ b/packages/ui-react/src/styles/index.css
@@ -42,6 +42,7 @@
 @import '@acronis-platform/tokens-pd/css/Footer/default.css';
 @import '@acronis-platform/tokens-pd/css/Popover/default.css';
 @import '@acronis-platform/tokens-pd/css/Carousel/default.css';
+@import '@acronis-platform/tokens-pd/css/Timeline/default.css';
 @import '@acronis-platform/tokens-pd/css/Timer/default.css';
 
 @layer base {

--- a/packages/ui-spec/components/timeline/README.md
+++ b/packages/ui-spec/components/timeline/README.md
@@ -105,10 +105,11 @@ a tree row can carry the branch button and the card chevron at once:
   values, and keep them distinct.
 - The marker takes an `icon` or `initials` (icon wins). Avatar's outset ring is
   switched off here, matching the design's strokeless marker.
-- The Figma variables `components/Timeline/{connectorColor,gap}` are not yet
-  "ready for dev" and have no `--ui-timeline-*` tier. Both are pure aliases,
-  identical across all six brands, so the implementation consumes the alias
-  targets (`--ui-border-on-surface-border`, `--ui-gap-16`) directly.
+- The Figma variables `components/Timeline/{connectorColor,gap}` ship as the
+  `--ui-timeline-*` tier and are consumed directly. `Timeline/gap` covers the
+  horizontal marker-to-card gap and the indent step derived from it; the
+  vertical rhythm between rows is unbound in the design and stays on
+  `--ui-gap-16`.
 - Composes `Avatar` (marker), `Card` (container), and `ButtonIcon` (disclosure);
   compose `Tag` into `tag` and anything you like into `children`. The kit ships no
   domain event types or icons.

--- a/packages/ui-spec/components/timeline/tokens.yaml
+++ b/packages/ui-spec/components/timeline/tokens.yaml
@@ -5,10 +5,11 @@ component: Timeline
 # brand/theme at paint time; never restate values here.
 #
 # The Figma widget references `components/Timeline/{connectorColor,gap}`, which
-# are not yet "ready for dev" and have no `--ui-timeline-*` tier. Both are pure
-# aliases in Figma, identical across all six brand modes, so this consumes the
-# alias targets directly: `--ui-border-on-surface-border` (connectorColor) and
-# `--ui-gap-16` (gap). Re-point them at `--ui-timeline-*` once that tier ships.
+# ship as the `--ui-timeline-*` tier and are consumed directly.
+#
+# `Timeline/gap` covers only the horizontal marker-to-card gap and the indent
+# step derived from it. The vertical rhythm between rows is an unbound 16px
+# literal in the design, so it stays on `--ui-gap-16` and is listed separately.
 #
 # The marker, disclosure button, and card come from Avatar / ButtonIcon / Card, so
 # their own tiers theme those parts; only the tokens Timeline references directly
@@ -16,16 +17,26 @@ component: Timeline
 source: '@acronis-platform/tokens-pd'
 
 tokens:
-  - name: --ui-border-on-surface-border
+  - name: --ui-timeline-connector-color
     affects: connector
     description: >-
-      The connector line and the elbow (Figma `components/Timeline/connectorColor`),
-      and the divider above the card body.
+      The connector line and the elbow (Figma
+      `components/Timeline/connectorColor`).
+  - name: --ui-border-on-surface-border
+    affects: item
+    description: >-
+      The divider above the card body, via the bridged `border-border` name.
+      Not the connector — that has its own Timeline token.
+  - name: --ui-timeline-gap
+    affects: item
+    description: >-
+      Marker-to-card gap and the indent step's spacing term (Figma
+      `components/Timeline/gap`).
   - name: --ui-gap-16
     affects: item
     description: >-
-      Row gap, marker-to-card gap, and the indent step's spacing term (Figma
-      `components/Timeline/gap`).
+      Vertical gap between rows, and the distance the connector descends into
+      it. Unbound in the design, so deliberately not the Timeline token.
   - name: --ui-gap-8
     affects: toggle
     description: Gap between the disclosure button and the marker in tree mode.


### PR DESCRIPTION
Follow-up to the 2026-08-19 Figma sync (#666), which shipped the
`--ui-timeline-*` tier the component had been waiting on.

## What

`Timeline` consumed the alias targets `--ui-border-on-surface-border` and
`--ui-gap-16` because the Figma variables it references had no tier of their
own — four places in the codebase said so explicitly. The tier now exists, so
the connector, the elbow and the marker-to-card gap read
`--ui-timeline-connector-color` and `--ui-timeline-gap` directly, and
`styles/index.css` imports the tier.

## Which `--ui-gap-16` moved, and which did not

`--ui-gap-16` appears in five places. Figma binds `components/Timeline/gap` to
exactly one thing — the row's **horizontal** marker-to-card gap — so only the
sites derived from that moved:

| Site | What it is | Result |
| --- | --- | --- |
| `GAP` const | Indent-step term (L2 = 88 = 32 + 8 + 32 + **16**) | → `--ui-timeline-gap` |
| Row flex gap | Horizontal marker↔card gap, **bound in the design** | → `--ui-timeline-gap` |
| `<ol>` gap | Vertical rhythm between rows (`flex flex-col`) | stays `--ui-gap-16` |
| Connector `bottom` | How far it descends into that vertical gap | stays `--ui-gap-16` |
| Card header gap | A literal `gap-[16px]` in the design | stays `--ui-gap-16` |

Repointing the vertical axis too would be invisible today — everything resolves
to 16px — and would desynchronise the connector from the row gap the moment
`Timeline/gap` changes, leaving the line short of the next row. The reasoning is
recorded in the source comment so it does not get "tidied up" later.

## Spec correction

`tokens.yaml` grouped the connector and the card-body divider under a single
`--ui-border-on-surface-border` entry. Only the connector moved: the divider is
painted via the bridged `border-border` name and still resolves to that token.
Two entries become four, each naming the part it actually affects.

## Visual impact: none

Every value resolves identically before and after. Verified two ways: the 32
Timeline baselines pass unchanged, and deleting and regenerating them in Docker
produces **byte-identical** PNGs in both light and dark — zero difference, not
"within the 0.5% threshold". That also proves the tier import took effect: had
it not, `var(--ui-timeline-connector-color)` would be undefined and the
connector would render with no background.

## Verification

| Check | Result |
| --- | --- |
| `component-readiness` gate | READY, no drift |
| Token refs resolving in tokens-pd | 8/8 |
| Tokens in compiled `dist/ui-react.css` | `--ui-timeline-connector-color: light-dark(#d6e4f5,#303236)`, `--ui-timeline-gap: 16px` |
| `vitest` (ui-react) | 1972 pass |
| `typecheck` / `lint` / `build` | clean |
| `pnpm -r typecheck` | clean |
| `ui-spec` test | 945 pass |
| `figma:connect` | valid |
| `uikit-docs build` | passes |
| VR Timeline, light + dark | 32 snapshots, byte-identical |
